### PR TITLE
Fix/issue 476: Image can't be null

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
@@ -23,6 +23,10 @@ public class BaseTeamMembersValidator : AbstractValidator<CreateTeamMemberDto>
         RuleFor(x => x.Description)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.Description)))
             .When(x => x.Status == Status.Published);
+        RuleFor(x => x.ImageId)
+            .NotNull().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.ImageId)))
+            .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateTeamMemberDto.ImageId)))
+            .When(x => x.Status == Status.Published);
     }
 
     public static int FullNameMinLength { get; } = 2;

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
@@ -115,4 +115,35 @@ public class BaseTeamMembersValidatorTests
         var result = _validator.TestValidate(model);
         result.ShouldNotHaveAnyValidationErrors();
     }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenImageIdIsNullForPublished()
+    {
+        var model = new CreateTeamMemberDto
+        {
+            FullName = "John Doe",
+            CategoryId = 1,
+            Status = Status.Published,
+            Description = "Valid description",
+            ImageId = null
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.ImageId)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.ImageId)));
+    }
+
+    [Fact]
+    public void BaseTeamMembersValidator_ShouldNotHaveError_WhenImageIdIsNullForDraft()
+    {
+        var model = new CreateTeamMemberDto
+        {
+            FullName = "John Doe",
+            CategoryId = 1,
+            Status = Status.Draft,
+            Description = "",
+            ImageId = null
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.ImageId);
+    }
 }


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

<img width="805" height="678" alt="image" src="https://github.com/user-attachments/assets/1ca1cb3f-e068-46a9-8f5c-0c70f645a3a7" />

## Summary of change

<img width="1375" height="705" alt="image" src="https://github.com/user-attachments/assets/465e1da7-fbe9-4f08-aa83-ec2bb1f314b1" />

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
