### PR TITLE
Fix/issue 571 Fix null localizationInfo while creating team member localization

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -48,11 +48,18 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
         }
 
         entityLocalization.CreatedAt = DateTimeOffset.UtcNow;
-        var result = await _repositoryWrapper.GetRepository<TEntityLocalization>().CreateAsync(entityLocalization);
+        var createdEntity = await _repositoryWrapper.GetRepository<TEntityLocalization>().CreateAsync(entityLocalization);
 
         if (await _repositoryWrapper.SaveChangesAsync() > 0)
         {
-            return result;
+            var resultWithLanguage = await _repositoryWrapper.GetRepository<TEntityLocalization>()
+            .GetFirstOrDefaultAsync(new QueryOptions<TEntityLocalization>
+            {
+                Filter = l => l.EntityId == createdEntity.EntityId,
+                Include = l => l.Include(x => x.Language)
+            });
+
+            return resultWithLanguage!;
         }
 
         throw new InvalidOperationException();

--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -55,11 +55,16 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
             var resultWithLanguage = await _repositoryWrapper.GetRepository<TEntityLocalization>()
             .GetFirstOrDefaultAsync(new QueryOptions<TEntityLocalization>
             {
-                Filter = l => l.EntityId == createdEntity.EntityId,
+                Filter = l => l.EntityId == createdEntity.EntityId && l.LanguageId == createdEntity.LanguageId,
                 Include = l => l.Include(x => x.Language)
             });
 
-            return resultWithLanguage!;
+            if (resultWithLanguage is null)
+            {
+                throw new InvalidOperationException("Failed to retrieve created localization with language.");
+            }
+
+            return resultWithLanguage;
         }
 
         throw new InvalidOperationException();

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
@@ -46,7 +46,17 @@ public class LocalizationServiceTests
 
         var language = new LocalizationLanguage { Id = 1, Code = "en", Name = "English" };
 
-        SetupRepositoryWrapper(teamMember: _teamMember, localizationLanguage: language);
+        var createdLocalizationWithLanguage = new TeamMemberLocalization
+        {
+            EntityId = entityLocalization.EntityId,
+            LanguageId = entityLocalization.LanguageId,
+            FullName = entityLocalization.FullName,
+            Description = entityLocalization.Description,
+            Language = language,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        SetupRepositoryWrapper(teamMember: _teamMember, localizationLanguage: language, teamMemberLocalization: createdLocalizationWithLanguage);
 
         _repositoryWrapper.Setup(x => x.GetRepository<TeamMemberLocalization>()
                 .CreateAsync(It.IsAny<TeamMemberLocalization>()))
@@ -63,7 +73,10 @@ public class LocalizationServiceTests
         Assert.Equal(entityLocalization.LanguageId, result.LanguageId);
         Assert.Equal(entityLocalization.FullName, result.FullName);
         Assert.NotEqual(default, result.CreatedAt);
-        _repositoryWrapper.Verify(x => x.GetRepository<TeamMemberLocalization>().CreateAsync(It.Is<TeamMemberLocalization>(l => l == result)), Times.Once);
+        Assert.NotNull(result.Language);
+        Assert.Equal(language.Id, result.Language.Id);
+        Assert.Equal(language.Code, result.Language.Code);
+        _repositoryWrapper.Verify(x => x.GetRepository<TeamMemberLocalization>().CreateAsync(It.IsAny<TeamMemberLocalization>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
This solves the problem when after creating the localization, the backend returned localizationInfoDto = null because the Language navigation property was not loaded after CreateAsync, and AutoMapper did not have data for mapping. Because of this, the client received incomplete information about the translation language in the API response.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Localization creation now returns the record with full language metadata, improving multi-language consistency and preventing missing language info after save.
* **Tests**
  * Test coverage updated to validate the enriched localization result and its language details, ensuring safer behavior in localization flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->