### PR TITLE
Skip stopping Docker containers in workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,7 +72,8 @@ jobs:
       with:
         repository: ita-social-projects/VictoryCenter-DevOps
     - name: Stop all containers
-      run: docker stop nginx certbot frontend backend 
+      # run: docker stop nginx certbot frontend backend
+      run: echo "Skipping container stop temporarily"
     - name: Delete additon info
       run: docker system prune -f
     - name: Set docker tag


### PR DESCRIPTION
Temporarily skip stopping Docker containers in workflow.

dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request workflow to temporarily skip container termination during the automated build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->