### PR TITLE
Fix/issue-927: Add Foreign Bank with Correspondent Bank

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Donate/ForeignBankDetails/CreateForeignBankDetailsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Donate/ForeignBankDetails/CreateForeignBankDetailsDto.cs
@@ -5,4 +5,6 @@ namespace VictoryCenter.BLL.DTOs.Admin.Donate.ForeignBankDetails;
 public record CreateForeignBankDetailsDto : BaseForeignBankDetailsDto
 {
     public BankCurrency Currency { get; set; }
+    public List<CreateForeignCorrespondentBankDetailsDto> CorrespondentBanks { get; set; } = [];
+
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Donate/ForeignBankDetails/CreateForeignCorrespondentBankDetailsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Donate/ForeignBankDetails/CreateForeignCorrespondentBankDetailsDto.cs
@@ -1,0 +1,6 @@
+using VictoryCenter.BLL.DTOs.Admin.Donate.CorrespondentBankDetails;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Donate.ForeignBankDetails;
+public record CreateForeignCorrespondentBankDetailsDto : BaseCorrespondentBankDetailsDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Donate/ForeignBankDetailsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Donate/ForeignBankDetailsProfile.cs
@@ -15,5 +15,6 @@ public class ForeignBankDetailsProfile : Profile
         CreateMap<UpdateForeignBankDetailsDto, ForeignBankDetails>()
             .ForMember(dest => dest.CorrespondentBanks, opt => opt.Ignore())
             .ForMember(dest => dest.Id, opt => opt.Ignore());
+        CreateMap<CreateForeignCorrespondentBankDetailsDto, CorrespondentBankDetails>();
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Donate/ForeignBankDetails/CreateForeignBankDetailsCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Donate/ForeignBankDetails/CreateForeignBankDetailsCommandValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.Donate.ForeignBankDetails.Create;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Validators.Donate.CorrespondentBankDetails;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.Validators.Donate.ForeignBankDetails;
@@ -15,5 +16,8 @@ public class CreateForeignBankDetailsCommandValidator : AbstractValidator<Create
         RuleFor(command => command.CreateForeignBankDetailsDto.Currency)
             .Must(currency => currency is BankCurrency.Usd or BankCurrency.Eur)
             .WithMessage(ForeignBankDetailsConstants.OnlyUsdOrEurMessage);
+
+        RuleForEach(command => command.CreateForeignBankDetailsDto.CorrespondentBanks)
+            .SetValidator(new BaseCorrespondentBankDetailsDtoValidator());
     }
 }


### PR DESCRIPTION
## Github ticker

* [Github](https://github.com/ita-social-projects/VictoryCenter-Back/issues/927)

* [Front](https://github.com/ita-social-projects/VictoryCenter-Client/pull/141)

## Summary of issue

CorrespondentBank entries were not being added together with the ForeignBank during creation.

## Summary of change

- Added validator
- Added mapping

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing multiple correspondent banks in foreign bank details configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->