### PR TITLE
Fix/issue 1135 - Fix null localization info when get published team members

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/TeamPage/GetPublished/GetPublishedTeamMembersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/TeamPage/GetPublished/GetPublishedTeamMembersHandler.cs
@@ -27,10 +27,16 @@ public class GetPublishedTeamMembersHandler : IRequestHandler<GetPublishedTeamMe
         var queryOptions = new QueryOptions<TeamCategory>
         {
             Filter = category => category.TeamMembers.Any(member => member.Status == Status.Published),
-            Include = categories => categories.Include(category => category.TeamMembers
+            Include = categories => categories
+                .Include(category => category.TeamMembers
                     .Where(member => member.Status == Status.Published)
                     .OrderBy(members => members.Priority))
-                .ThenInclude(member => member.Image!)
+                    .ThenInclude(member => member.Image!)
+                .Include(category => category.TeamMembers
+                    .Where(member => member.Status == Status.Published)
+                    .OrderBy(members => members.Priority))
+                    .ThenInclude(member => member.Localizations)
+                .ThenInclude(l => l.Language)
         };
 
         IEnumerable<TeamCategory> categoriesWithPublishedMembers =


### PR DESCRIPTION
dev

## After changes

<img width="893" height="829" alt="image" src="https://github.com/user-attachments/assets/f58d8fd1-3079-44ab-91de-0bfc7e6470c7" />


## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database queries for retrieving published team member information, including images and localization data, for improved performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->