### PR TITLE
fix/issue-825 - iban must contains only digits

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -109,6 +109,11 @@ public static class ErrorMessagesConstants
         return $"{collection} cannot be empty";
     }
 
+    public static string OnlyDigitsAllowed()
+    {
+        return "Only digits allowed";
+    }
+
     public static string CollectionCannotContainMoreThan(string collection, long numberOfElements)
     {
         return $"{collection} cannot contain more than {numberOfElements} elements";

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Donate/UahBankDetails/UahBankDetailsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Donate/UahBankDetails/UahBankDetailsDtoValidator.cs
@@ -22,13 +22,15 @@ public class UahBankDetailsDtoValidator<T> : AbstractValidator<T>
             .WithMessage(UahBankDetailsConstants.OnlyDigitsMessage);
 
         RuleFor(dto => dto.Iban)
-            .NotEmpty()
+            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateUahBankDetailsDto.Iban)))
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UahBankDetailsDto.Iban)))
-            .MaximumLength(UahBankDetailsConstants.Iban.MaxLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UahBankDetailsDto.Iban), UahBankDetailsConstants.Iban.MaxLength))
+            .Matches(@"^UA\d+$")
+            .WithMessage(ErrorMessagesConstants.OnlyDigitsAllowed())
             .MinimumLength(UahBankDetailsConstants.Iban.MinLength)
             .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UahBankDetailsDto.Iban), UahBankDetailsConstants.Iban.MinLength));
+              .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UahBankDetailsDto.Iban), UahBankDetailsConstants.Iban.MinLength))
+            .MaximumLength(UahBankDetailsConstants.Iban.MaxLength)
+            .WithMessage(ErrorMessagesConstants
+                .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UahBankDetailsDto.Iban), UahBankDetailsConstants.Iban.MaxLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Donate/CreateUahBankDetailsCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Donate/CreateUahBankDetailsCommandValidatorTests.cs
@@ -101,7 +101,7 @@ public class CreateUahBankDetailsCommandValidatorTests
             new CreateUahBankDetailsDto
             {
                 Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
-                Iban = new string('1', UahBankDetailsConstants.Iban.MinLength - 1)
+                Iban = new string("UA") + new string('1', UahBankDetailsConstants.Iban.MinLength - 3)
             });
 
         var result = _validator.TestValidate(command);
@@ -118,7 +118,7 @@ public class CreateUahBankDetailsCommandValidatorTests
             new CreateUahBankDetailsDto
             {
                 Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
-                Iban = new string('1', UahBankDetailsConstants.Iban.MaxLength + 1)
+                Iban = new string("UA") + new string('1', UahBankDetailsConstants.Iban.MaxLength + 1)
             });
 
         var result = _validator.TestValidate(command);
@@ -135,11 +135,39 @@ public class CreateUahBankDetailsCommandValidatorTests
             new CreateUahBankDetailsDto
             {
                 Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
-                Iban = new string('1', UahBankDetailsConstants.Iban.MinLength)
+                Iban = new string("UA") + new string('1', UahBankDetailsConstants.Iban.MinLength - 2)
             });
 
         var result = _validator.TestValidate(command);
 
         result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIbanDoesNotStartWithUA()
+    {
+        var command = new CreateUahBankDetailsCommand(
+            new CreateUahBankDetailsDto
+            {
+                Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
+                Iban = new string('1', UahBankDetailsConstants.Iban.MinLength)
+            });
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.CreateUahBankDetailsDto.Iban)
+            .WithErrorMessage(ErrorMessagesConstants.OnlyDigitsAllowed());
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIbanContainsInvalidCharacters()
+    {
+        var command = new CreateUahBankDetailsCommand(
+            new CreateUahBankDetailsDto
+            {
+                Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
+                Iban = "UA12AB34567890123456789012345"
+            });
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.CreateUahBankDetailsDto.Iban)
+            .WithErrorMessage(ErrorMessagesConstants.OnlyDigitsAllowed());
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Donate/UpdateUahBankDetailsCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Donate/UpdateUahBankDetailsCommandValidatorTests.cs
@@ -71,7 +71,7 @@ public class UpdateUahBankDetailsCommandValidatorTests
             new UpdateUahBankDetailsDto
             {
                 Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
-                Iban = new string('1', UahBankDetailsConstants.Iban.MinLength - 1)
+                Iban = "UA" + new string('1', UahBankDetailsConstants.Iban.MinLength - 3)
             },
             1L);
 
@@ -89,12 +89,42 @@ public class UpdateUahBankDetailsCommandValidatorTests
             new UpdateUahBankDetailsDto
             {
                 Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
-                Iban = new string('1', UahBankDetailsConstants.Iban.MinLength)
+                Iban = "UA" + new string('1', UahBankDetailsConstants.Iban.MinLength - 2)
             },
             1L);
 
         var result = _validator.TestValidate(command);
 
         result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIbanDoesNotStartWithUA()
+    {
+        var command = new UpdateUahBankDetailsCommand(
+            new UpdateUahBankDetailsDto
+            {
+                Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
+                Iban = "US" + new string('1', UahBankDetailsConstants.Iban.MinLength - 2)
+            },
+            1L);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.UpdateUahBankDetailsDto.Iban)
+            .WithErrorMessage(ErrorMessagesConstants.OnlyDigitsAllowed());
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIbanContainsInvalidCharacters()
+    {
+        var command = new UpdateUahBankDetailsCommand(
+            new UpdateUahBankDetailsDto
+            {
+                Edrpou = new string('1', UahBankDetailsConstants.Edrpou.MinLength),
+                Iban = "UA12345A7890"
+            },
+            1L);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(c => c.UpdateUahBankDetailsDto.Iban)
+            .WithErrorMessage(ErrorMessagesConstants.OnlyDigitsAllowed());
     }
 }


### PR DESCRIPTION

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/852)

## Summary of issue

When Iban was created with not only digits it does not give "only digits allowed error"

## Summary of change

Add additional rule for validator to check whether iban has not digit chars or not and update unit and integration tests

## Testing approach

Unit ans integration testing

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced IBAN validation for Ukrainian bank details to enforce stricter format requirements, ensuring only valid Ukrainian account numbers are accepted.

* **Tests**
  * Added validation tests to verify proper handling of incorrectly formatted IBANs and improved error messaging for invalid entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->