### PR TITLE
fix/issue-853 add only digits validation

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Validators/Donate/UahBankDetails/UahBankDetailsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Donate/UahBankDetails/UahBankDetailsDtoValidator.cs
@@ -19,9 +19,7 @@ public class UahBankDetailsDtoValidator<T> : AbstractValidator<T>
                 .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UahBankDetailsDto.Edrpou), UahBankDetailsConstants.Edrpou.MaxLength))
             .MinimumLength(UahBankDetailsConstants.Edrpou.MinLength)
             .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UahBankDetailsDto.Edrpou), UahBankDetailsConstants.Edrpou.MinLength))
-            .Matches(UahBankDetailsConstants.OnlyDigits)
-            .WithMessage(UahBankDetailsConstants.OnlyDigitsMessage);
+                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UahBankDetailsDto.Edrpou), UahBankDetailsConstants.Edrpou.MinLength));
 
         RuleFor(dto => dto.Iban)
             .NotEmpty()

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Donate/UahBankDetails/UahBankDetailsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Donate/UahBankDetails/UahBankDetailsDtoValidator.cs
@@ -12,6 +12,8 @@ public class UahBankDetailsDtoValidator<T> : AbstractValidator<T>
         RuleFor(dto => dto.Edrpou)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UahBankDetailsDto.Edrpou)))
+            .Matches(UahBankDetailsConstants.OnlyDigits)
+            .WithMessage(UahBankDetailsConstants.OnlyDigitsMessage)
             .MaximumLength(UahBankDetailsConstants.Edrpou.MaxLength)
             .WithMessage(ErrorMessagesConstants
                 .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UahBankDetailsDto.Edrpou), UahBankDetailsConstants.Edrpou.MaxLength))


### PR DESCRIPTION

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/853)

## Summary of issue

Incorrect error message in 'ЄДРПОУ' field in UAH bank details when letters and symbols are entered

## Summary of change

Add validation for the 'ЄДРПОУ' field wheter it contains symbols

## Testing approach

Unit tests

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bank details validation: Edrpou now enforces digits-only immediately on input, with clearer error messaging; length checks (minimum and maximum) remain enforced to prevent invalid submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->