### PR TITLE
Feature/issue-256: refactor dtos to be readonly

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Categories/CategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Categories/CategoryDto.cs
@@ -2,8 +2,8 @@ namespace VictoryCenter.BLL.DTOs.Categories;
 
 public record CategoryDto
 {
-    public long Id { get; set; }
-    public string Name { get; set; } = null!;
-    public string? Description { get; set; }
-    public DateTime CreatedAt { get; set; }
+    public long Id { get; init; }
+    public string Name { get; init; } = null!;
+    public string? Description { get; init; }
+    public DateTime CreatedAt { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Categories/CreateCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Categories/CreateCategoryDto.cs
@@ -2,6 +2,6 @@ namespace VictoryCenter.BLL.DTOs.Categories;
 
 public record CreateCategoryDto
 {
-    public string Name { get; set; } = null!;
-    public string? Description { get; set; }
+    public string Name { get; init; } = null!;
+    public string? Description { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Categories/UpdateCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Categories/UpdateCategoryDto.cs
@@ -2,5 +2,5 @@ namespace VictoryCenter.BLL.DTOs.Categories;
 
 public record UpdateCategoryDto : CreateCategoryDto
 {
-    public long Id { get; set; }
+    public long Id { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/CreateTeamMemberDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/CreateTeamMemberDto.cs
@@ -4,18 +4,18 @@ namespace VictoryCenter.BLL.DTOs.TeamMembers;
 
 public record CreateTeamMemberDto
 {
-    public string FullName { get; set; } = null!;
+    public string FullName { get; init; } = null!;
 
-    public long CategoryId { get; set; }
+    public long CategoryId { get; init; }
 
-    public Status Status { get; set; }
+    public Status Status { get; init; }
 
-    public string? Description { get; set; }
+    public string? Description { get; init; }
 #pragma warning disable SA1011
 
     // Change private set to set when photo logic is added
     public byte[]? Photo { get; private set; }
 #pragma warning restore SA1011
 
-    public string? Email { get; set; }
+    public string? Email { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/ReorderTeamMembersDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/ReorderTeamMembersDto.cs
@@ -2,6 +2,6 @@
 
 public class ReorderTeamMembersDto
 {
-    public long CategoryId { get; set; }
-    public List<long> OrderedIds { get; set; } = [];
+    public long CategoryId { get; init; }
+    public List<long> OrderedIds { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/TeamMemberDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/TeamMemberDto.cs
@@ -4,21 +4,21 @@ namespace VictoryCenter.BLL.DTOs.TeamMembers;
 
 public record TeamMemberDto
 {
-    public long Id { get; set; }
+    public long Id { get; init; }
 
-    public string FullName { get; set; } = null!;
+    public string FullName { get; init; } = null!;
 
-    public long CategoryId { get; set; }
+    public long CategoryId { get; init; }
 
-    public long Priority { get; set; }
+    public long Priority { get; init; }
 
-    public Status Status { get; set; }
+    public Status Status { get; init; }
 
-    public string? Description { get; set; }
+    public string? Description { get; init; }
 
 #pragma warning disable SA1011
-    public byte[]? Photo { get; set; }
+    public byte[]? Photo { get; init; }
 #pragma warning restore SA1011
 
-    public string? Email { get; set; }
+    public string? Email { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/TeamMembersFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/TeamMembers/TeamMembersFilterDto.cs
@@ -4,11 +4,11 @@ namespace VictoryCenter.BLL.DTOs.TeamMembers;
 
 public record TeamMembersFilterDto
 {
-    public int? Offset { get; set; }
+    public int? Offset { get; init; }
 
-    public int? Limit { get; set; }
+    public int? Limit { get; init; }
 
-    public Status? Status { get; set; }
+    public Status? Status { get; init; }
 
-    public long? CategoryId { get; set; }
+    public long? CategoryId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Categories/CreateCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Categories/CreateCategoryTests.cs
@@ -24,7 +24,7 @@ public class CreateCategoryTests
         CreatedAt = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Local),
     };
 
-    private readonly CategoryDto _testCategoryDto = new()
+    private CategoryDto _testCategoryDto = new()
     {
         Name = "Test Category",
         Description = "Test Category Description",
@@ -46,7 +46,10 @@ public class CreateCategoryTests
     public async Task Handle_ShouldCreateCategory(string? description)
     {
         _testEntity.Description = description;
-        _testCategoryDto.Description = description;
+        _testCategoryDto = _testCategoryDto with
+        {
+            Description = description
+        };
         SetupDependencies();
         var handler = new CreateCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
 
@@ -68,8 +71,11 @@ public class CreateCategoryTests
     [InlineData(null)]
     public async Task Handle_ShouldFail_InvalidName(string? name)
     {
-        _testEntity.Name = name;
-        _testCategoryDto.Name = name;
+        _testEntity.Name = name!;
+        _testCategoryDto = _testCategoryDto with
+        {
+            Name = name!
+        };
         SetupDependencies();
         var handler = new CreateCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Categories/UpdateCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Categories/UpdateCategoryTests.cs
@@ -31,7 +31,7 @@ public class UpdateCategoryTests
         Description = "Updated Description",
     };
 
-    private readonly CategoryDto _testUpdatedCategoryDto = new ()
+    private CategoryDto _testUpdatedCategoryDto = new ()
     {
         Name = "Updated Name",
         Description = "Updated Description",
@@ -52,7 +52,10 @@ public class UpdateCategoryTests
     public async Task Handle_ShouldUpdateEntity(string? testDescription)
     {
         _testUpdatedCategory.Description = testDescription;
-        _testUpdatedCategoryDto.Description = testDescription;
+        _testUpdatedCategoryDto = _testUpdatedCategoryDto with
+        {
+            Description = testDescription
+        };
         SetupDependencies(_testExistingCategory);
         var handler = new UpdateCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
 
@@ -76,8 +79,11 @@ public class UpdateCategoryTests
     [InlineData(" ")]
     public async Task Handle_ShouldNotUpdateEntity_IncorrectName(string? testName)
     {
-        _testUpdatedCategoryDto.Name = testName;
-        _testUpdatedCategory.Name = testName;
+        _testUpdatedCategoryDto = _testUpdatedCategoryDto with
+        {
+            Name = testName!
+        };
+        _testUpdatedCategory.Name = testName!;
         SetupDependencies(_testExistingCategory);
         var handler = new UpdateCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
@@ -64,7 +64,7 @@ public class UpdateTeamMemberTests
         Photo = null
     };
 
-    private readonly TeamMemberDto _testUpdatedTeamMemberDto = new()
+    private TeamMemberDto _testUpdatedTeamMemberDto = new()
     {
         FullName = "Updated Name",
         Description = "Updated Description"
@@ -151,7 +151,10 @@ public class UpdateTeamMemberTests
     [InlineData(" ")]
     public async Task Handle_InvalidFullName_ShouldReturnValidationError(string? testName)
     {
-        _testUpdatedTeamMemberDto.FullName = testName!;
+        _testUpdatedTeamMemberDto = _testUpdatedTeamMemberDto with
+        {
+            FullName = testName!
+        };
         _testUpdatedTeamMember.FullName = testName!;
         SetupDependencies(_testExistingTeamMember);
         var handler = new UpdateTeamMemberHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);


### PR DESCRIPTION
dev
## JIRA

* #256 

## Code reviewers

@maxvonlancaster
@ZhmudAnastasiia
@VladimirSushinsky
@roman-stozhuk
@milrusy
@Oleh-Bashtovyi
@OlyaMraka
@IceStorman
@MarkBevz50
@taraskibysh

## Summary of issue

Refactor all existing DTOs to be readonly.

## Summary of change

Changed `set` to `init` accross all DTOs in the project.

## Testing approach

Unit and Integration tests using xUnit.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved immutability for several data objects, ensuring their properties can only be set during object creation and not modified afterward.

* **Tests**
  * Updated test cases to support immutable data objects, using new patterns for modifying test data during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->