### PR TITLE
Fix/issue 936 - Extract validation rules into constants

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/FaqQuestionConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/FaqQuestionConstants.cs
@@ -2,6 +2,11 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class FaqConstants
 {
+    public static readonly short QuestionTextMinLength = 10;
+    public static readonly short QuestionTextMaxLength = 150;
+    public static readonly short AnswerTextMinLength = 50;
+    public static readonly short AnswerTextMaxLength = 1000;
+
     public static readonly string PageNotFoundOrContainsNoFaqQuestions = "VisitorPage not found or does not contain FaqQuestions";
     public static readonly string SomePagesNotFound = "Some VisitorPages were not found";
     public static readonly string IdsAreNonConsecutive = "OrderedIds are non-consecutive";

--- a/VictoryCenter/VictoryCenter.BLL/Constants/GlobalSearchConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/GlobalSearchConstants.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class GlobalSearchConstants
+{
+    public static readonly int DefaultSearchQueryMinLength = 2;
+    public static readonly int DefaultSearchQueryMaxLength = 100;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ImageConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ImageConstants.cs
@@ -2,6 +2,18 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class ImageConstants
 {
+    public static readonly int MaxImageSizeInMb = 3;
+    public static readonly int BytesPerMb = 1024 * 1024;
+    public static readonly int MaxImageSizeInBytes = MaxImageSizeInMb * BytesPerMb;
+
+    public static readonly string[] AllowedMimeTypes =
+    [
+        "image/jpeg",
+        "image/jpg",
+        "image/png",
+        "image/webp"
+    ];
+
     public static readonly string Base64ValidationError = "Base64 content is invalid";
     public static readonly string FailToSaveImageInStorage = "An error occurred while saving the image in storage";
     public static readonly string FailToSaveImageInDatabase = "An error occurred while saving the image in database";

--- a/VictoryCenter/VictoryCenter.BLL/Constants/TeamMemberConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/TeamMemberConstants.cs
@@ -2,6 +2,11 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class TeamMemberConstants
 {
+    public static readonly int FullNameMinLength = 2;
+    public static readonly int FullNameMaxLength = 100;
+    public static readonly int DescriptionNameMinLength = 10;
+    public static readonly int DescriptionNameMaxLength = 200;
+
     public static readonly string CategoryNotFoundOrContainsNoTeamMembers = "Category not found or contains no team members";
     public static readonly string FailedRetrievingMemberPhoto = "Failed to retrieve team member photo ";
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/TeamMemberConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/TeamMemberConstants.cs
@@ -2,6 +2,8 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class TeamMemberConstants
 {
+    // Allows international names containing letters, spaces, hyphens, and apostrophes.
+    public static readonly string FullNameRegexPattern = @"^[\p{L}'\u2019\- ]+$";
     public static readonly int FullNameMinLength = 2;
     public static readonly int FullNameMaxLength = 100;
     public static readonly int DescriptionNameMinLength = 10;

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Common/BaseSearchDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Common/BaseSearchDto.cs
@@ -1,0 +1,10 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Common;
+
+public record BaseSearchDto
+{
+    public string SearchQuery { get; init; } = null!;
+
+    public int? Offset { get; init; }
+
+    public int? Limit { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyPrograms/SearchHippotherapyProgramDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyPrograms/SearchHippotherapyProgramDto.cs
@@ -1,10 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.Common;
+
 namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 
-public record SearchHippotherapyProgramDto
+public record SearchHippotherapyProgramDto : BaseSearchDto
 {
-    public string SearchQuery { get; init; } = null!;
-
-    public int? Offset { get; init; }
-
-    public int? Limit { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/FaqQuestions/BaseFaqQuestionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/FaqQuestions/BaseFaqQuestionValidator.cs
@@ -6,32 +6,27 @@ namespace VictoryCenter.BLL.Validators.FaqQuestions;
 
 public class BaseFaqQuestionValidator : AbstractValidator<CreateFaqQuestionDto>
 {
-    public static readonly short QuestionTextMinLength = 10;
-    public static readonly short QuestionTextMaxLength = 150;
-    public static readonly short AnswerTextMinLength = 50;
-    public static readonly short AnswerTextMaxLength = 1000;
-
     public BaseFaqQuestionValidator()
     {
         RuleFor(x => x.QuestionText)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqQuestionDto.QuestionText)))
-            .MinimumLength(QuestionTextMinLength)
+            .MinimumLength(FaqConstants.QuestionTextMinLength)
             .WithMessage(ErrorMessagesConstants
-                            .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), QuestionTextMinLength))
-            .MaximumLength(QuestionTextMaxLength)
+                            .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), FaqConstants.QuestionTextMinLength))
+            .MaximumLength(FaqConstants.QuestionTextMaxLength)
             .WithMessage(ErrorMessagesConstants
-                            .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), QuestionTextMaxLength));
+                            .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), FaqConstants.QuestionTextMaxLength));
 
         RuleFor(x => x.AnswerText)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqQuestionDto.AnswerText)))
-            .MinimumLength(AnswerTextMinLength)
+            .MinimumLength(FaqConstants.AnswerTextMinLength)
             .WithMessage(ErrorMessagesConstants
-                            .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), AnswerTextMinLength))
-            .MaximumLength(AnswerTextMaxLength)
+                            .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), FaqConstants.AnswerTextMinLength))
+            .MaximumLength(FaqConstants.AnswerTextMaxLength)
             .WithMessage(ErrorMessagesConstants
-                            .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), AnswerTextMaxLength));
+                            .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), FaqConstants.AnswerTextMaxLength));
 
         RuleFor(x => x.PageIds)
             .NotEmpty()

--- a/VictoryCenter/VictoryCenter.BLL/Validators/FaqQuestions/ReorderFaqQuestionsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/FaqQuestions/ReorderFaqQuestionsValidator.cs
@@ -7,27 +7,28 @@ namespace VictoryCenter.BLL.Validators.FaqQuestions;
 
 public class ReorderFaqQuestionsValidator : AbstractValidator<ReorderFaqQuestionsCommand>
 {
-    public static readonly int MaxFaqQuestionIds = 500;
-
     public ReorderFaqQuestionsValidator()
     {
         RuleFor(x => x.ReorderFaqQuestionsDto.PageId)
             .GreaterThan(0)
-            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(ReorderFaqQuestionsDto.PageId)));
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(ReorderFaqQuestionsDto.PageId)));
 
         RuleFor(x => x.ReorderFaqQuestionsDto.OrderedIds)
             .NotEmpty()
-            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(nameof(ReorderFaqQuestionsDto.OrderedIds)))
-            .Must(ids => ids.Count <= MaxFaqQuestionIds)
-            .WithMessage(ErrorMessagesConstants
-                .CollectionCannotContainMoreThan(nameof(ReorderFaqQuestionsDto.OrderedIds), MaxFaqQuestionIds))
+            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(ReorderFaqQuestionsDto.OrderedIds)))
+            .Must(ids => ids.Count <= ReorderConstants.MaxElementsSwapCount)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(ReorderFaqQuestionsDto.OrderedIds),
+                ReorderConstants.MaxElementsSwapCount))
             .Must(ids => ids.Distinct().Count() == ids.Count)
-            .WithMessage(ErrorMessagesConstants
-                .CollectionMustContainUniqueValues(nameof(ReorderFaqQuestionsDto.OrderedIds)));
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(ReorderFaqQuestionsDto.OrderedIds)));
 
         RuleForEach(x => x.ReorderFaqQuestionsDto.OrderedIds)
             .GreaterThan(0)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustBePositive($"Each {nameof(ReorderFaqQuestionsDto.OrderedIds)} element"));
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                $"Each {nameof(ReorderFaqQuestionsDto.OrderedIds)} element"));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryValidator.cs
@@ -11,12 +11,15 @@ public class CreateHippotherapyProgramCategoryValidator : AbstractValidator<Crea
     {
         RuleFor(command => command.CreateProgramCategoryDto.Name)
             .NotEmpty()
-            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(HippotherapyProgramCategoryDto.Name)))
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(HippotherapyProgramCategoryDto.Name)))
             .MaximumLength(HippotherapyProgramCategoryConstants.MaxNameLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(HippotherapyProgramCategoryDto.Name), HippotherapyProgramCategoryConstants.MaxNameLength))
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(HippotherapyProgramCategoryDto.Name),
+                HippotherapyProgramCategoryConstants.MaxNameLength))
             .MinimumLength(HippotherapyProgramCategoryConstants.MinNameLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(HippotherapyProgramCategoryDto.Name), HippotherapyProgramCategoryConstants.MinNameLength));
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(HippotherapyProgramCategoryDto.Name),
+                HippotherapyProgramCategoryConstants.MinNameLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryValidator.cs
@@ -11,12 +11,15 @@ public class UpdateHippotherapyProgramCategoryValidator : AbstractValidator<Upda
     {
         RuleFor(command => command.UpdateProgramCategoryDto.Name)
             .NotEmpty()
-            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateHippotherapyProgramCategoryDto.Name)))
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(UpdateHippotherapyProgramCategoryDto.Name)))
             .MaximumLength(HippotherapyProgramCategoryConstants.MaxNameLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateHippotherapyProgramCategoryDto.Name), HippotherapyProgramCategoryConstants.MaxNameLength))
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateHippotherapyProgramCategoryDto.Name),
+                HippotherapyProgramCategoryConstants.MaxNameLength))
             .MinimumLength(HippotherapyProgramCategoryConstants.MinNameLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateHippotherapyProgramCategoryDto.Name), HippotherapyProgramCategoryConstants.MinNameLength));
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateHippotherapyProgramCategoryDto.Name),
+                HippotherapyProgramCategoryConstants.MinNameLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyPrograms/SearchHippotherapyProgramValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyPrograms/SearchHippotherapyProgramValidator.cs
@@ -10,13 +10,16 @@ public class SearchHippotherapyProgramValidator : AbstractValidator<SearchHippot
     public SearchHippotherapyProgramValidator()
     {
         RuleFor(x => x.SearchHippotherapyProgramDto.SearchQuery)
-            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(SearchHippotherapyProgramDto.SearchQuery)))
-            .MinimumLength(SearchQueryMinLength).WithMessage(ErrorMessagesConstants
-            .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(SearchHippotherapyProgramDto.SearchQuery), SearchQueryMinLength))
-            .MaximumLength(SearchQueryMaxLength).WithMessage(ErrorMessagesConstants
-            .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(SearchHippotherapyProgramDto.SearchQuery), SearchQueryMaxLength));
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(SearchHippotherapyProgramDto.SearchQuery)))
+            .MinimumLength(GlobalSearchConstants.DefaultSearchQueryMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(SearchHippotherapyProgramDto.SearchQuery),
+                GlobalSearchConstants.DefaultSearchQueryMinLength))
+            .MaximumLength(GlobalSearchConstants.DefaultSearchQueryMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(SearchHippotherapyProgramDto.SearchQuery),
+                GlobalSearchConstants.DefaultSearchQueryMaxLength));
     }
-
-    public static int SearchQueryMinLength { get; } = 2;
-    public static int SearchQueryMaxLength { get; } = 100;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Images/BaseImageValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Images/BaseImageValidator.cs
@@ -1,21 +1,10 @@
 using FluentValidation;
+using VictoryCenter.BLL.Constants;
 
 namespace VictoryCenter.BLL.Validators.Images;
 
 public abstract class BaseImageValidator<TImageCommand> : AbstractValidator<TImageCommand>
 {
-    protected const int MaxImageSizeInMb = 3;
-    protected const int BytesPerMb = 1024 * 1024;
-    protected const int MaxImageSizeInBytes = MaxImageSizeInMb * BytesPerMb;
-
-    protected static readonly string[] AllowedMimeTypes =
-    [
-        "image/jpeg",
-        "image/jpg",
-        "image/png",
-        "image/webp"
-    ];
-
     private const char Base64PaddingChar = '=';
     private const int DoublePaddingLength = 2;
     private const int SinglePaddingLength = 1;
@@ -50,7 +39,7 @@ public abstract class BaseImageValidator<TImageCommand> : AbstractValidator<TIma
 
         double originalSize = (base64!.Length * Base64BytesPer3Chars / Base64CharsPer3Bytes) - padding;
 
-        return originalSize <= MaxImageSizeInBytes;
+        return originalSize <= ImageConstants.MaxImageSizeInBytes;
     }
 
     protected static bool IsValidBase64(string? base64)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Images/CreateImageValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Images/CreateImageValidator.cs
@@ -17,7 +17,7 @@ public class CreateImageValidator : BaseImageValidator<CreateImageCommand>
 
         RuleFor(x => x.CreateImageDto.MimeType)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateImageDto.MimeType)))
-            .Must(mimeType => AllowedMimeTypes.Contains(mimeType, StringComparer.InvariantCultureIgnoreCase))
-            .WithMessage(ImageConstants.MimeTypeValidationError(AllowedMimeTypes));
+            .Must(mimeType => ImageConstants.AllowedMimeTypes.Contains(mimeType, StringComparer.InvariantCultureIgnoreCase))
+            .WithMessage(ImageConstants.MimeTypeValidationError(ImageConstants.AllowedMimeTypes));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Images/UpdateImageValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Images/UpdateImageValidator.cs
@@ -17,7 +17,7 @@ public class UpdateImageValidator : BaseImageValidator<UpdateImageCommand>
 
         RuleFor(x => x.UpdateImageDto.MimeType)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateImageDto.MimeType)))
-            .Must(mimeType => AllowedMimeTypes.Contains(mimeType, StringComparer.InvariantCultureIgnoreCase))
-            .WithMessage(ImageConstants.MimeTypeValidationError(AllowedMimeTypes));
+            .Must(mimeType => ImageConstants.AllowedMimeTypes.Contains(mimeType, StringComparer.InvariantCultureIgnoreCase))
+            .WithMessage(ImageConstants.MimeTypeValidationError(ImageConstants.AllowedMimeTypes));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamCategories/BaseTeamCategoryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamCategories/BaseTeamCategoryValidator.cs
@@ -10,22 +10,28 @@ public class BaseTeamCategoryValidator : AbstractValidator<CreateTeamCategoryDto
     {
         RuleFor(dto => dto.Name)
             .NotEmpty()
-            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamCategoryDto.Name)))
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamCategoryDto.Name)))
             .MinimumLength(TeamCategoryConstants.MinNameLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamCategoryDto.Name), TeamCategoryConstants.MinNameLength))
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateTeamCategoryDto.Name),
+                TeamCategoryConstants.MinNameLength))
             .MaximumLength(TeamCategoryConstants.MaxNameLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamCategoryDto.Name), TeamCategoryConstants.MaxNameLength));
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateTeamCategoryDto.Name),
+                TeamCategoryConstants.MaxNameLength));
 
         RuleFor(dto => dto.Description)
             .NotEmpty()
-            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamCategoryDto.Description)))
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamCategoryDto.Description)))
             .MinimumLength(TeamCategoryConstants.MinDescriptionLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamCategoryDto.Description), TeamCategoryConstants.MinDescriptionLength))
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateTeamCategoryDto.Description),
+                TeamCategoryConstants.MinDescriptionLength))
             .MaximumLength(TeamCategoryConstants.MaxDescriptionLength)
-            .WithMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamCategoryDto.Description), TeamCategoryConstants.MaxDescriptionLength));
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateTeamCategoryDto.Description),
+                TeamCategoryConstants.MaxDescriptionLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
@@ -10,11 +10,11 @@ public class BaseTeamMembersValidator : AbstractValidator<CreateTeamMemberDto>
     public BaseTeamMembersValidator()
     {
         RuleFor(x => x.FullName)
-            .Matches(@"^[\p{L}'\u2019\- ]+$")
-            .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(
-                nameof(CreateTeamMemberDto.FullName)))
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamMemberDto.FullName)))
+            .Matches(TeamMemberConstants.FullNameRegexPattern)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(
                 nameof(CreateTeamMemberDto.FullName)))
             .MinimumLength(TeamMemberConstants.FullNameMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/BaseTeamMembersValidator.cs
@@ -10,27 +10,51 @@ public class BaseTeamMembersValidator : AbstractValidator<CreateTeamMemberDto>
     public BaseTeamMembersValidator()
     {
         RuleFor(x => x.FullName)
-            .Matches(@"^[\p{L}'\u2019\- ]+$").WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(CreateTeamMemberDto.FullName)))
-            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.FullName)))
-            .MinimumLength(FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMinLength))
-            .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.FullName), FullNameMaxLength));
+            .Matches(@"^[\p{L}'\u2019\- ]+$")
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(
+                nameof(CreateTeamMemberDto.FullName)))
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamMemberDto.FullName)))
+            .MinimumLength(TeamMemberConstants.FullNameMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateTeamMemberDto.FullName),
+                TeamMemberConstants.FullNameMinLength))
+            .MaximumLength(TeamMemberConstants.FullNameMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateTeamMemberDto.FullName),
+                TeamMemberConstants.FullNameMaxLength));
+
         RuleFor(x => x.CategoryId)
-            .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateTeamMemberDto.CategoryId)));
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(CreateTeamMemberDto.CategoryId)));
+
         RuleFor(x => x.Status)
-            .IsInEnum().WithMessage(ErrorMessagesConstants.UnknownStatusValue);
+            .IsInEnum()
+            .WithMessage(ErrorMessagesConstants.UnknownStatusValue);
+
         RuleFor(x => x.Description)
-            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.Description)))
-            .MinimumLength(DescriptionNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.Description), DescriptionNameMinLength))
-            .MaximumLength(DescriptionNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateTeamMemberDto.Description), DescriptionNameMaxLength))
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamMemberDto.Description)))
+            .MinimumLength(TeamMemberConstants.DescriptionNameMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateTeamMemberDto.Description),
+                TeamMemberConstants.DescriptionNameMinLength))
+            .MaximumLength(TeamMemberConstants.DescriptionNameMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateTeamMemberDto.Description),
+                TeamMemberConstants.DescriptionNameMaxLength))
             .When(x => x.Status == Status.Published);
+
         RuleFor(x => x.ImageId)
-            .NotNull().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.ImageId)))
-            .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateTeamMemberDto.ImageId)))
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamMemberDto.ImageId)))
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(CreateTeamMemberDto.ImageId)))
             .When(x => x.Status == Status.Published);
     }
-
-    public static int FullNameMinLength { get; } = 2;
-    public static int FullNameMaxLength { get; } = 100;
-    public static int DescriptionNameMinLength { get; } = 10;
-    public static int DescriptionNameMaxLength { get; } = 200;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/ReorderTeamMembersValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/ReorderTeamMembersValidator.cs
@@ -11,25 +11,28 @@ public class ReorderTeamMembersValidator : AbstractValidator<ReorderTeamMembersC
     {
         RuleFor(x => x.ReorderTeamMembersDto.CategoryId)
             .GreaterThan(0)
-            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(ReorderTeamMembersDto.CategoryId)));
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(ReorderTeamMembersDto.CategoryId)));
 
         RuleFor(x => x.ReorderTeamMembersDto.OrderedIds)
             .NotNull()
-            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(ReorderTeamMembersDto.OrderedIds)))
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(ReorderTeamMembersDto.OrderedIds)))
             .Must(ids => ids.Count > 0)
-            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(nameof(ReorderTeamMembersDto.OrderedIds)))
-            .Must(ids => ids.Count <= MaxTeamMemberIds)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(ReorderTeamMembersDto.OrderedIds)))
+            .Must(ids => ids.Count <= ReorderConstants.MaxElementsSwapCount)
             .WithMessage(ErrorMessagesConstants
-                .CollectionCannotContainMoreThan(nameof(ReorderTeamMembersDto.OrderedIds), MaxTeamMemberIds))
+                .CollectionCannotContainMoreThan(
+                nameof(ReorderTeamMembersDto.OrderedIds),
+                ReorderConstants.MaxElementsSwapCount))
             .Must(ids => ids.Distinct().Count() == ids.Count)
-            .WithMessage(ErrorMessagesConstants
-                .CollectionMustContainUniqueValues(nameof(ReorderTeamMembersDto.OrderedIds)));
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(ReorderTeamMembersDto.OrderedIds)));
 
         RuleForEach(x => x.ReorderTeamMembersDto.OrderedIds)
             .GreaterThan(0)
             .WithMessage(ErrorMessagesConstants
                 .PropertyMustBePositive($"Each {nameof(ReorderTeamMembersDto.OrderedIds)} element"));
     }
-
-    public static int MaxTeamMemberIds { get; } = 500;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/SearchTeamMemberValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/TeamMembers/SearchTeamMemberValidator.cs
@@ -10,13 +10,16 @@ public class SearchTeamMemberValidator : AbstractValidator<SearchTeamMemberQuery
     public SearchTeamMemberValidator()
     {
         RuleFor(x => x.SearchTeamMemberDto.FullName)
-            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(SearchTeamMemberDto.FullName)))
-            .MinimumLength(FullNameMinLength).WithMessage(ErrorMessagesConstants
-            .PropertyMustHaveAMinimumLengthOfNCharacters(nameof(SearchTeamMemberDto.FullName), FullNameMinLength))
-            .MaximumLength(FullNameMaxLength).WithMessage(ErrorMessagesConstants
-            .PropertyMustHaveAMaximumLengthOfNCharacters(nameof(SearchTeamMemberDto.FullName), FullNameMaxLength));
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(SearchTeamMemberDto.FullName)))
+            .MinimumLength(GlobalSearchConstants.DefaultSearchQueryMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(SearchTeamMemberDto.FullName),
+                GlobalSearchConstants.DefaultSearchQueryMinLength))
+            .MaximumLength(GlobalSearchConstants.DefaultSearchQueryMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(SearchTeamMemberDto.FullName),
+                GlobalSearchConstants.DefaultSearchQueryMaxLength));
     }
-
-    public static int FullNameMinLength { get; } = 2;
-    public static int FullNameMaxLength { get; } = 100;
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/FaqQuestions/Create/CreateQuestionTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/FaqQuestions/Create/CreateQuestionTests.cs
@@ -3,8 +3,8 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.FaqQuestions;
-using VictoryCenter.BLL.Validators.FaqQuestions;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
@@ -43,8 +43,8 @@ public class CreateQuestionTests : BaseTestClass
         var page = await Fixture.DbContext.VisitorPages.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
         var createFaqQuestionDto = new CreateFaqQuestionDto
         {
-            QuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMinLength + 1),
-            AnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength - 1),
+            QuestionText = new('Q', FaqConstants.QuestionTextMinLength + 1),
+            AnswerText = new('A', FaqConstants.AnswerTextMinLength - 1),
             Status = Status.Published,
             PageIds = [page.Id],
         };
@@ -60,8 +60,8 @@ public class CreateQuestionTests : BaseTestClass
     {
         var createFaqQuestionDto = new CreateFaqQuestionDto
         {
-            QuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMinLength + 1),
-            AnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength + 1),
+            QuestionText = new('Q', FaqConstants.QuestionTextMinLength + 1),
+            AnswerText = new('A', FaqConstants.AnswerTextMinLength + 1),
             Status = Status.Published,
             PageIds = [long.MaxValue],
         };

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/FaqQuestions/Update/UpdateFaqQuestionTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/FaqQuestions/Update/UpdateFaqQuestionTests.cs
@@ -2,8 +2,8 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.FaqQuestions;
-using VictoryCenter.BLL.Validators.FaqQuestions;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.IntegrationTests.Utils;
@@ -26,8 +26,8 @@ public class UpdateFaqQuestionTests : BaseTestClass
 
         var updateFaqQuestionDto = new UpdateFaqQuestionDto
         {
-            QuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMinLength + 1),
-            AnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength + 1),
+            QuestionText = new('Q', FaqConstants.QuestionTextMinLength + 1),
+            AnswerText = new('A', FaqConstants.AnswerTextMinLength + 1),
             PageIds = [3],
             Status = Status.Published,
         };
@@ -51,7 +51,7 @@ public class UpdateFaqQuestionTests : BaseTestClass
         var updateFaqQuestionDto = new UpdateFaqQuestionDto
         {
             QuestionText = "",
-            AnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength + 1),
+            AnswerText = new('A', FaqConstants.AnswerTextMinLength + 1),
             PageIds = [3],
             Status = Status.Published,
         };
@@ -69,8 +69,8 @@ public class UpdateFaqQuestionTests : BaseTestClass
     {
         var updateFaqQuestionDto = new UpdateFaqQuestionDto
         {
-            QuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMinLength + 1),
-            AnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength + 1),
+            QuestionText = new('Q', FaqConstants.QuestionTextMinLength + 1),
+            AnswerText = new('A', FaqConstants.AnswerTextMinLength + 1),
             PageIds = [3],
             Status = Status.Published,
         };

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/TeamMembers/Update/UpdateTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/TeamMembers/Update/UpdateTeamMemberTests.cs
@@ -2,8 +2,8 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
-using VictoryCenter.BLL.Validators.TeamMembers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.IntegrationTests.Utils;
@@ -21,7 +21,7 @@ public class UpdateTeamMemberTests : BaseTestClass
     [Fact]
     public async Task UpdateTeamMember_ValidRequest_ShouldUpdateTeamMember()
     {
-        var validDescription = new string('A', BaseTeamMembersValidator.DescriptionNameMinLength + 5);
+        var validDescription = new string('A', TeamMemberConstants.DescriptionNameMinLength + 5);
 
         TeamMember existingEntity = await Fixture.DbContext.TeamMembers
                                         .Include(tm => tm.TeamCategory)

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamMembers/UpdateTeamMemberTests.cs
@@ -95,7 +95,7 @@ public class UpdateTeamMemberTests
     [Fact]
     public async Task Handle_ValidRequestWithDifferentDescriptions_ShouldUpdateEntity()
     {
-        var validDescription = new string('A', BaseTeamMembersValidator.DescriptionNameMinLength + 5);
+        var validDescription = new string('A', TeamMemberConstants.DescriptionNameMinLength + 5);
 
         var testUpdatedTeamMemberDto = new TeamMemberDto
         {

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/FaqQuestions/BaseFaqQuestionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/FaqQuestions/BaseFaqQuestionValidatorTests.cs
@@ -7,14 +7,14 @@ namespace VictoryCenter.UnitTests.ValidatorsTests.FaqQuestions;
 
 public class BaseFaqQuestionValidatorTests
 {
-    private readonly string _validQuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMinLength + 1);
-    private readonly string _validAnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength + 1);
+    private readonly string _validQuestionText = new('Q', FaqConstants.QuestionTextMinLength + 1);
+    private readonly string _validAnswerText = new('A', FaqConstants.AnswerTextMinLength + 1);
 
-    private readonly string _tooShortQuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMinLength - 1);
-    private readonly string _tooLongQuestionText = new('Q', BaseFaqQuestionValidator.QuestionTextMaxLength + 1);
+    private readonly string _tooShortQuestionText = new('Q', FaqConstants.QuestionTextMinLength - 1);
+    private readonly string _tooLongQuestionText = new('Q', FaqConstants.QuestionTextMaxLength + 1);
 
-    private readonly string _tooShortAnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMinLength - 1);
-    private readonly string _tooLongAnswerText = new('A', BaseFaqQuestionValidator.AnswerTextMaxLength + 1);
+    private readonly string _tooShortAnswerText = new('A', FaqConstants.AnswerTextMinLength - 1);
+    private readonly string _tooLongAnswerText = new('A', FaqConstants.AnswerTextMaxLength + 1);
     private readonly BaseFaqQuestionValidator _validator;
 
     public BaseFaqQuestionValidatorTests()
@@ -37,7 +37,7 @@ public class BaseFaqQuestionValidatorTests
         var model = new CreateFaqQuestionDto { QuestionText = _tooShortQuestionText, AnswerText = _validAnswerText, };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.QuestionText)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), BaseFaqQuestionValidator.QuestionTextMinLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), FaqConstants.QuestionTextMinLength));
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class BaseFaqQuestionValidatorTests
         var model = new CreateFaqQuestionDto { QuestionText = _tooLongQuestionText, AnswerText = _validAnswerText, };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.QuestionText)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), BaseFaqQuestionValidator.QuestionTextMaxLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.QuestionText), FaqConstants.QuestionTextMaxLength));
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class BaseFaqQuestionValidatorTests
         var model = new CreateFaqQuestionDto { QuestionText = _validQuestionText, AnswerText = _tooShortAnswerText, };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.AnswerText)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), BaseFaqQuestionValidator.AnswerTextMinLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), FaqConstants.AnswerTextMinLength));
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class BaseFaqQuestionValidatorTests
         var model = new CreateFaqQuestionDto { QuestionText = _validQuestionText, AnswerText = _tooLongAnswerText, };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.AnswerText)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), BaseFaqQuestionValidator.AnswerTextMaxLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(CreateFaqQuestionDto.AnswerText), FaqConstants.AnswerTextMaxLength));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/FaqQuestions/ReorderFaqQuestionsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/FaqQuestions/ReorderFaqQuestionsValidatorTests.cs
@@ -93,7 +93,7 @@ public class ReorderFaqQuestionsValidatorTests
     [Fact]
     public void Validate_OrderedIdsExceedsMaxLimit_ShouldHaveError()
     {
-        var idsCount = ReorderFaqQuestionsValidator.MaxFaqQuestionIds + 1;
+        var idsCount = ReorderConstants.MaxElementsSwapCount + 1;
         var dto = new ReorderFaqQuestionsDto
         {
             PageId = 1,
@@ -103,7 +103,8 @@ public class ReorderFaqQuestionsValidatorTests
 
         var result = _validator.TestValidate(command);
         result.ShouldHaveValidationErrorFor(x => x.ReorderFaqQuestionsDto.OrderedIds)
-            .WithErrorMessage(ErrorMessagesConstants
-                .CollectionCannotContainMoreThan(nameof(ReorderFaqQuestionsDto.OrderedIds), ReorderFaqQuestionsValidator.MaxFaqQuestionIds));
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(ReorderFaqQuestionsDto.OrderedIds),
+                ReorderConstants.MaxElementsSwapCount));
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyPrograms/SearchHippotherapyProgramValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyPrograms/SearchHippotherapyProgramValidatorTests.cs
@@ -54,13 +54,13 @@ public class SearchHippotherapyProgramValidatorTests
 
         result.ShouldHaveValidationErrorFor(x => x.SearchHippotherapyProgramDto.SearchQuery)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(SearchHippotherapyProgramDto.SearchQuery), SearchHippotherapyProgramValidator.SearchQueryMinLength));
+                nameof(SearchHippotherapyProgramDto.SearchQuery), GlobalSearchConstants.DefaultSearchQueryMinLength));
     }
 
     [Fact]
     public void Validate_InvalidQuery_SearchQueryTooLongShouldHaveError()
     {
-        string searchQuery = new('A', SearchHippotherapyProgramValidator.SearchQueryMaxLength + 1);
+        string searchQuery = new('A', GlobalSearchConstants.DefaultSearchQueryMaxLength + 1);
         var dto = new SearchHippotherapyProgramDto
         {
             SearchQuery = searchQuery,
@@ -71,6 +71,6 @@ public class SearchHippotherapyProgramValidatorTests
 
         result.ShouldHaveValidationErrorFor(x => x.SearchHippotherapyProgramDto.SearchQuery)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(SearchHippotherapyProgramDto.SearchQuery), SearchHippotherapyProgramValidator.SearchQueryMaxLength));
+                nameof(SearchHippotherapyProgramDto.SearchQuery), GlobalSearchConstants.DefaultSearchQueryMaxLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
@@ -32,18 +32,18 @@ public class BaseTeamMembersValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.FullName)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
                 nameof(CreateTeamMemberDto.FullName),
-                BaseTeamMembersValidator.FullNameMinLength));
+                TeamMemberConstants.FullNameMinLength));
     }
 
     [Fact]
     public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameIsTooLong()
     {
-        var model = new CreateTeamMemberDto { FullName = new string('A', BaseTeamMembersValidator.FullNameMaxLength + 1), CategoryId = 1 };
+        var model = new CreateTeamMemberDto { FullName = new string('A', TeamMemberConstants.FullNameMaxLength + 1), CategoryId = 1 };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.FullName)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(CreateTeamMemberDto.FullName),
-                BaseTeamMembersValidator.FullNameMaxLength));
+                TeamMemberConstants.FullNameMaxLength));
     }
 
     [Fact]
@@ -90,14 +90,14 @@ public class BaseTeamMembersValidatorTests
         {
             FullName = "John Doe",
             CategoryId = 1,
-            Description = new string('A', BaseTeamMembersValidator.DescriptionNameMaxLength + 1),
+            Description = new string('A', TeamMemberConstants.DescriptionNameMaxLength + 1),
             Status = Status.Published
         };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(CreateTeamMemberDto.Description),
-                BaseTeamMembersValidator.DescriptionNameMaxLength));
+                TeamMemberConstants.DescriptionNameMaxLength));
     }
 
     [Fact]
@@ -112,7 +112,8 @@ public class BaseTeamMembersValidatorTests
         };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.Description)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.Description)));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamMemberDto.Description)));
     }
 
     [Fact]
@@ -123,7 +124,7 @@ public class BaseTeamMembersValidatorTests
             FullName = "Anna",
             CategoryId = 1,
             Status = Status.Draft,
-            Description = new string('A', BaseTeamMembersValidator.DescriptionNameMinLength + 5),
+            Description = new string('A', TeamMemberConstants.DescriptionNameMinLength + 1),
         };
 
         var result = _validator.TestValidate(model);
@@ -144,7 +145,8 @@ public class BaseTeamMembersValidatorTests
 
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.Description)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(CreateTeamMemberDto.Description), BaseTeamMembersValidator.DescriptionNameMinLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateTeamMemberDto.Description), TeamMemberConstants.DescriptionNameMinLength));
     }
 
     [Fact]
@@ -160,7 +162,8 @@ public class BaseTeamMembersValidatorTests
         };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.ImageId)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateTeamMemberDto.ImageId)));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateTeamMemberDto.ImageId)));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
@@ -18,10 +18,11 @@ public class BaseTeamMembersValidatorTests
     [Fact]
     public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameIsEmpty()
     {
-        var model = new CreateTeamMemberDto { FullName = "", CategoryId = 1 };
+        var model = new CreateTeamMemberDto { FullName = "ha-ha here is unex#p32324ected string -(X_X)-", CategoryId = 1 };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(x => x.FullName)
-            .WithErrorMessage("FullName must be in a valid format");
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(
+                nameof(CreateTeamMemberDto.FullName)));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/BaseTeamMemberValidatorTests.cs
@@ -16,7 +16,7 @@ public class BaseTeamMembersValidatorTests
     }
 
     [Fact]
-    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameIsEmpty()
+    public void BaseTeamMembersValidator_ShouldHaveError_WhenFullNameHasInvalidFormat()
     {
         var model = new CreateTeamMemberDto { FullName = "ha-ha here is unex#p32324ected string -(X_X)-", CategoryId = 1 };
         var result = _validator.TestValidate(model);

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/ReorderTeamMembersValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/ReorderTeamMembersValidatorTests.cs
@@ -1,5 +1,6 @@
 using FluentValidation.TestHelper;
 using VictoryCenter.BLL.Commands.Admin.TeamMembers.Reorder;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.TeamMembers;
 using VictoryCenter.BLL.Validators.TeamMembers;
 
@@ -100,7 +101,7 @@ public class ReorderTeamMembersValidatorTests
     [Fact]
     public void Validate_OrderedIdsExceedsMaxLimit_ShouldHaveError()
     {
-        var idsCount = 501;
+        var idsCount = ReorderConstants.MaxElementsSwapCount + 1;
         var dto = new ReorderTeamMembersDto
         {
             CategoryId = 1,

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/SearchTeamMemberValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/TeamMembers/SearchTeamMemberValidatorTests.cs
@@ -36,7 +36,8 @@ public class SearchTeamMemberValidatorTests
 
         var result = _validator.TestValidate(command);
         result.ShouldHaveValidationErrorFor(x => x.SearchTeamMemberDto.FullName)
-        .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(SearchTeamMemberDto.FullName)));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(SearchTeamMemberDto.FullName)));
     }
 
     [Fact]
@@ -50,13 +51,15 @@ public class SearchTeamMemberValidatorTests
 
         var result = _validator.TestValidate(command);
         result.ShouldHaveValidationErrorFor(x => x.SearchTeamMemberDto.FullName)
-        .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(SearchTeamMemberDto.FullName), 2));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(SearchTeamMemberDto.FullName),
+                GlobalSearchConstants.DefaultSearchQueryMinLength));
     }
 
     [Fact]
     public void Validate_InvalidQuery_FullNameTooLongShouldHaveError()
     {
-        string fullName = new('A', 101);
+        var fullName = new string('A', GlobalSearchConstants.DefaultSearchQueryMaxLength + 1);
         var dto = new SearchTeamMemberDto
         {
             FullName = fullName!,
@@ -65,6 +68,8 @@ public class SearchTeamMemberValidatorTests
 
         var result = _validator.TestValidate(command);
         result.ShouldHaveValidationErrorFor(x => x.SearchTeamMemberDto.FullName)
-        .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(SearchTeamMemberDto.FullName), 100));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(SearchTeamMemberDto.FullName),
+                GlobalSearchConstants.DefaultSearchQueryMaxLength));
     }
 }


### PR DESCRIPTION
dev
## JIRA

* [936](https://github.com/ita-social-projects/VictoryCenter-Back/issues/936)

## Summary of issue

At the moment some validation rules are in the validators and some are in the constants. This should be consistent, all validation rules must be in constant classes.

## Summary of change

Move all validation rules to  separate files

## Testing approach

- Unit testing
- Integration testing

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized validation constraints for FAQs, search queries, images, and team members.
  * Standardized image upload limits and allowed image types used by validators.
* **Refactor**
  * Validators and DTOs now use shared defaults for length and format checks.
  * Tests updated to reference the centralized constants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->