### PR TITLE
bug fix 475

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
@@ -10,6 +10,7 @@ public class BaseTeamMembersValidator : AbstractValidator<CreateTeamMemberDto>
     public BaseTeamMembersValidator()
     {
         RuleFor(x => x.FullName)
+            .Matches(@"^[\p{L}'\- ]+$").WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)))
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.FullName)))
             .MinimumLength(FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMinLength))
             .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMaxLength));

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
@@ -10,7 +10,7 @@ public class BaseTeamMembersValidator : AbstractValidator<CreateTeamMemberDto>
     public BaseTeamMembersValidator()
     {
         RuleFor(x => x.FullName)
-            .Matches(@"^[\p{L}'\- ]+$").WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)))
+            .Matches(@"^[\p{L}'\u2019\- ]+$").WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)))
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.FullName)))
             .MinimumLength(FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMinLength))
             .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMaxLength));

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/CreateTeamMemberValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/CreateTeamMemberValidator.cs
@@ -1,5 +1,7 @@
 ﻿using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.TeamMembers.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 
 namespace VictoryCenter.BLL.Validators.TeamMembers;
 
@@ -8,5 +10,8 @@ public class CreateTeamMemberValidator : AbstractValidator<CreateTeamMemberComma
     public CreateTeamMemberValidator(BaseTeamMembersValidator baseTeamMembersValidator)
     {
         RuleFor(c => c.CreateTeamMemberDto).SetValidator(baseTeamMembersValidator);
+        RuleFor(c => c.CreateTeamMemberDto.FullName)
+                    .Matches(@"^[\p{L}'\- ]+$")
+                    .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/CreateTeamMemberValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/CreateTeamMemberValidator.cs
@@ -1,7 +1,5 @@
 ﻿using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.TeamMembers.Create;
-using VictoryCenter.BLL.Constants;
-using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 
 namespace VictoryCenter.BLL.Validators.TeamMembers;
 
@@ -10,8 +8,5 @@ public class CreateTeamMemberValidator : AbstractValidator<CreateTeamMemberComma
     public CreateTeamMemberValidator(BaseTeamMembersValidator baseTeamMembersValidator)
     {
         RuleFor(c => c.CreateTeamMemberDto).SetValidator(baseTeamMembersValidator);
-        RuleFor(c => c.CreateTeamMemberDto.FullName)
-                    .Matches(@"^[\p{L}'\- ]+$")
-                    .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)));
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/TeamMembers/TeamMemberSeeder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/TeamMembers/TeamMemberSeeder.cs
@@ -36,7 +36,7 @@ public class TeamMembersSeeder : BaseSeeder<TeamMember>
             var category = selectedCategories[i % selectedCategories.Count];
             teamMembers.Add(new TeamMember
             {
-                FullName = $"FirstName{i} LastName{i}",
+                FullName = $"FirstName LastName",
                 CategoryId = category.Id,
                 Priority = i + 1,
                 Status = (Status)(i % Enum.GetNames<Status>().Length),

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
@@ -161,7 +161,8 @@ public class UpdateTeamMemberTests
                 }, _testExistingTeamMember.Id), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
-        Assert.Contains(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamMemberDto.FullName)), result.Errors[0].Message);
+        Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamMemberDto.FullName)));
+
     }
 
     [Fact]
@@ -182,7 +183,7 @@ public class UpdateTeamMemberTests
             new UpdateTeamMemberCommand(
                 new UpdateTeamMemberDto
                 {
-                    FullName = "test1",
+                    FullName = "testOne",
                     CategoryId = 10000,
                     Description = "Updated Description"
                 }, _testExistingTeamMember.Id), CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
@@ -162,7 +162,6 @@ public class UpdateTeamMemberTests
 
         Assert.False(result.IsSuccess);
         Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamMemberDto.FullName)));
-
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
@@ -47,6 +47,34 @@ public class BaseTeamMembersValidatorTests
     }
 
     [Fact]
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameConsistSymbols()
+    {
+        var model = new CreateTeamMemberDto
+        {
+            FullName = "@#$",
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage(
+                ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)));
+    }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameConsistNumbers()
+    {
+        var model = new CreateTeamMemberDto
+        {
+            FullName = "123",
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage(
+                ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)));
+    }
+
+    [Fact]
     public void BaseTeamMembersValidator_ShouldHaveError_WhenCategoryIdIsZero()
     {
         var model = new CreateTeamMemberDto { FullName = "John Doe", CategoryId = 0 };


### PR DESCRIPTION

* [Github](https://github.com/ita-social-projects/VictoryCenter-Back/issues/475#issue-3408008930)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Team member name can consist sumbols and numbers

## Summary of change

Add validation on team me,mber full name that it can consist only letters, spaces, apostrophe

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation tightened for team member Full Name: only letters, apostrophes, hyphens, and spaces are allowed; names with digits or unsupported symbols are rejected and surface a clearer format error.

* **Tests**
  * Added unit tests to confirm names with only symbols or only digits are rejected with the correct validation message.
  * Updated tests to assert the expected validation message is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->