### PR TITLE
Fix/issue 474: Fullname cannot be made up of digits

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -112,4 +112,9 @@ public static class ErrorMessagesConstants
     {
         return $"Blob error: {message}";
     }
+
+    public static string FullNameInvalidPattern()
+    {
+        return $"Поле може містити лише літери, пробіли, апострофи та дефіси. Поле не може містити цифри";
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -115,6 +115,6 @@ public static class ErrorMessagesConstants
 
     public static string FullNameInvalidPattern()
     {
-        return $"Поле може містити лише літери, пробіли, апострофи та дефіси. Поле не може містити цифри";
+        return "Field can only contain letters, spaces, apostrophes and hyphens. Field cannot contain digits";
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
@@ -12,7 +12,8 @@ public class BaseTeamMembersValidator : AbstractValidator<CreateTeamMemberDto>
         RuleFor(x => x.FullName)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.FullName)))
             .MinimumLength(FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMinLength))
-            .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMaxLength));
+            .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMaxLength))
+            .Matches(@"^[A-Za-zА-Яа-яҐґЄєІіЇї''\-\s]+$").WithMessage(ErrorMessagesConstants.FullNameInvalidPattern());
         RuleFor(x => x.CategoryId)
             .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateTeamMemberDto.CategoryId)));
         RuleFor(x => x.Status)

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
@@ -115,4 +115,47 @@ public class BaseTeamMembersValidatorTests
         var result = _validator.TestValidate(model);
         result.ShouldNotHaveAnyValidationErrors();
     }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameContainsDigits()
+    {
+        var model = new CreateTeamMemberDto { FullName = "12345", CategoryId = 1 };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage(ErrorMessagesConstants.FullNameInvalidPattern());
+    }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameContainsSpecialCharacters()
+    {
+        var model = new CreateTeamMemberDto { FullName = "John@Doe", CategoryId = 1 };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage(ErrorMessagesConstants.FullNameInvalidPattern());
+    }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameMixedWithDigits()
+    {
+        var model = new CreateTeamMemberDto { FullName = "John123", CategoryId = 1 };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.FullName)
+            .WithErrorMessage(ErrorMessagesConstants.FullNameInvalidPattern());
+    }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldNotHaveError_WhenFullNameContainsValidCharacters()
+    {
+        var model = new CreateTeamMemberDto { FullName = "John O'Connor-Smith", CategoryId = 1 };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.FullName);
+    }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldNotHaveError_WhenFullNameContainsCyrillicCharacters()
+    {
+        var model = new CreateTeamMemberDto { FullName = "Іван Петрович", CategoryId = 1 };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.FullName);
+    }
 }


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

<img width="809" height="675" alt="image" src="https://github.com/user-attachments/assets/0334f414-c669-435a-8707-fdce25372caa" />


## Summary of change

<img width="1199" height="821" alt="image" src="https://github.com/user-attachments/assets/0151ee3c-f50f-4740-b2eb-58ae27047cc1" />


## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added stricter validation for team member full names: only letters, spaces, apostrophes, and hyphens are allowed; digits and other special characters are rejected.
  - Introduced a clear, user-friendly error message for invalid full name formats.
  - Support confirmed for names using Cyrillic characters.

- Tests
  - Added comprehensive test coverage for valid and invalid full name scenarios, including digits, mixed characters, special characters, and multilingual inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->