### PR TITLE
Fix/issue-621: Enhance SearchTeamMemberHandler with additional includes

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/Search/SearchTeamMemberHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/Search/SearchTeamMemberHandler.cs
@@ -47,11 +47,12 @@ public class SearchTeamMemberHandler : IRequestHandler<SearchTeamMemberQuery, Re
             };
 
             var searchExpression = _searchService.CreateSearchExpression(searchTerm);
+
             var teamMembers = await _repositoryWrapper.TeamMembersRepository.GetAllAsync(new QueryOptions<TeamMember>
             {
-                Include = tm => tm
+                Include = q => q
                     .Include(tm => tm.Category)
-                    .Include(tm => tm.Image),
+                    .Include(tm => tm.Image!),
                 Filter = searchExpression,
                 Offset = dto.Offset is > 0 ? (int)dto.Offset : 0,
                 Limit = dto.Limit is > 0 ? (int)dto.Limit : 0,

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/Search/SearchTeamMemberHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/Search/SearchTeamMemberHandler.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using FluentResults;
 using FluentValidation;
 using MediatR;
@@ -49,7 +49,9 @@ public class SearchTeamMemberHandler : IRequestHandler<SearchTeamMemberQuery, Re
             var searchExpression = _searchService.CreateSearchExpression(searchTerm);
             var teamMembers = await _repositoryWrapper.TeamMembersRepository.GetAllAsync(new QueryOptions<TeamMember>
             {
-                Include = tm => tm.Include(tm => tm.Category),
+                Include = tm => tm
+                    .Include(tm => tm.Category)
+                    .Include(tm => tm.Image),
                 Filter = searchExpression,
                 Offset = dto.Offset is > 0 ? (int)dto.Offset : 0,
                 Limit = dto.Limit is > 0 ? (int)dto.Limit : 0,

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
@@ -21,30 +21,14 @@ public class SearchTeamMemberTests
     private readonly Mock<ISearchService<TeamMember>> _searchServiceMock;
     private readonly IValidator<SearchTeamMemberQuery> _validator;
 
-    private readonly List<TeamMember> _teamMembers = [
-        new TeamMember
-        {
-            Id = 1,
-            FullName = "TestName",
-            Priority = 1,
-            CategoryId = 1,
-            Status = Status.Draft,
-            Description = "Long description",
-            Email = "Test@gmail.com",
-            CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-10)
-        },
+    private readonly List<TeamMember> _teamMembers =
+    [
+        CreateTeamMember(1, "TestName", Status.Draft, "Test@gmail.com")
     ];
 
-    private readonly List<TeamMemberDto> _teamMemberDtos = [
-        new TeamMemberDto
-        {
-            Id = 1,
-            FullName = "TestName",
-            Priority = 1,
-            Status = Status.Draft,
-            Description = "Long description",
-            Email = "Test@gmail.com"
-        },
+    private readonly List<TeamMemberDto> _teamMemberDtos =
+    [
+        CreateTeamMemberDto(1, "TestName", Status.Draft, "Test@gmail.com")
     ];
 
     public SearchTeamMemberTests()
@@ -115,53 +99,16 @@ public class SearchTeamMemberTests
     public async Task Handle_WithImage_ShouldReturnImage()
     {
         // Arrange
-        var members = new List<TeamMember>
-        {
-            new()
-            {
-                Id = 2,
-                FullName = "With Image",
-                Priority = 1,
-                CategoryId = 1,
-                Status = Status.Published,
-                Description = "desc",
-                Email = "with@img.com",
-                Image = new Image
-                {
-                    Id = 10,
-                    BlobName = "blob.jpg",
-                    Url = "https://cdn.example.com/blob.jpg",
-                    MimeType = "image/jpeg",
-                    CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
-                },
-                CreatedAt = DateTimeOffset.UtcNow
-            }
-        };
-        var dtos = new List<TeamMemberDto>
-        {
-            new()
-            {
-                Id = 2,
-                FullName = "With Image",
-                Priority = 1,
-                Status = Status.Published,
-                Description = "desc",
-                Email = "with@img.com",
-                Image = new ImageDto
-                {
-                    Id = 10,
-                    BlobName = "blob.jpg",
-                    Url = "https://cdn.example.com/blob.jpg",
-                    MimeType = "image/jpeg",
-                    CreatedAt = members[0].Image!.CreatedAt
-                }
-            }
-        };
-        SetupMapper(dtos);
-        SetupRepositoryWrapper(members);
+        var image = CreateImage(10, "blob.jpg", "https://cdn.example.com/blob.jpg");
+        var member = CreateTeamMember(2, "With Image", Status.Published, "with@img.com", image);
+        var imageDto = CreateImageDto(10, "blob.jpg", "https://cdn.example.com/blob.jpg", image.CreatedAt);
+        var dto = CreateTeamMemberDto(2, "With Image", Status.Published, "with@img.com", imageDto);
 
-        var dto = new SearchTeamMemberDto { FullName = "With Image" };
-        var query = new SearchTeamMemberQuery(dto);
+        SetupMapper([dto]);
+        SetupRepositoryWrapper([member]);
+
+        var searchDto = new SearchTeamMemberDto { FullName = "With Image" };
+        var query = new SearchTeamMemberQuery(searchDto);
         var handler = new SearchTeamMemberHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator, _searchServiceMock.Object);
 
         // Act
@@ -175,39 +122,14 @@ public class SearchTeamMemberTests
     public async Task Handle_WithoutImage_ShouldReturnNullImage()
     {
         // Arrange
-        var members = new List<TeamMember>
-        {
-            new()
-            {
-                Id = 3,
-                FullName = "No Image",
-                Priority = 1,
-                CategoryId = 1,
-                Status = Status.Published,
-                Description = "desc",
-                Email = "no@img.com",
-                Image = null,
-                CreatedAt = DateTimeOffset.UtcNow
-            }
-        };
-        var dtos = new List<TeamMemberDto>
-        {
-            new()
-            {
-                Id = 3,
-                FullName = "No Image",
-                Priority = 1,
-                Status = Status.Published,
-                Description = "desc",
-                Email = "no@img.com",
-                Image = null
-            }
-        };
-        SetupMapper(dtos);
-        SetupRepositoryWrapper(members);
+        var member = CreateTeamMember(3, "No Image", Status.Published, "no@img.com");
+        var dto = CreateTeamMemberDto(3, "No Image", Status.Published, "no@img.com");
 
-        var dto = new SearchTeamMemberDto { FullName = "No Image" };
-        var query = new SearchTeamMemberQuery(dto);
+        SetupMapper([dto]);
+        SetupRepositoryWrapper([member]);
+
+        var searchDto = new SearchTeamMemberDto { FullName = "No Image" };
+        var query = new SearchTeamMemberQuery(searchDto);
         var handler = new SearchTeamMemberHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator, _searchServiceMock.Object);
 
         // Act
@@ -215,6 +137,60 @@ public class SearchTeamMemberTests
 
         // Assert
         Assert.Null(Assert.Single(result.Value!.Items).Image);
+    }
+
+    private static TeamMember CreateTeamMember(int id, string fullName, Status status, string email, Image? image = null)
+    {
+        return new TeamMember
+        {
+            Id = id,
+            FullName = fullName,
+            Priority = 1,
+            CategoryId = 1,
+            Status = status,
+            Description = "desc",
+            Email = email,
+            Image = image,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static TeamMemberDto CreateTeamMemberDto(int id, string fullName, Status status, string email, ImageDto? image = null)
+    {
+        return new TeamMemberDto
+        {
+            Id = id,
+            FullName = fullName,
+            Priority = 1,
+            Status = status,
+            Description = "desc",
+            Email = email,
+            Image = image
+        };
+    }
+
+    private static Image CreateImage(int id, string blobName, string url)
+    {
+        return new Image
+        {
+            Id = id,
+            BlobName = blobName,
+            Url = url,
+            MimeType = "image/jpeg",
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+        };
+    }
+
+    private static ImageDto CreateImageDto(int id, string blobName, string url, DateTimeOffset createdAt)
+    {
+        return new ImageDto
+        {
+            Id = id,
+            BlobName = blobName,
+            Url = url,
+            MimeType = "image/jpeg",
+            CreatedAt = createdAt
+        };
     }
 
     private void SetupMapper(List<TeamMemberDto> teamMemberDtos)

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
@@ -150,6 +150,7 @@ public class SearchTeamMemberTests
             Status = status,
             Description = "desc",
             Email = email,
+            ImageId = image?.Id,
             Image = image,
             CreatedAt = DateTimeOffset.UtcNow
         };

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
@@ -1,8 +1,9 @@
-﻿using AutoMapper;
+using AutoMapper;
 using FluentValidation;
 using Moq;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
+using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Interfaces.Search;
 using VictoryCenter.BLL.Queries.Admin.TeamMembers.Search;
 using VictoryCenter.BLL.Validators.TeamMembers;
@@ -108,6 +109,112 @@ public class SearchTeamMemberTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains(ErrorMessagesConstants.PropertyIsRequired(nameof(SearchTeamMemberDto.FullName)), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithImage_ShouldReturnImage()
+    {
+        // Arrange
+        var members = new List<TeamMember>
+        {
+            new()
+            {
+                Id = 2,
+                FullName = "With Image",
+                Priority = 1,
+                CategoryId = 1,
+                Status = Status.Published,
+                Description = "desc",
+                Email = "with@img.com",
+                Image = new Image
+                {
+                    Id = 10,
+                    BlobName = "blob.jpg",
+                    Url = "https://cdn.example.com/blob.jpg",
+                    MimeType = "image/jpeg",
+                    CreatedAt = DateTimeOffset.UtcNow.AddHours(-1)
+                },
+                CreatedAt = DateTimeOffset.UtcNow
+            }
+        };
+        var dtos = new List<TeamMemberDto>
+        {
+            new()
+            {
+                Id = 2,
+                FullName = "With Image",
+                Priority = 1,
+                Status = Status.Published,
+                Description = "desc",
+                Email = "with@img.com",
+                Image = new ImageDto
+                {
+                    Id = 10,
+                    BlobName = "blob.jpg",
+                    Url = "https://cdn.example.com/blob.jpg",
+                    MimeType = "image/jpeg",
+                    CreatedAt = members[0].Image!.CreatedAt
+                }
+            }
+        };
+        SetupMapper(dtos);
+        SetupRepositoryWrapper(members);
+
+        var dto = new SearchTeamMemberDto { FullName = "With Image" };
+        var query = new SearchTeamMemberQuery(dto);
+        var handler = new SearchTeamMemberHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator, _searchServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(Assert.Single(result.Value!.Items).Image);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutImage_ShouldReturnNullImage()
+    {
+        // Arrange
+        var members = new List<TeamMember>
+        {
+            new()
+            {
+                Id = 3,
+                FullName = "No Image",
+                Priority = 1,
+                CategoryId = 1,
+                Status = Status.Published,
+                Description = "desc",
+                Email = "no@img.com",
+                Image = null,
+                CreatedAt = DateTimeOffset.UtcNow
+            }
+        };
+        var dtos = new List<TeamMemberDto>
+        {
+            new()
+            {
+                Id = 3,
+                FullName = "No Image",
+                Priority = 1,
+                Status = Status.Published,
+                Description = "desc",
+                Email = "no@img.com",
+                Image = null
+            }
+        };
+        SetupMapper(dtos);
+        SetupRepositoryWrapper(members);
+
+        var dto = new SearchTeamMemberDto { FullName = "No Image" };
+        var query = new SearchTeamMemberQuery(dto);
+        var handler = new SearchTeamMemberHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator, _searchServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Null(Assert.Single(result.Value!.Items).Image);
     }
 
     private void SetupMapper(List<TeamMemberDto> teamMemberDtos)

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/SearchTeamMemberTests.cs
@@ -28,7 +28,7 @@ public class SearchTeamMemberTests
 
     private readonly List<TeamMemberDto> _teamMemberDtos =
     [
-        CreateTeamMemberDto(1, "TestName", Status.Draft, "Test@gmail.com")
+        CreateTeamMemberDto(1, "TestName", Status.Draft)
     ];
 
     public SearchTeamMemberTests()
@@ -102,7 +102,7 @@ public class SearchTeamMemberTests
         var image = CreateImage(10, "blob.jpg", "https://cdn.example.com/blob.jpg");
         var member = CreateTeamMember(2, "With Image", Status.Published, "with@img.com", image);
         var imageDto = CreateImageDto(10, "blob.jpg", "https://cdn.example.com/blob.jpg", image.CreatedAt);
-        var dto = CreateTeamMemberDto(2, "With Image", Status.Published, "with@img.com", imageDto);
+        var dto = CreateTeamMemberDto(2, "With Image", Status.Published, imageDto);
 
         SetupMapper([dto]);
         SetupRepositoryWrapper([member]);
@@ -123,7 +123,7 @@ public class SearchTeamMemberTests
     {
         // Arrange
         var member = CreateTeamMember(3, "No Image", Status.Published, "no@img.com");
-        var dto = CreateTeamMemberDto(3, "No Image", Status.Published, "no@img.com");
+        var dto = CreateTeamMemberDto(3, "No Image", Status.Published);
 
         SetupMapper([dto]);
         SetupRepositoryWrapper([member]);
@@ -155,7 +155,7 @@ public class SearchTeamMemberTests
         };
     }
 
-    private static TeamMemberDto CreateTeamMemberDto(int id, string fullName, Status status, string email, ImageDto? image = null)
+    private static TeamMemberDto CreateTeamMemberDto(int id, string fullName, Status status, ImageDto? image = null)
     {
         return new TeamMemberDto
         {
@@ -164,7 +164,6 @@ public class SearchTeamMemberTests
             Priority = 1,
             Status = status,
             Description = "desc",
-            Email = email,
             Image = image
         };
     }


### PR DESCRIPTION
dev
## JIRA

* [621](https://github.com/ita-social-projects/VictoryCenter-Back/issues/621)

## Summary of issue

Handler for searching team members, returns team members without Image

## Summary of change

Added Incude so that Image is in the team member

## Testing approach

- Go to Swagger
- Call up the team members search
- Check whether there is an Image field in the objects 

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin team member search and listings now reliably include member images so pictures display correctly.

* **Refactor**
  * Data retrieval adjusted to explicitly include related image and category information without changing external behavior.

* **Tests**
  * Added unit tests and test helpers to cover members with and without images and to validate DTO mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->