### PR TITLE
Fix/issue 612 Fix null localizationInfo while updating team member localization

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -112,11 +112,23 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
 
         entityLocalization.TranslationStatus = TranslationStatus.Relevant;
 
-        _repositoryWrapper.GetRepository<TEntityLocalization>().Update(entityLocalization);
+        var updatedEntity = _repositoryWrapper.GetRepository<TEntityLocalization>().Update(entityLocalization);
 
         if (await _repositoryWrapper.SaveChangesAsync() > 0)
         {
-            return entityLocalization;
+            var resultWithLanguage = await _repositoryWrapper.GetRepository<TEntityLocalization>()
+                .GetFirstOrDefaultAsync(new QueryOptions<TEntityLocalization>
+                {
+                    Filter = l => l.EntityId == updatedEntity.Entity.EntityId && l.LanguageId == updatedEntity.Entity.LanguageId,
+                    Include = l => l.Include(x => x.Language)
+                });
+
+            if (resultWithLanguage is null)
+            {
+                throw new InvalidOperationException("Failed to retrieve created localization with language.");
+            }
+
+            return resultWithLanguage;
         }
 
         throw new InvalidOperationException();

--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -125,7 +125,7 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
 
             if (resultWithLanguage is null)
             {
-                throw new InvalidOperationException("Failed to retrieve created localization with language.");
+                throw new InvalidOperationException("Failed to retrieve updated localization with language.");
             }
 
             return resultWithLanguage;

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
@@ -159,6 +159,16 @@ public class LocalizationServiceTests
             CreatedAt = DateTimeOffset.UtcNow.AddDays(-1)
         };
 
+        var updatedLocalizationFromDb = new TeamMemberLocalization
+        {
+            EntityId = 1,
+            LanguageId = 1,
+            FullName = "New Localized Name",
+            Description = "New Localized Description",
+            TranslationStatus = TranslationStatus.Relevant,
+            Language = new LocalizationLanguage { Id = 1, Code = "en", Name = "English" }
+        };
+
         var newLocalization = new TeamMemberLocalization
         {
             EntityId = 1,
@@ -167,9 +177,12 @@ public class LocalizationServiceTests
             Description = "New Localized Description"
         };
 
-        SetupRepositoryWrapper(teamMemberLocalization: existingLocalization);
+        _repositoryWrapper
+            .SetupSequence(x => x.GetRepository<TeamMemberLocalization>()
+                .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<TeamMemberLocalization>>()))
+            .ReturnsAsync(existingLocalization)
+            .ReturnsAsync(updatedLocalizationFromDb);
 
-        // Update is a synchronous call on repository interface - ensure Save returns success
         _repositoryWrapper.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
 
         // Act
@@ -179,7 +192,13 @@ public class LocalizationServiceTests
         Assert.NotNull(result);
         Assert.Equal(TranslationStatus.Relevant, result.TranslationStatus);
         Assert.Equal(newLocalization.FullName, result.FullName);
-        _repositoryWrapper.Verify(x => x.GetRepository<TeamMemberLocalization>().Update(It.Is<TeamMemberLocalization>(l => l == newLocalization)), Times.Once);
+        Assert.NotNull(result.Language);
+        Assert.Equal("en", result.Language.Code);
+
+        _repositoryWrapper.Verify(
+            x => x.GetRepository<TeamMemberLocalization>()
+                .Update(It.Is<TeamMemberLocalization>(l => l == newLocalization)),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
This solves the problem when after updating the localization, the backend returned localizationInfoDto = null because the Language navigation property was not loaded after UpdateAsync, and AutoMapper did not have data for mapping. Because of this, the client received incomplete information about the translation language in the API response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure localization updates return fully populated entities including language details after saving, preventing incomplete data being returned to callers.

* **Tests**
  * Updated localization service tests to validate returned entities include complete language information and to cover the post-update retrieval and error handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->