### PR TITLE
Fix GITHUB_TOKEN usage in pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,8 +44,10 @@ jobs:
     steps:
      - name: "Get approval message for Stage deploy"
        id: set_env
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
        run: |
-          echo "comment=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          echo "comment=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
                -H "Accept: application/vnd.github+json" \
                 https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals \
               | jq '.[] | {user: .user.login, comment: .comment, environments: [.environments[].name]}' \
@@ -102,8 +104,10 @@ jobs:
     steps:
      - name: "Get rollback message for Stage deploy"
        id: set_comment_rollback
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
        run: |
-              echo "comment=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              echo "comment=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
                 -H "Accept: application/vnd.github+json" \
                 https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals \
                 | jq -r '.[0].comment')" >> $GITHUB_OUTPUT    


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security in handling authentication credentials for automated approval and rollback processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->