### PR TITLE
Fix/issue-867: Fixed searching team member by last name not working

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/Search/SearchTeamMemberHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamMembers/Search/SearchTeamMemberHandler.cs
@@ -43,7 +43,7 @@ public class SearchTeamMemberHandler : IRequestHandler<SearchTeamMemberQuery, Re
             {
                 TermSelector = tm => tm.FullName.ToLower(),
                 TermValue = dto.FullName.ToLower(),
-                SearchLogic = SearchLogic.Prefix,
+                SearchLogic = SearchLogic.Contains,
             };
 
             var searchExpression = _searchService.CreateSearchExpression(searchTerm);

--- a/VictoryCenter/VictoryCenter.BLL/Services/Search/Helpers/SearchLogic.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Search/Helpers/SearchLogic.cs
@@ -16,4 +16,9 @@ public enum SearchLogic
     /// Matches values that start with the specific value
     /// </summary>
     Prefix,
+
+    /// <summary>
+    /// Matches values that contain the search term anywhere in the string
+    /// </summary>
+    Contains,
 }

--- a/VictoryCenter/VictoryCenter.BLL/Services/Search/SearchService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Search/SearchService.cs
@@ -36,6 +36,10 @@ public class SearchService<T> : ISearchService<T>
                                         member,
                                         typeof(string).GetMethod(nameof(string.StartsWith), [typeof(string)])!,
                                         constant),
+                SearchLogic.Contains => Expression.Call(
+                                        member,
+                                        typeof(string).GetMethod(nameof(string.Contains), [typeof(string)])!,
+                                        constant),
                 _ => throw new NotSupportedException($"Unsupported search logic: {term.SearchLogic}"),
             };
 


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/867)

## Description

This PR fixes the issue where searching a team member by last name did not work in the Admin panel.
The root cause was that the search logic used prefix (string.StartsWith) matching, which failed when the search value appeared not on the start of search request 

## How it looks

https://github.com/user-attachments/assets/d499668a-53b6-4485-b23b-766aee025f63

When entering partial last-name text in the search field on the Команда page, the system now displays the dropdown list of matching profiles instead of showing “Нічого не знайдено”

## Summary of change

1. Updated search configuration for team member last name to use contains-based matching
2. Added expression logic for SearchLogic.Contains

## How to recreate changes

1. Log in as an Admin.
2. Open the Команда page in the Admin panel.
3. Ensure a test profile exists (e.g., "Тестовий профіль").
4. Click the search field and type "про".
5. The dropdown must show profiles whose full name contains "про".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced team member search functionality with substring-based matching. Users can now search and locate team members using any portion of text within relevant fields, rather than matching only from the beginning of the field. This provides a more flexible, intuitive, and user-friendly search experience when browsing or managing team member information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->