### PR TITLE
Feature/issue-542: Added translation status filter for team member

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMembers/Update/UpdateTeamMemberHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamMembers/Update/UpdateTeamMemberHandler.cs
@@ -75,9 +75,9 @@ public class UpdateTeamMemberHandler : IRequestHandler<UpdateTeamMemberCommand, 
             {
                 var rowsAffected = 0;
 
-                _mapper.Map(request.UpdateTeamMemberDto, entityToUpdate);
-
                 SetTranslationsToOutdated(request, entityToUpdate);
+
+                _mapper.Map(request.UpdateTeamMemberDto, entityToUpdate);
 
                 if (categoryChanged)
                 {

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/Base/ITranslationStatusFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/Base/ITranslationStatusFilterDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+public interface ITranslationStatusFilterDto
+{
+    TranslationStatus? TranslationStatus { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/Base/ITranslationStatusFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/Base/ITranslationStatusFilterDto.cs
@@ -1,8 +1,8 @@
-using VictoryCenter.DAL.Enums;
+using VictoryCenter.BLL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.Base;
 
 public interface ITranslationStatusFilterDto
 {
-    TranslationStatus? TranslationStatus { get; set; }
+    TranslationStatusFilter? TranslationStatusFilter { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMembers/TeamMembersFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMembers/TeamMembersFilterDto.cs
@@ -1,8 +1,11 @@
 using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 
-public record TeamMembersFilterDto : BaseFilterDto
+public record TeamMembersFilterDto : BaseFilterDto, ITranslationStatusFilterDto
 {
     public long? CategoryId { get; init; }
+    public TranslationStatus? TranslationStatus { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMembers/TeamMembersFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamMembers/TeamMembersFilterDto.cs
@@ -1,11 +1,11 @@
 using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
-using VictoryCenter.DAL.Enums;
+using VictoryCenter.BLL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 
 public record TeamMembersFilterDto : BaseFilterDto, ITranslationStatusFilterDto
 {
     public long? CategoryId { get; init; }
-    public TranslationStatus? TranslationStatus { get; set; }
+    public TranslationStatusFilter? TranslationStatusFilter { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Enums/TranslationStatusFilter.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Enums/TranslationStatusFilter.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.Enums;
+
+public enum TranslationStatusFilter
+{
+    All,
+    Outdated,
+    Missing,
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
@@ -31,6 +31,9 @@ public class GetTeamMembersByFiltersHandler : IRequestHandler<GetTeamMembersByFi
         var translationStatusFilter = request.TeamMembersFilterDto.TranslationStatusFilter;
         var languageCount = await _repository.LocalizationLanguagesRepository.CountAsync();
 
+        // There always will be one less localization than languages due to the default locale
+        languageCount -= 1;
+
         Expression<Func<TeamMember, bool>> filter = t =>
             (status == null || t.Status == status) &&
             (categoryId == null || t.TeamCategory.Id == categoryId) &&

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
@@ -26,9 +26,12 @@ public class GetTeamMembersByFiltersHandler : IRequestHandler<GetTeamMembersByFi
     {
         var status = request.TeamMembersFilterDto.Status;
         var categoryId = request.TeamMembersFilterDto.CategoryId;
+        var translationStatus = request.TeamMembersFilterDto.TranslationStatus;
 
-        Expression<Func<TeamMember, bool>> filter =
-            t => (status == null || t.Status == status) && (categoryId == null || t.TeamCategory.Id == categoryId);
+        Expression<Func<TeamMember, bool>> filter = t =>
+            (status == null || t.Status == status) &&
+            (categoryId == null || t.TeamCategory.Id == categoryId) &&
+            (translationStatus == null || t.Localizations.Any(l => l.TranslationStatus == translationStatus));
 
         var queryOptions = new QueryOptions<TeamMember>
         {

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/GetByFilters/GetTeamMembersByFiltersHandler.cs
@@ -5,7 +5,9 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Enums;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -26,12 +28,18 @@ public class GetTeamMembersByFiltersHandler : IRequestHandler<GetTeamMembersByFi
     {
         var status = request.TeamMembersFilterDto.Status;
         var categoryId = request.TeamMembersFilterDto.CategoryId;
-        var translationStatus = request.TeamMembersFilterDto.TranslationStatus;
+        var translationStatusFilter = request.TeamMembersFilterDto.TranslationStatusFilter;
+        var languageCount = await _repository.LocalizationLanguagesRepository.CountAsync();
 
         Expression<Func<TeamMember, bool>> filter = t =>
             (status == null || t.Status == status) &&
             (categoryId == null || t.TeamCategory.Id == categoryId) &&
-            (translationStatus == null || t.Localizations.Any(l => l.TranslationStatus == translationStatus));
+            (translationStatusFilter == null ||
+            translationStatusFilter == TranslationStatusFilter.All ||
+            (translationStatusFilter == TranslationStatusFilter.Outdated &&
+            t.Localizations.Any(l => l.TranslationStatus == TranslationStatus.Outdated)) ||
+            (translationStatusFilter == TranslationStatusFilter.Missing &&
+            t.Localizations.Count < languageCount));
 
         var queryOptions = new QueryOptions<TeamMember>
         {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/GetTeamMembersTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/GetTeamMembersTests.cs
@@ -1,8 +1,10 @@
 using AutoMapper;
 using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamMembers;
 using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 using VictoryCenter.BLL.Queries.Admin.TeamMembers.GetByFilters;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -171,6 +173,41 @@ public class GetTeamMembersTests
             () => Assert.Equal(teamMemberList.Count, result.Value.TotalItemsCount));
     }
 
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatus()
+    {
+        // Arrange
+        var translationStatus = TranslationStatus.Relevant;
+        var teamMemberList = GetTeamMemberList();
+        var teamMemberDtoList = GetTeamMemberDtoList()
+            .Where(t => t.Localizations.Any(l => l.TranslationStatus == translationStatus))
+            .OrderBy(t => t.Priority)
+            .ToList();
+
+        SetupRepository(teamMemberList);
+        SetupMapper(teamMemberDtoList);
+
+        var filtersDto = new TeamMembersFilterDto
+        {
+            Offset = 0,
+            Limit = 0,
+            TranslationStatus = translationStatus,
+        };
+
+        var handler = new GetTeamMembersByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
+
+        // Act
+        var result = await handler.Handle(new GetTeamMembersByFiltersQuery(filtersDto), CancellationToken.None);
+
+        // Assert
+        Assert.Multiple(
+            () => Assert.NotNull(result),
+            () => Assert.NotNull(result.Value),
+            () => Assert.NotEmpty(result.Value.Items),
+            () => Assert.Equal(teamMemberDtoList, result.Value.Items),
+            () => Assert.Equal(teamMemberList.Count, result.Value.TotalItemsCount));
+    }
+
     private static List<TeamMember> GetTeamMemberList()
     {
         var teamMemberList = new List<TeamMember>
@@ -181,7 +218,16 @@ public class GetTeamMembersTests
                 Priority = 3,
                 Status = Status.Draft,
                 CategoryId = 1,
-                TeamCategory = new TeamCategory { Id = 1, Name = "Category 1" }
+                TeamCategory = new TeamCategory { Id = 1, Name = "Category 1" },
+                Localizations = new List<TeamMemberLocalization>
+                {
+                    new()
+                    {
+                        EntityId = 4,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    }
+                }
             },
             new()
             {
@@ -189,7 +235,16 @@ public class GetTeamMembersTests
                 Priority = 2,
                 Status = Status.Draft,
                 CategoryId = 2,
-                TeamCategory = new TeamCategory { Id = 2, Name = "Category 2" }
+                TeamCategory = new TeamCategory { Id = 2, Name = "Category 2" },
+                Localizations = new List<TeamMemberLocalization>
+                {
+                    new()
+                    {
+                        EntityId = 2,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    }
+                }
             },
             new()
             {
@@ -197,7 +252,16 @@ public class GetTeamMembersTests
                 Priority = 1,
                 Status = Status.Published,
                 CategoryId = 1,
-                TeamCategory = new TeamCategory { Id = 1, Name = "Category 1" }
+                TeamCategory = new TeamCategory { Id = 1, Name = "Category 1" },
+                Localizations = new List<TeamMemberLocalization>
+                {
+                    new()
+                    {
+                        EntityId = 3,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Outdated,
+                    }
+                }
             },
             new()
             {
@@ -236,14 +300,30 @@ public class GetTeamMembersTests
                 Id = 3,
                 Priority = 1,
                 Status = Status.Published,
-                CategoryId = 1
+                CategoryId = 1,
+                Localizations = new List<TeamMemberLocalizationDto>
+                {
+                    new()
+                    {
+                        EntityId = 3,
+                        TranslationStatus = TranslationStatus.Outdated,
+                    }
+                }
             },
             new()
             {
                 Id = 2,
                 Priority = 2,
                 Status = Status.Draft,
-                CategoryId = 12
+                CategoryId = 12,
+                Localizations = new List<TeamMemberLocalizationDto>
+                {
+                    new()
+                    {
+                        EntityId = 2,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    }
+                }
             },
             new()
             {
@@ -258,6 +338,14 @@ public class GetTeamMembersTests
                 Priority = 3,
                 Status = Status.Draft,
                 CategoryId = 1,
+                Localizations = new List<TeamMemberLocalizationDto>
+                {
+                    new()
+                    {
+                        EntityId = 4,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    }
+                },
             },
         };
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/GetTeamMembersTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/GetTeamMembersTests.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Moq;
 using VictoryCenter.BLL.DTOs.Admin.Localization.TeamMembers;
 using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
+using VictoryCenter.BLL.Enums;
 using VictoryCenter.BLL.Queries.Admin.TeamMembers.GetByFilters;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
@@ -173,14 +174,14 @@ public class GetTeamMembersTests
             () => Assert.Equal(teamMemberList.Count, result.Value.TotalItemsCount));
     }
 
-    [Fact]
-    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatus()
+    [Theory]
+    [InlineData(TranslationStatusFilter.All)]
+    [InlineData(null)]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatusFilterAllOrNull(TranslationStatusFilter? translationStatusFilter)
     {
         // Arrange
-        var translationStatus = TranslationStatus.Relevant;
         var teamMemberList = GetTeamMemberList();
         var teamMemberDtoList = GetTeamMemberDtoList()
-            .Where(t => t.Localizations.Any(l => l.TranslationStatus == translationStatus))
             .OrderBy(t => t.Priority)
             .ToList();
 
@@ -191,7 +192,76 @@ public class GetTeamMembersTests
         {
             Offset = 0,
             Limit = 0,
-            TranslationStatus = translationStatus,
+            TranslationStatusFilter = translationStatusFilter,
+        };
+
+        var handler = new GetTeamMembersByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
+
+        // Act
+        var result = await handler.Handle(new GetTeamMembersByFiltersQuery(filtersDto), CancellationToken.None);
+
+        // Assert
+        Assert.Multiple(
+            () => Assert.NotNull(result),
+            () => Assert.NotNull(result.Value),
+            () => Assert.NotEmpty(result.Value.Items),
+            () => Assert.Equal(teamMemberDtoList, result.Value.Items),
+            () => Assert.Equal(teamMemberList.Count, result.Value.TotalItemsCount));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatusFilterMissing()
+    {
+        // Arrange
+        int languagesCount = 2;
+        var teamMemberList = GetTeamMemberList();
+        var teamMemberDtoList = GetTeamMemberDtoList()
+            .Where(t => t.Localizations.Count() < languagesCount)
+            .OrderBy(t => t.Priority)
+            .ToList();
+
+        SetupRepository(teamMemberList);
+        SetupMapper(teamMemberDtoList);
+
+        var filtersDto = new TeamMembersFilterDto
+        {
+            Offset = 0,
+            Limit = 0,
+            TranslationStatusFilter = TranslationStatusFilter.Missing,
+        };
+
+        var handler = new GetTeamMembersByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
+
+        // Act
+        var result = await handler.Handle(new GetTeamMembersByFiltersQuery(filtersDto), CancellationToken.None);
+
+        // Assert
+        Assert.Multiple(
+            () => Assert.NotNull(result),
+            () => Assert.NotNull(result.Value),
+            () => Assert.NotEmpty(result.Value.Items),
+            () => Assert.Equal(teamMemberDtoList, result.Value.Items),
+            () => Assert.Equal(teamMemberList.Count, result.Value.TotalItemsCount));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatusFilterOutdated()
+    {
+        // Arrange
+        var teamMemberList = GetTeamMemberList();
+        var teamMemberDtoList = GetTeamMemberDtoList()
+            .Where(t => t.Localizations.Any(l => l.TranslationStatus == TranslationStatus.Outdated))
+            .OrderBy(t => t.Priority)
+            .ToList();
+
+        SetupRepository(teamMemberList);
+        SetupMapper(teamMemberDtoList);
+
+        var filtersDto = new TeamMembersFilterDto
+        {
+            Offset = 0,
+            Limit = 0,
+            TranslationStatusFilter = TranslationStatusFilter.Outdated,
         };
 
         var handler = new GetTeamMembersByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
@@ -225,6 +295,12 @@ public class GetTeamMembersTests
                     {
                         EntityId = 4,
                         LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    },
+                    new()
+                    {
+                        EntityId = 4,
+                        LanguageId = 1,
                         TranslationStatus = TranslationStatus.Relevant,
                     }
                 }
@@ -344,6 +420,11 @@ public class GetTeamMembersTests
                     {
                         EntityId = 4,
                         TranslationStatus = TranslationStatus.Relevant,
+                    },
+                    new()
+                    {
+                        EntityId = 4,
+                        TranslationStatus = TranslationStatus.Relevant,
                     }
                 },
             },
@@ -359,6 +440,9 @@ public class GetTeamMembersTests
             .ReturnsAsync(teamMembers);
         _mockRepository.Setup(repositoryWrapper => repositoryWrapper.TeamMembersRepository.CountAsync(It.IsAny<QueryOptions<TeamMember>>()))
             .ReturnsAsync(teamMembers.Count);
+        _mockRepository.Setup(repositoryWrapper => repositoryWrapper.LocalizationLanguagesRepository.CountAsync(
+             It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(2);
     }
 
     private void SetupMapper(List<TeamMemberDto> teamMemberDTOList)


### PR DESCRIPTION
## Github

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/542)

## Summary of issue

Translation status filter for team members

## Summary of change

Added translation filter to get team members by filters

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation-status filtering for team members with options: All, Outdated, and Missing — view members by translation coverage.

* **Tests**
  * Added unit tests to validate translation-status filter behavior and ensure correct filtering results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->