### PR TITLE
Localization support poc

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Create/CreateLocalizationLanguageCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Create/CreateLocalizationLanguageCommand.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.Create;
+
+public record CreateLocalizationLanguageCommand(CreateLocalizationLanguageDto CreateLocalizationLanguageDto)
+    : IRequest<Result<LocalizationLanguageDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Create/CreateLocalizationLanguageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Create/CreateLocalizationLanguageHandler.cs
@@ -1,0 +1,55 @@
+﻿using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.Create;
+
+public class CreateLocalizationLanguageHandler : IRequestHandler<CreateLocalizationLanguageCommand, Result<LocalizationLanguageDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<CreateLocalizationLanguageCommand> _validator;
+
+    public CreateLocalizationLanguageHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, IValidator<CreateLocalizationLanguageCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<LocalizationLanguageDto>> Handle(CreateLocalizationLanguageCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var entity = _mapper.Map<LocalizationLanguage>(request.CreateLocalizationLanguageDto);
+            entity.CreatedAt = DateTime.UtcNow;
+
+            await _repositoryWrapper.LocalizationLanguagesRepository.CreateAsync(entity);
+
+            if (await _repositoryWrapper.SaveChangesAsync() > 0)
+            {
+                var resultDto = _mapper.Map<LocalizationLanguageDto>(entity);
+                return Result.Ok(resultDto);
+            }
+
+            return Result.Fail<LocalizationLanguageDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(LocalizationLanguage)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<LocalizationLanguageDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException ex)
+        {
+            return Result.Fail<LocalizationLanguageDto>(ErrorMessagesConstants.
+                FailedToCreateEntityInDatabase(typeof(LocalizationLanguage)) + ex.Message);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Delete/DeleteLocalizationLanguageCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Delete/DeleteLocalizationLanguageCommand.cs
@@ -1,0 +1,6 @@
+﻿using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.Delete;
+
+public record DeleteLocalizationLanguageCommand(long Id) : IRequest<Result<long>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Delete/DeleteLocalizationLanguageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Delete/DeleteLocalizationLanguageHandler.cs
@@ -1,0 +1,42 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.Delete;
+
+public class DeleteLocalizationLanguageHandler : IRequestHandler<DeleteLocalizationLanguageCommand, Result<long>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public DeleteLocalizationLanguageHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<long>> Handle(DeleteLocalizationLanguageCommand request, CancellationToken cancellationToken)
+    {
+        LocalizationLanguage? entityToDelete = await _repositoryWrapper.LocalizationLanguagesRepository
+            .GetFirstOrDefaultAsync(new QueryOptions<LocalizationLanguage>
+            {
+                Filter = localizationLanguage => localizationLanguage.Id == request.Id,
+            });
+
+        if (entityToDelete is null)
+        {
+            return Result.Fail<long>(ErrorMessagesConstants
+                .NotFound(request.Id, typeof(LocalizationLanguage)));
+        }
+
+        _repositoryWrapper.LocalizationLanguagesRepository.Delete(entityToDelete);
+
+        if (await _repositoryWrapper.SaveChangesAsync() > 0)
+        {
+            return Result.Ok(entityToDelete.Id);
+        }
+
+        return Result.Fail(ErrorMessagesConstants.FailedToDeleteEntity(typeof(LocalizationLanguage)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Update/UpdateLocalizationLanguageCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Update/UpdateLocalizationLanguageCommand.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.Update;
+
+public record UpdateLocalizationLanguageCommand(UpdateLocalizationLanguageDto UpdateLocalizationLanguageDto, long Id)
+    : IRequest<Result<LocalizationLanguageDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Update/UpdateLocalizationLanguageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/Update/UpdateLocalizationLanguageHandler.cs
@@ -1,0 +1,66 @@
+﻿using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.Update;
+
+public class UpdateLocalizationLanguageHandler : IRequestHandler<UpdateLocalizationLanguageCommand, Result<LocalizationLanguageDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<UpdateLocalizationLanguageCommand> _validator;
+
+    public UpdateLocalizationLanguageHandler(
+        IMapper mapper,
+        IRepositoryWrapper repositoryWrapper,
+        IValidator<UpdateLocalizationLanguageCommand> validator)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<LocalizationLanguageDto>> Handle(UpdateLocalizationLanguageCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var existingEntity =
+                await _repositoryWrapper.LocalizationLanguagesRepository.GetFirstOrDefaultAsync(new QueryOptions<LocalizationLanguage>
+                {
+                    Filter = entity => entity.Id == request.Id
+                });
+
+            if (existingEntity is null)
+            {
+                return Result.Fail<LocalizationLanguageDto>(ErrorMessagesConstants.NotFound(request.Id, typeof(LocalizationLanguage)));
+            }
+
+            var entityToUpdate = _mapper.Map<UpdateLocalizationLanguageDto, LocalizationLanguage>(request.UpdateLocalizationLanguageDto);
+            entityToUpdate.Id = request.Id;
+            entityToUpdate.CreatedAt = existingEntity.CreatedAt;
+
+            _repositoryWrapper.LocalizationLanguagesRepository.Update(entityToUpdate);
+
+            if (await _repositoryWrapper.SaveChangesAsync() > 0)
+            {
+                var resultDto = _mapper.Map<LocalizationLanguage, LocalizationLanguageDto>(entityToUpdate);
+                return Result.Ok(resultDto);
+            }
+
+            return Result.Fail<LocalizationLanguageDto>(ErrorMessagesConstants.FailedToUpdateEntity(typeof(LocalizationLanguage)));
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<LocalizationLanguageDto>(ex.Message);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Create/CreateTeamMemberLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Create/CreateTeamMemberLocalizationCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+namespace VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Create;
+
+public record CreateTeamMemberLocalizationCommand(CreateTeamMemberLocalizationDto CreateTeamMemberLocalizationDto)
+    : IRequest<Result<TeamMemberLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Create/CreateTeamMemberLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Create/CreateTeamMemberLocalizationHandler.cs
@@ -1,0 +1,54 @@
+﻿using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Create;
+
+public class CreateTeamMemberLocalizationHandler : IRequestHandler<CreateTeamMemberLocalizationCommand, Result<TeamMemberLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<CreateTeamMemberLocalizationCommand> _validator;
+
+    public CreateTeamMemberLocalizationHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, IValidator<CreateTeamMemberLocalizationCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<TeamMemberLocalizationDto>> Handle(CreateTeamMemberLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            TeamMemberLocalization entity = _mapper.Map<TeamMemberLocalization>(request.CreateTeamMemberLocalizationDto);
+            entity.CreatedAt = DateTime.UtcNow;
+            await _repositoryWrapper.TeamMemberLocalizationsRepository.CreateAsync(entity);
+
+            if (await _repositoryWrapper.SaveChangesAsync() > 0)
+            {
+                TeamMemberLocalizationDto responseDto = _mapper.Map<TeamMemberLocalizationDto>(entity);
+                return Result.Ok(responseDto);
+            }
+
+            return Result.Fail<TeamMemberLocalizationDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(TeamMemberLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<TeamMemberLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException ex)
+        {
+            return Result.Fail<TeamMemberLocalizationDto>(ErrorMessagesConstants.
+                FailedToCreateEntityInDatabase(typeof(TeamMemberLocalization)) + ex.Message);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Delete/DeleteTeamMemberLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Delete/DeleteTeamMemberLocalizationCommand.cs
@@ -1,0 +1,6 @@
+﻿using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Delete;
+
+public record DeleteTeamMemberLocalizationCommand(long TeamMemberId, long LanguageId) : IRequest<Result<(long TeamMemberId, long LanguageId)>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Delete/DeleteTeamMemberLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Delete/DeleteTeamMemberLocalizationHandler.cs
@@ -1,0 +1,43 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Delete;
+
+public class DeleteTeamMemberLocalizationHandler : IRequestHandler<DeleteTeamMemberLocalizationCommand, Result<(long TeamMemberId, long LanguageId)>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public DeleteTeamMemberLocalizationHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<(long TeamMemberId, long LanguageId)>> Handle(DeleteTeamMemberLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        TeamMemberLocalization? entityToDelete = await _repositoryWrapper.TeamMemberLocalizationsRepository
+            .GetFirstOrDefaultAsync(new QueryOptions<TeamMemberLocalization>
+            {
+                Filter = localization => localization.EntityId == request.TeamMemberId &&
+                                           localization.LanguageId == request.LanguageId
+            });
+
+        if (entityToDelete is null)
+        {
+            return Result.Fail<(long TeamMemberId, long LanguageId)>(ErrorMessagesConstants
+                .NotFound((request.TeamMemberId, request.LanguageId), typeof(TeamMemberLocalization)));
+        }
+
+        _repositoryWrapper.TeamMemberLocalizationsRepository.Delete(entityToDelete);
+
+        if (await _repositoryWrapper.SaveChangesAsync() > 0)
+        {
+            return Result.Ok((request.TeamMemberId, request.LanguageId));
+        }
+
+        return Result.Fail(ErrorMessagesConstants.FailedToDeleteEntity(typeof(TeamMemberLocalization)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Update/UpdateTeamMemberLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Update/UpdateTeamMemberLocalizationCommand.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+namespace VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Update;
+
+public record UpdateTeamMemberLocalizationCommand(UpdateTeamMemberLocalizationDto UpdateTeamMemberLocalizationDto)
+    : IRequest<Result<TeamMemberLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Update/UpdateTeamMemberLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMemberLocalizations/Update/UpdateTeamMemberLocalizationHandler.cs
@@ -1,0 +1,65 @@
+﻿using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Update;
+
+public class UpdateTeamMemberLocalizationHandler : IRequestHandler<UpdateTeamMemberLocalizationCommand, Result<TeamMemberLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<UpdateTeamMemberLocalizationCommand> _validator;
+
+    public UpdateTeamMemberLocalizationHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper, IValidator<UpdateTeamMemberLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<TeamMemberLocalizationDto>> Handle(UpdateTeamMemberLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var dto = request.UpdateTeamMemberLocalizationDto;
+
+            TeamMemberLocalization? entity = await _repositoryWrapper.TeamMemberLocalizationsRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<TeamMemberLocalization>
+                {
+                    Filter = localization => localization.EntityId == dto.TeamMemberId &&
+                                           localization.LanguageId == dto.LanguageId
+                });
+
+            if (entity is null)
+            {
+                return Result.Fail<TeamMemberLocalizationDto>(ErrorMessagesConstants
+                    .NotFound(new { dto.TeamMemberId, dto.LanguageId }, typeof(TeamMemberLocalization)));
+            }
+
+            TeamMemberLocalization entityToUpdate = _mapper.Map(dto, entity);
+            entityToUpdate.CreatedAt = entity.CreatedAt;
+
+            _repositoryWrapper.TeamMemberLocalizationsRepository.Update(entityToUpdate);
+
+            if (await _repositoryWrapper.SaveChangesAsync() > 0)
+            {
+                TeamMemberLocalizationDto responseDto = _mapper.Map<TeamMemberLocalizationDto>(entityToUpdate);
+                return Result.Ok(responseDto);
+            }
+
+            return Result.Fail<TeamMemberLocalizationDto>(ErrorMessagesConstants.FailedToUpdateEntity(typeof(TeamMemberLocalization)));
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<TeamMemberLocalizationDto>(ex.Errors.Select(e => e.ErrorMessage));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CreateLocalizationLanguageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CreateLocalizationLanguageDto.cs
@@ -1,0 +1,6 @@
+﻿namespace VictoryCenter.BLL.DTOs.Admin.Localization;
+
+public record CreateLocalizationLanguageDto
+{
+    public string Code { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/UpdateLocalizationLanguageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/UpdateLocalizationLanguageDto.cs
@@ -1,0 +1,5 @@
+﻿namespace VictoryCenter.BLL.DTOs.Admin.Localization;
+
+public record UpdateLocalizationLanguageDto : CreateLocalizationLanguageDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMemberLocalizations/CreateTeamMemberLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMemberLocalizations/CreateTeamMemberLocalizationDto.cs
@@ -1,0 +1,9 @@
+﻿namespace VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+public record CreateTeamMemberLocalizationDto
+{
+    public long TeamMemberId { get; init; }
+    public long LanguageId { get; init; }
+    public string FullName { get; init; } = null!;
+    public string? Description { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMemberLocalizations/TeamMemberLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMemberLocalizations/TeamMemberLocalizationDto.cs
@@ -1,0 +1,11 @@
+﻿using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+public record TeamMemberLocalizationDto
+{
+    public long TeamMemberId { get; init; }
+    public LocalizationLanguageDto LocalizationLanguageDto { get; init; } = null!;
+    public string FullName { get; init; } = null!;
+    public string? Description { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMemberLocalizations/UpdateTeamMemberLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMemberLocalizations/UpdateTeamMemberLocalizationDto.cs
@@ -1,0 +1,3 @@
+﻿namespace VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+public record UpdateTeamMemberLocalizationDto : CreateTeamMemberLocalizationDto;

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMembers/TeamMemberDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMembers/TeamMemberDto.cs
@@ -1,3 +1,4 @@
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
 using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.DAL.Enums;
 
@@ -20,4 +21,6 @@ public record TeamMemberDto
     public string? Email { get; init; }
 
     public ImageDto? Image { get; set; }
+
+    public IEnumerable<TeamMemberLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Common/LocalizationLanguageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Common/LocalizationLanguageDto.cs
@@ -1,0 +1,8 @@
+﻿namespace VictoryCenter.BLL.DTOs.Common;
+
+public record LocalizationLanguageDto
+{
+    public long Id { get; set; }
+
+    public string Code { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Public/TeamPage/PublishedTeamMembersDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Public/TeamPage/PublishedTeamMembersDto.cs
@@ -1,3 +1,4 @@
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
 using VictoryCenter.BLL.DTOs.Common;
 
 namespace VictoryCenter.BLL.DTOs.Public.TeamPage;
@@ -8,4 +9,5 @@ public record PublishedTeamMembersDto
     public string FullName { get; init; } = null!;
     public string? Description { get; init; }
     public ImageDto? Image { get; init; }
+    public IEnumerable<TeamMemberLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/LocalizationLanguageProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/LocalizationLanguageProfile.cs
@@ -1,0 +1,18 @@
+﻿using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Mapping.Localization;
+
+public class LocalizationLanguageProfile : Profile
+{
+    public LocalizationLanguageProfile()
+    {
+        CreateMap<CreateLocalizationLanguageDto, LocalizationLanguage>();
+
+        CreateMap<LocalizationLanguage, LocalizationLanguageDto>();
+
+        CreateMap<UpdateLocalizationLanguageDto, LocalizationLanguageDto>();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/TeamMemberLocalizations/TeamMemberLocalizationsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/TeamMemberLocalizations/TeamMemberLocalizationsProfile.cs
@@ -1,0 +1,21 @@
+﻿using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Mapping.TeamMemberLocalizations;
+
+public class TeamMemberLocalizationsProfile : Profile
+{
+    public TeamMemberLocalizationsProfile()
+    {
+        CreateMap<CreateTeamMemberLocalizationDto, TeamMemberLocalization>()
+            .ForMember(dest => dest.EntityId, opt => opt.MapFrom(src => src.TeamMemberId));
+
+        CreateMap<UpdateTeamMemberLocalizationDto, TeamMemberLocalization>()
+            .ForMember(dest => dest.EntityId, opt => opt.MapFrom(src => src.TeamMemberId));
+
+        CreateMap<TeamMemberLocalization, TeamMemberLocalizationDto>()
+            .ForMember(dest => dest.TeamMemberId, opt => opt.MapFrom(src => src.EntityId))
+            .ForMember(dest => dest.LocalizationLanguageDto, opt => opt.MapFrom(src => src.Language));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByLanguageId/GetByLanguageIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByLanguageId/GetByLanguageIdHandler.cs
@@ -1,0 +1,35 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.TeamMemberLocalizations.GetByLanguageId;
+
+public class GetByLanguageIdHandler : IRequestHandler<GetByLanguageIdQuery, Result<IEnumerable<TeamMemberLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repository;
+
+    public GetByLanguageIdHandler(IMapper mapper, IRepositoryWrapper repository)
+    {
+        _mapper = mapper;
+        _repository = repository;
+    }
+
+    public async Task<Result<IEnumerable<TeamMemberLocalizationDto>>> Handle(GetByLanguageIdQuery request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<TeamMemberLocalization>
+        {
+            Filter = l => l.LanguageId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+        };
+        IEnumerable<TeamMemberLocalization> localizations = await _repository.TeamMemberLocalizationsRepository.GetAllAsync(queryOptions);
+        List<TeamMemberLocalizationDto>? localizationsDto = _mapper.Map<List<TeamMemberLocalizationDto>>(localizations);
+
+        return Result.Ok(localizationsDto.AsEnumerable());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByLanguageId/GetByLanguageIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByLanguageId/GetByLanguageIdQuery.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+namespace VictoryCenter.BLL.Queries.Admin.TeamMemberLocalizations.GetByLanguageId;
+
+public record GetByLanguageIdQuery(long Id)
+    : IRequest<Result<IEnumerable<TeamMemberLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByTeamMemberId/GetByTeamMemberIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByTeamMemberId/GetByTeamMemberIdHandler.cs
@@ -1,0 +1,35 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.TeamMemberLocalizations.GetByTeamMemberId;
+
+public class GetByTeamMemberIdHandler : IRequestHandler<GetByTeamMemberIdQuery, Result<IEnumerable<TeamMemberLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repository;
+
+    public GetByTeamMemberIdHandler(IMapper mapper, IRepositoryWrapper repository)
+    {
+        _mapper = mapper;
+        _repository = repository;
+    }
+
+    public async Task<Result<IEnumerable<TeamMemberLocalizationDto>>> Handle(GetByTeamMemberIdQuery request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<TeamMemberLocalization>
+        {
+            Filter = l => l.EntityId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+        };
+        IEnumerable<TeamMemberLocalization> localizations = await _repository.TeamMemberLocalizationsRepository.GetAllAsync(queryOptions);
+        List<TeamMemberLocalizationDto>? localizationsDto = _mapper.Map<List<TeamMemberLocalizationDto>>(localizations);
+
+        return Result.Ok(localizationsDto.AsEnumerable());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByTeamMemberId/GetByTeamMemberIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMemberLocalizations/GetByTeamMemberId/GetByTeamMemberIdQuery.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+
+namespace VictoryCenter.BLL.Queries.Admin.TeamMemberLocalizations.GetByTeamMemberId;
+
+public record GetByTeamMemberIdQuery(long Id)
+    : IRequest<Result<IEnumerable<TeamMemberLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
@@ -35,7 +35,7 @@ public class GetTeamMembersByFiltersHandler : IRequestHandler<GetTeamMembersByFi
             Offset = request.TeamMembersFilterDto.Offset is > 0 ? (int)request.TeamMembersFilterDto.Offset : 0,
             Limit = request.TeamMembersFilterDto.Limit is > 0 ? (int)request.TeamMembersFilterDto.Limit : 0,
             Filter = filter,
-            Include = tm => tm.Include(member => member.Image!),
+            Include = tm => tm.Include(member => member.Image!).Include(member => member.Localizations).ThenInclude(l => l.Language),
             OrderByASC = tm => tm.Priority
         };
 

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Common/Localization/GetAll/GetAllLocalizationLanguagesHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Common/Localization/GetAll/GetAllLocalizationLanguagesHandler.cs
@@ -1,0 +1,27 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Queries.Common.Localization.GetAll;
+
+public class GetAllLocalizationLanguagesHandler : IRequestHandler<GetAllLocalizationLanguagesQuery, Result<IEnumerable<LocalizationLanguageDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetAllLocalizationLanguagesHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<IEnumerable<LocalizationLanguageDto>>> Handle(
+        GetAllLocalizationLanguagesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var entities = await _repositoryWrapper.LocalizationLanguagesRepository.GetAllAsync();
+        return Result.Ok(_mapper.Map<IEnumerable<LocalizationLanguageDto>>(entities));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Common/Localization/GetAll/GetAllLocalizationLanguagesQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Common/Localization/GetAll/GetAllLocalizationLanguagesQuery.cs
@@ -1,0 +1,8 @@
+﻿using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.Queries.Common.Localization.GetAll;
+
+public record GetAllLocalizationLanguagesQuery
+    : IRequest<Result<IEnumerable<LocalizationLanguageDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/BaseLocalizationLanguageValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/BaseLocalizationLanguageValidator.cs
@@ -1,0 +1,17 @@
+﻿using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization;
+
+namespace VictoryCenter.BLL.Validators.Localization;
+
+public class BaseLocalizationLanguageValidator : AbstractValidator<CreateLocalizationLanguageDto>
+{
+    public BaseLocalizationLanguageValidator()
+    {
+        RuleFor(x => x.Code)
+            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateLocalizationLanguageDto.Code)))
+            .Length(CodeLength).WithMessage($"Code length has to be {CodeLength} long");
+    }
+
+    public static int CodeLength { get; } = 2;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/CreateLocalizationLanguageValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/CreateLocalizationLanguageValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.Create;
+
+namespace VictoryCenter.BLL.Validators.Localization;
+
+public class CreateLocalizationLanguageValidator : AbstractValidator<CreateLocalizationLanguageCommand>
+{
+    public CreateLocalizationLanguageValidator(BaseLocalizationLanguageValidator baseLocalizationLanguageValidator)
+    {
+        RuleFor(c => c.CreateLocalizationLanguageDto).SetValidator(baseLocalizationLanguageValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/UpdateLocalizationLanguageValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/UpdateLocalizationLanguageValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization;
+
+public class UpdateLocalizationLanguageValidator : AbstractValidator<UpdateLocalizationLanguageCommand>
+{
+    public UpdateLocalizationLanguageValidator(BaseLocalizationLanguageValidator baseLocalizationLanguageValidator)
+    {
+        RuleFor(u => u.UpdateLocalizationLanguageDto).SetValidator(baseLocalizationLanguageValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMemberLocalizations/BaseTeamMemberLocalizationsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMemberLocalizations/BaseTeamMemberLocalizationsValidator.cs
@@ -1,0 +1,30 @@
+﻿using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
+
+namespace VictoryCenter.BLL.Validators.TeamMemberLocalizations;
+
+public class BaseTeamMemberLocalizationsValidator : AbstractValidator<CreateTeamMemberLocalizationDto>
+{
+    public BaseTeamMemberLocalizationsValidator()
+    {
+        RuleFor(x => x.LanguageId)
+            .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateTeamMemberDto.CategoryId)));
+        RuleFor(x => x.FullName)
+            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.FullName)))
+            .MinimumLength(FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMinLength))
+            .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMaxLength));
+        RuleFor(x => x.Description)
+            .MaximumLength(DescriptionNameMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.Description), DescriptionNameMaxLength));
+
+        // RuleFor(x => x.Description)
+        //    .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.Description)))
+        //    .When(x => x.Status == Status.Published);
+    }
+
+    public static int FullNameMinLength { get; } = 2;
+    public static int FullNameMaxLength { get; } = 100;
+    public static int DescriptionNameMaxLength { get; } = 200;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMemberLocalizations/CreateTeamMemberLocalizationsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMemberLocalizations/CreateTeamMemberLocalizationsValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Create;
+
+namespace VictoryCenter.BLL.Validators.TeamMemberLocalizations;
+
+public class CreateTeamMemberLocalizationsValidator : AbstractValidator<CreateTeamMemberLocalizationCommand>
+{
+    public CreateTeamMemberLocalizationsValidator(BaseTeamMemberLocalizationsValidator baseTeamMemberLocalizationsValidator)
+    {
+        RuleFor(c => c.CreateTeamMemberLocalizationDto).SetValidator(baseTeamMemberLocalizationsValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMemberLocalizations/UpdateTeamMemberLocalizationsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMemberLocalizations/UpdateTeamMemberLocalizationsValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Update;
+
+namespace VictoryCenter.BLL.Validators.TeamMemberLocalizations;
+
+public class UpdateTeamMemberLocalizationsValidator : AbstractValidator<UpdateTeamMemberLocalizationCommand>
+{
+    public UpdateTeamMemberLocalizationsValidator(BaseTeamMemberLocalizationsValidator baseTeamMemberLocalizationsValidator)
+    {
+        RuleFor(c => c.UpdateTeamMemberLocalizationDto).SetValidator(baseTeamMemberLocalizationsValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/LocalizationLanguageConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/LocalizationLanguageConfig.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class LocalizationLanguageConfig : IEntityTypeConfiguration<LocalizationLanguage>
+{
+    public void Configure(EntityTypeBuilder<LocalizationLanguage> entity)
+    {
+        entity.HasKey(e => e.Id);
+
+        entity.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity.Property(e => e.Code)
+            .IsRequired();
+
+        entity.HasIndex(e => e.Code)
+            .IsUnique();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/TeamMemberLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/TeamMemberLocalizationConfig.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class TeamMemberLocalizationConfig : IEntityTypeConfiguration<TeamMemberLocalization>
+{
+    public void Configure(EntityTypeBuilder<TeamMemberLocalization> entity)
+    {
+        entity.HasKey(tl => new { tl.EntityId, tl.LanguageId });
+
+        entity.HasOne(tl => tl.Entity)
+            .WithMany(t => t.Localizations)
+            .HasForeignKey(tl => tl.EntityId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.Property(e => e.FullName)
+            .IsRequired();
+
+        entity.Property(e => e.Description);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -24,6 +24,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<LocalizationLanguage> LocalizationLanguages { get; set; }
 
+    public DbSet<TeamMemberLocalization> TeamMemberLocalizations { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -22,6 +22,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<Program> Programs { get; set; }
 
+    public DbSet<LocalizationLanguage> LocalizationLanguages { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/VictoryCenter/VictoryCenter.DAL/Entities/LocalizationBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/LocalizationBase.cs
@@ -1,0 +1,13 @@
+﻿namespace VictoryCenter.DAL.Entities;
+
+public abstract class LocalizationBase<T>
+    where T : class
+{
+    public long EntityId { get; set; }
+
+    public long LanguageId { get; set; }
+
+    public T Entity { get; set; } = null!;
+
+    public LocalizationLanguage Language { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/LocalizationLanguage.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/LocalizationLanguage.cs
@@ -1,0 +1,11 @@
+﻿namespace VictoryCenter.DAL.Entities;
+
+public class LocalizationLanguage
+{
+    public long Id { get; set; }
+
+    // ISO 639-1 is used for distinguishing languages
+    public string Code { get; set; } = null!;
+
+    public DateTime CreatedAt { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/TeamMember.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/TeamMember.cs
@@ -27,4 +27,6 @@ public class TeamMember
     public Category Category { get; set; } = null!;
 
     public Image? Image { get; set; }
+
+    public ICollection<TeamMemberLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/TeamMemberLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/TeamMemberLocalization.cs
@@ -1,0 +1,10 @@
+﻿namespace VictoryCenter.DAL.Entities;
+
+public class TeamMemberLocalization : LocalizationBase<TeamMember>
+{
+    public string FullName { get; set; } = null!;
+
+    public string? Description { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20250907171337_AddedLocalizationLanguages.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20250907171337_AddedLocalizationLanguages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250907171337_AddedLocalizationLanguages")]
+    partial class AddedLocalizationLanguages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20250907171337_AddedLocalizationLanguages.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20250907171337_AddedLocalizationLanguages.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedLocalizationLanguages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LocalizationLanguages",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Code = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LocalizationLanguages", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocalizationLanguages_Code",
+                table: "LocalizationLanguages",
+                column: "Code",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LocalizationLanguages");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20250908083203_AddedTeamMemberLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20250908083203_AddedTeamMemberLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250908083203_AddedTeamMemberLocalization")]
+    partial class AddedTeamMemberLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20250908083203_AddedTeamMemberLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20250908083203_AddedTeamMemberLocalization.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedTeamMemberLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TeamMemberLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    FullName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamMemberLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_TeamMemberLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_TeamMemberLocalizations_TeamMembers_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "TeamMembers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMemberLocalizations_LanguageId",
+                table: "TeamMemberLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TeamMemberLocalizations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -1,5 +1,6 @@
 using System.Transactions;
 using VictoryCenter.DAL.Repositories.Interfaces.Categories;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Media;
 using VictoryCenter.DAL.Repositories.Interfaces.ProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Programs;
@@ -14,6 +15,7 @@ public interface IRepositoryWrapper
     IImageRepository ImageRepository { get; }
     IProgramCategoriesRepository ProgramCategoriesRepository { get; }
     IProgramsRepository ProgramsRepository { get; }
+    ILocalizationLanguagesRepository LocalizationLanguagesRepository { get; }
 
     int SaveChanges();
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -16,6 +16,7 @@ public interface IRepositoryWrapper
     IProgramCategoriesRepository ProgramCategoriesRepository { get; }
     IProgramsRepository ProgramsRepository { get; }
     ILocalizationLanguagesRepository LocalizationLanguagesRepository { get; }
+    ITeamMemberLocalizationsRepository TeamMemberLocalizationsRepository { get; }
 
     int SaveChanges();
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/ILocalizationLanguagesRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/ILocalizationLanguagesRepository.cs
@@ -1,0 +1,8 @@
+﻿using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization;
+
+public interface ILocalizationLanguagesRepository : IRepositoryBase<LocalizationLanguage>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/TeamMembers/ITeamMemberLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/TeamMembers/ITeamMemberLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+﻿using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.TeamMembers;
+
+public interface ITeamMemberLocalizationsRepository : IRepositoryBase<TeamMemberLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -26,6 +26,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IProgramCategoriesRepository? _programCategoriesRepository;
     private IProgramsRepository? _programsRepository;
     private ILocalizationLanguagesRepository? _localizationLanguagesRepository;
+    private ITeamMemberLocalizationsRepository? _teamMemberLocalizationsRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -40,6 +41,8 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IProgramsRepository ProgramsRepository => _programsRepository ??= new ProgramsRepository(_victoryCenterDbContext);
     public ILocalizationLanguagesRepository LocalizationLanguagesRepository => _localizationLanguagesRepository
         ??= new LocalizationLanguagesRepository(_victoryCenterDbContext);
+    public ITeamMemberLocalizationsRepository TeamMemberLocalizationsRepository => _teamMemberLocalizationsRepository
+        ??= new TeamMemberLocalizationsRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -2,11 +2,13 @@ using System.Transactions;
 using VictoryCenter.DAL.Data;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.Categories;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Media;
 using VictoryCenter.DAL.Repositories.Interfaces.ProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Programs;
 using VictoryCenter.DAL.Repositories.Interfaces.TeamMembers;
 using VictoryCenter.DAL.Repositories.Realizations.Categories;
+using VictoryCenter.DAL.Repositories.Realizations.Localization;
 using VictoryCenter.DAL.Repositories.Realizations.Media;
 using VictoryCenter.DAL.Repositories.Realizations.ProgramCategories;
 using VictoryCenter.DAL.Repositories.Realizations.Programs;
@@ -23,6 +25,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IImageRepository? _imageRepository;
     private IProgramCategoriesRepository? _programCategoriesRepository;
     private IProgramsRepository? _programsRepository;
+    private ILocalizationLanguagesRepository? _localizationLanguagesRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -35,6 +38,8 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IProgramCategoriesRepository ProgramCategoriesRepository => _programCategoriesRepository
         ??= new ProgramCategoriesRepository(_victoryCenterDbContext);
     public IProgramsRepository ProgramsRepository => _programsRepository ??= new ProgramsRepository(_victoryCenterDbContext);
+    public ILocalizationLanguagesRepository LocalizationLanguagesRepository => _localizationLanguagesRepository
+        ??= new LocalizationLanguagesRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/LocalizationLanguagesRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/LocalizationLanguagesRepository.cs
@@ -1,0 +1,13 @@
+﻿using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization;
+public class LocalizationLanguagesRepository : RepositoryBase<LocalizationLanguage>, ILocalizationLanguagesRepository
+{
+    public LocalizationLanguagesRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/TeamMembers/TeamMemberLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/TeamMembers/TeamMemberLocalizationsRepository.cs
@@ -1,0 +1,14 @@
+﻿using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.TeamMembers;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.TeamMembers;
+
+public class TeamMemberLocalizationsRepository : RepositoryBase<TeamMemberLocalization>, ITeamMemberLocalizationsRepository
+{
+    public TeamMemberLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/LocalizationController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/LocalizationController.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.Localization.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.Delete;
+using VictoryCenter.BLL.Commands.Admin.Localization.Update;
+using VictoryCenter.BLL.DTOs.Admin.Localization;
+using VictoryCenter.BLL.Queries.Common.Localization.GetAll;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class LocalizationController : AuthorizedApiController
+{
+    [HttpPost]
+    public async Task<IActionResult> CreateLocalizationLanguage([FromBody] CreateLocalizationLanguageDto localizationLanguageDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateLocalizationLanguageCommand(localizationLanguageDto)));
+    }
+
+    [HttpDelete]
+    [Route("{id:long}")]
+    public async Task<IActionResult> DeleteLocalizationLanguage(long id)
+    {
+        return HandleResult(await Mediator.Send(new DeleteLocalizationLanguageCommand(id)));
+    }
+
+    [HttpPut]
+    [Route("{id:long}")]
+    public async Task<IActionResult> UpdateLocalizationLanguage([FromBody] UpdateLocalizationLanguageDto updateLocalizationLanguageDto, long id)
+    {
+        return HandleResult(await Mediator.Send(new UpdateLocalizationLanguageCommand(updateLocalizationLanguageDto, id)));
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetLocalizationLanguages()
+    {
+        return HandleResult(await Mediator.Send(new GetAllLocalizationLanguagesQuery()));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/TeamMemberLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/TeamMemberLocalizationsController.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Create;
+using VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Delete;
+using VictoryCenter.BLL.Commands.Admin.TeamMemberLocalizations.Update;
+using VictoryCenter.BLL.DTOs.Admin.TeamMemberLocalizations;
+using VictoryCenter.BLL.Queries.Admin.TeamMemberLocalizations.GetByLanguageId;
+using VictoryCenter.BLL.Queries.Admin.TeamMemberLocalizations.GetByTeamMemberId;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+public class TeamMemberLocalizationsController : AuthorizedApiController
+{
+    [HttpGet("member/{id:long}")]
+    public async Task<IActionResult> GetByTeamMemberId(long id)
+    {
+        return HandleResult(await Mediator.Send(new GetByTeamMemberIdQuery(id)));
+    }
+
+    [HttpGet("lang/{id:long}")]
+    public async Task<IActionResult> GetByLanguageId(long id)
+    {
+        return HandleResult(await Mediator.Send(new GetByLanguageIdQuery(id)));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateTeamMemberLocalization([FromBody] CreateTeamMemberLocalizationDto createTeamMemberLocalizationDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateTeamMemberLocalizationCommand(createTeamMemberLocalizationDto)));
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> UpdateTeamMemberLocalization([FromBody] UpdateTeamMemberLocalizationDto updateTeamMemberLocalizationDto)
+    {
+        return HandleResult(await Mediator.Send(new UpdateTeamMemberLocalizationCommand(updateTeamMemberLocalizationDto)));
+    }
+
+    [HttpDelete("{memberId:long}/{langId:long}")]
+    public async Task<IActionResult> DeleteTeamMemberLocalization(
+        [FromRoute(Name = "memberId")] long TeamMemberId,
+        [FromRoute(Name = "langId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(new DeleteTeamMemberLocalizationCommand(TeamMemberId, LanguageId)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -177,6 +177,7 @@ public static class ServicesConfiguration
     {
         await app.CreateInitialAdminAsync();
         await app.CreateInitialCategoriesAsync();
+        await app.CreateInitialLocalizationLanguages();
     }
 
     private static async Task CreateInitialAdminAsync(this WebApplication app)
@@ -247,6 +248,36 @@ public static class ServicesConfiguration
             if (!await dbContext.Categories.AnyAsync(c => c.Name == category.Name))
             {
                 dbContext.Categories.Add(category);
+                await dbContext.SaveChangesAsync();
+            }
+        }
+    }
+
+    private static async Task CreateInitialLocalizationLanguages(this WebApplication app)
+    {
+        await using var asyncServiceScope = app.Services.CreateAsyncScope();
+        var dbContext = asyncServiceScope.ServiceProvider.GetRequiredService<VictoryCenterDbContext>();
+        var languages = new List<LocalizationLanguage>
+        {
+            new()
+            {
+                Code = "uk",
+            },
+            new()
+            {
+                Code = "en",
+            },
+            new()
+            {
+                Code = "es",
+            }
+        };
+
+        foreach (var language in languages)
+        {
+            if (!await dbContext.LocalizationLanguages.AnyAsync(l => l.Code == language.Code))
+            {
+                dbContext.LocalizationLanguages.Add(language);
                 await dbContext.SaveChangesAsync();
             }
         }


### PR DESCRIPTION
dev
## Github

## Summary of issue
This is a localiztion poc for backend, where admin should be able interact and change the dynamic localization for team members

## Summary of change
- Added support for different languages (LocalizationLanguages table)
- Added localization for team members (TeamMemberLocaliztions table)
- Added a separate controller with crud endpoints for languages and team member localizations
- Modified team member to include localizations (entity and dto)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admin API to list, create, update, and delete localization languages.
  - Admin API to create, update, delete, and fetch team member localizations (by member or language).
  - Team members now include localized names and descriptions; queries return language details.
  - Public/team endpoints now surface available localizations where applicable.
  - Initial languages seeded: uk, en, es.
- Chores
  - Added underlying localization infrastructure and validation to support the features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->