### PR TITLE
Feature/issue-1132: Add support for section frames for single programs

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/HippotherapyProgramSectionConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/HippotherapyProgramSectionConstants.cs
@@ -16,6 +16,8 @@ public static class HippotherapyProgramSectionConstants
         (int Min, int Max) DescriptionCount,
         (int Min, int Max) DescriptionLength,
         (int Min, int Max) ImageCount,
+        (int Min, int Max) AuthorCount = default,
+        (int Min, int Max) AuthorLength = default,
         GroupingConfig? Grouping = null
     );
 
@@ -119,6 +121,22 @@ public static class HippotherapyProgramSectionConstants
             DescriptionLength: (10, 300),
             ImageCount: (0, 0)
         ),
+        [ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 50),
+            DescriptionCount: (1, 5),
+            DescriptionLength: (10, 100),
+            ImageCount: (0, 0),
+            AuthorCount: (1, 5),
+            AuthorLength: (2, 50),
+            Grouping: new GroupingConfig(
+                GroupCount: (1, 5),
+                PerGroupCounts: new Dictionary<ContentType, (int Min, int Max)>
+                {
+                    [ContentType.Description] = (1, 1),
+                    [ContentType.Author] = (1, 1)
+                })
+        ),
     };
     public static TemplateRequirementsConfig GetRequirements(ProgramSectionTemplate template)
         => TemplateRequirements[template];
@@ -140,6 +158,12 @@ public static class HippotherapyProgramSectionConstants
 
     public static string GetDescriptionLengthErrorMessage(CreateHippotherapyProgramSectionDto section)
         => GetLengthErrorMessage(GetRequirements(section.Template).DescriptionLength, "description");
+
+    public static string GetAuthorsCountErrorMessage(CreateHippotherapyProgramSectionDto section)
+        => GetCountErrorMessage(section, ContentType.Author, GetRequirements(section.Template).AuthorCount, "author(s)");
+
+    public static string GetAuthorLengthErrorMessage(CreateHippotherapyProgramSectionDto section)
+        => GetLengthErrorMessage(GetRequirements(section.Template).AuthorLength, "author");
 
     public static string GetGroupIndexRequiredErrorMessage(CreateHippotherapyProgramSectionDto section)
         => $"Template {section.Template} requires GroupIndex for grouped content";

--- a/VictoryCenter/VictoryCenter.BLL/Constants/HippotherapyProgramSectionConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/HippotherapyProgramSectionConstants.cs
@@ -5,98 +5,165 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class HippotherapyProgramSectionConstants
 {
+    public sealed record GroupingConfig(
+        (int Min, int Max) GroupCount,
+        IReadOnlyDictionary<ContentType, (int Min, int Max)> PerGroupCounts
+    );
+
     public sealed record TemplateRequirementsConfig(
         (int Min, int Max) TitleCount,
         (int Min, int Max) TitleLength,
         (int Min, int Max) DescriptionCount,
         (int Min, int Max) DescriptionLength,
-        (int Min, int Max) ImageCount
+        (int Min, int Max) ImageCount,
+        GroupingConfig? Grouping = null
     );
 
-    private static readonly Dictionary<ProgramSectionTemplate, TemplateRequirementsConfig>
-        TemplateRequirements = new()
-        {
-            [ProgramSectionTemplate.QuadImagesBottom] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (4, 4)
-            ),
-            [ProgramSectionTemplate.DualImagesBottom] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (2, 2)
-            ),
-            [ProgramSectionTemplate.TextOnly] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (0, 0)
-            ),
-            [ProgramSectionTemplate.TripleImagesBottom] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (3, 3)
-            ),
-            [ProgramSectionTemplate.SingleImageBottom] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (1, 1)
-            ),
-            [ProgramSectionTemplate.SingleImageTop] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (1, 1)
-            ),
-            [ProgramSectionTemplate.SingleImageRight] = new(
-                TitleCount: (1, 1),
-                TitleLength: (5, 60),
-                DescriptionCount: (1, 1),
-                DescriptionLength: (10, 600),
-                ImageCount: (1, 1)
-            )
-        };
-
+    private static readonly Dictionary<ProgramSectionTemplate, TemplateRequirementsConfig> TemplateRequirements = new()
+    {
+        [ProgramSectionTemplate.QuadImagesBottom] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (4, 4)
+        ),
+        [ProgramSectionTemplate.DualImagesBottom] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (2, 2)
+        ),
+        [ProgramSectionTemplate.TextOnly] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (0, 0)
+        ),
+        [ProgramSectionTemplate.TripleImagesBottom] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (3, 3)
+        ),
+        [ProgramSectionTemplate.SingleImageBottom] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (1, 1)
+        ),
+        [ProgramSectionTemplate.SingleImageTop] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (1, 1)
+        ),
+        [ProgramSectionTemplate.SingleImageRight] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (1, 1),
+            DescriptionLength: (10, 600),
+            ImageCount: (1, 1)
+        ),
+        [ProgramSectionTemplate.DualTitleDescriptionPairs] = new(
+            TitleCount: (2, 2),
+            TitleLength: (5, 60),
+            DescriptionCount: (2, 2),
+            DescriptionLength: (10, 300),
+            ImageCount: (0, 0),
+            Grouping: new GroupingConfig(
+                GroupCount: (2, 2),
+                PerGroupCounts: new Dictionary<ContentType, (int Min, int Max)>
+                {
+                    [ContentType.Title] = (1, 1),
+                    [ContentType.Description] = (1, 1)
+                })
+        ),
+        [ProgramSectionTemplate.TripleTitleDescriptionPairs] = new(
+            TitleCount: (3, 3),
+            TitleLength: (5, 60),
+            DescriptionCount: (3, 3),
+            DescriptionLength: (10, 300),
+            ImageCount: (0, 0),
+            Grouping: new GroupingConfig(
+                GroupCount: (3, 3),
+                PerGroupCounts: new Dictionary<ContentType, (int Min, int Max)>
+                {
+                    [ContentType.Title] = (1, 1),
+                    [ContentType.Description] = (1, 1)
+                })
+        ),
+        [ProgramSectionTemplate.QuadTitleDescriptionPairs] = new(
+            TitleCount: (4, 4),
+            TitleLength: (5, 60),
+            DescriptionCount: (4, 4),
+            DescriptionLength: (10, 300),
+            ImageCount: (0, 0),
+            Grouping: new GroupingConfig(
+                GroupCount: (4, 4),
+                PerGroupCounts: new Dictionary<ContentType, (int Min, int Max)>
+                {
+                    [ContentType.Title] = (1, 1),
+                    [ContentType.Description] = (1, 1)
+                })
+        ),
+        [ProgramSectionTemplate.SingleTitleQuintupleDescription] = new(
+            TitleCount: (1, 1),
+            TitleLength: (5, 60),
+            DescriptionCount: (5, 5),
+            DescriptionLength: (10, 300),
+            ImageCount: (0, 0)
+        ),
+    };
     public static TemplateRequirementsConfig GetRequirements(ProgramSectionTemplate template)
         => TemplateRequirements[template];
 
+    public static string GetGroupCompositionErrorMessage(CreateHippotherapyProgramSectionDto section)
+        => $"Template {section.Template} has invalid group composition";
+
     public static string GetTitlesCountErrorMessage(CreateHippotherapyProgramSectionDto section)
-    {
-        var req = GetRequirements(section.Template);
-        return $"Template {section.Template} requires exactly {req.TitleCount.Min} title(s), but received {section.Titles?.Count ?? 0}";
-    }
+        => GetCountErrorMessage(section, ContentType.Title, GetRequirements(section.Template).TitleCount, "title(s)");
 
     public static string GetDescriptionsCountErrorMessage(CreateHippotherapyProgramSectionDto section)
-    {
-        var req = GetRequirements(section.Template);
-        return $"Template {section.Template} requires exactly {req.DescriptionCount.Min} description(s), but received {section.Descriptions?.Count ?? 0}";
-    }
+        => GetCountErrorMessage(section, ContentType.Description, GetRequirements(section.Template).DescriptionCount, "description(s)");
 
     public static string GetImagesCountErrorMessage(CreateHippotherapyProgramSectionDto section)
-    {
-        var req = GetRequirements(section.Template);
-        return $"Template {section.Template} requires exactly {req.ImageCount.Min} image(s), but received {section.ImageIds?.Count ?? 0}";
-    }
+        => GetCountErrorMessage(section, ContentType.Image, GetRequirements(section.Template).ImageCount, "image(s)");
 
     public static string GetTitleLengthErrorMessage(CreateHippotherapyProgramSectionDto section)
-    {
-        var req = GetRequirements(section.Template);
-        return $"Each title must be between {req.TitleLength.Min} and {req.TitleLength.Max} characters";
-    }
+        => GetLengthErrorMessage(GetRequirements(section.Template).TitleLength, "title");
 
     public static string GetDescriptionLengthErrorMessage(CreateHippotherapyProgramSectionDto section)
+        => GetLengthErrorMessage(GetRequirements(section.Template).DescriptionLength, "description");
+
+    public static string GetGroupIndexRequiredErrorMessage(CreateHippotherapyProgramSectionDto section)
+        => $"Template {section.Template} requires GroupIndex for grouped content";
+
+    public static string GetGroupCountErrorMessage(CreateHippotherapyProgramSectionDto section, int actual)
     {
-        var req = GetRequirements(section.Template);
-        return $"Each description must be between {req.DescriptionLength.Min} and {req.DescriptionLength.Max} characters";
+        var req = GetRequirements(section.Template).Grouping!;
+
+        return $"Template {section.Template} requires between {req.GroupCount.Min} and {req.GroupCount.Max} group(s), but received {actual}";
     }
+
+    private static int CountByType(CreateHippotherapyProgramSectionDto section, ContentType type)
+        => (section.Contents ?? []).Count(c => c.ContentType == type);
+
+    private static string GetCountErrorMessage(
+        CreateHippotherapyProgramSectionDto section,
+        ContentType type,
+        (int Min, int Max) req,
+        string label)
+    {
+        var actual = CountByType(section, type);
+        return $"Template {section.Template} requires between {req.Min} and {req.Max} {label}, but received {actual}";
+    }
+
+    private static string GetLengthErrorMessage((int Min, int Max) req, string label)
+        => $"Each {label} must be between {req.Min} and {req.Max} characters";
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateHippotherapyProgramSectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateHippotherapyProgramSectionDto.cs
@@ -8,5 +8,5 @@ public record CreateHippotherapyProgramSectionDto
 
     public int Order { get; set; }
 
-    public List<CreateProgramSectionContentDto> Contents { get; set; } = [];
+    public List<CreateProgramSectionContentDto>? Contents { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateHippotherapyProgramSectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateHippotherapyProgramSectionDto.cs
@@ -5,8 +5,8 @@ namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 public record CreateHippotherapyProgramSectionDto
 {
     public ProgramSectionTemplate Template { get; set; }
+
     public int Order { get; set; }
-    public List<string> Titles { get; set; } = [];
-    public List<string> Descriptions { get; set; } = [];
-    public List<long> ImageIds { get; set; } = [];
+
+    public List<CreateProgramSectionContentDto> Contents { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
@@ -1,15 +1,18 @@
-using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 
-public record HippotherapyProgramSectionContentDto
+public record CreateProgramSectionContentDto
 {
-    public long Id { get; init; }
     public ContentType ContentType { get; init; }
+
     public int Order { get; init; }
+
     public int? GroupIndex { get; init; }
+
     public string? Title { get; init; }
+
     public string? Description { get; init; }
-    public ImageDto? Image { get; init; }
+
+    public long? ImageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
@@ -15,4 +15,6 @@ public record CreateProgramSectionContentDto
     public string? Description { get; init; }
 
     public long? ImageId { get; init; }
+
+    public string? Author { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/HippotherapyProgramSectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/HippotherapyProgramSectionContentDto.cs
@@ -12,4 +12,5 @@ public record HippotherapyProgramSectionContentDto
     public string? Title { get; init; }
     public string? Description { get; init; }
     public ImageDto? Image { get; init; }
+    public string? Author { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
@@ -37,91 +37,76 @@ public static class HippotherapyProgramSectionsBuilder
         CreateHippotherapyProgramSectionDto sectionDto,
         IReadOnlyDictionary<long, Image> imagesById)
     {
-        var contents = new List<ProgramSectionContent>(GetCapacity(sectionDto));
-        var order = 0;
-
-        AddTitles(contents, sectionDto.Titles, ref order);
-        AddDescriptions(contents, sectionDto.Descriptions, ref order);
-        AddImages(contents, sectionDto.ImageIds, imagesById, ref order);
-
-        return contents;
-    }
-
-    private static int GetCapacity(CreateHippotherapyProgramSectionDto sectionDto)
-    {
-        return
-            (sectionDto.Titles?.Count ?? 0) +
-            (sectionDto.Descriptions?.Count ?? 0) +
-            (sectionDto.ImageIds?.Count ?? 0);
-    }
-
-    private static void AddTitles(
-        List<ProgramSectionContent> contents,
-        List<string>? titles,
-        ref int order)
-    {
-        if (titles is null || titles.Count == 0)
+        var dtoContents = sectionDto.Contents ?? [];
+        if (dtoContents.Count == 0)
         {
-            return;
+            return [];
         }
 
-        foreach (var title in titles)
-        {
-            contents.Add(new TitleProgramContent
-            {
-                ContentType = ContentType.Title,
-                Order = order++,
-                Title = title.Trim()
-            });
-        }
-    }
+        var contents = new List<ProgramSectionContent>(dtoContents.Count);
 
-    private static void AddDescriptions(
-        List<ProgramSectionContent> contents,
-        List<string>? descriptions,
-        ref int order)
-    {
-        if (descriptions is null || descriptions.Count == 0)
+        foreach (var dto in dtoContents.OrderBy(x => x.Order))
         {
-            return;
-        }
-
-        foreach (var description in descriptions)
-        {
-            contents.Add(new DescriptionProgramContent
-            {
-                ContentType = ContentType.Description,
-                Order = order++,
-                Description = description.Trim()
-            });
-        }
-    }
-
-    private static void AddImages(
-        List<ProgramSectionContent> contents,
-        List<long>? imageIds,
-        IReadOnlyDictionary<long, Image> imagesById,
-        ref int order)
-    {
-        if (imageIds is null || imageIds.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var imageId in imageIds)
-        {
-            if (!imagesById.TryGetValue(imageId, out var image))
+            var entity = CreateContent(dto, imagesById);
+            if (entity is null)
             {
                 continue;
             }
 
-            contents.Add(new ImageProgramContent
+            contents.Add(entity);
+        }
+
+        return contents;
+    }
+
+    private static ProgramSectionContent? CreateContent(
+        CreateProgramSectionContentDto dto,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        if (dto.ContentType == ContentType.Title)
+        {
+            return new TitleProgramContent
+            {
+                ContentType = ContentType.Title,
+                Order = dto.Order,
+                GroupIndex = dto.GroupIndex,
+                Title = dto.Title!.Trim()
+            };
+        }
+
+        if (dto.ContentType == ContentType.Description)
+        {
+            return new DescriptionProgramContent
+            {
+                ContentType = ContentType.Description,
+                Order = dto.Order,
+                GroupIndex = dto.GroupIndex,
+                Description = dto.Description!.Trim()
+            };
+        }
+
+        if (dto.ContentType == ContentType.Image)
+        {
+            if (dto.ImageId is null or <= 0)
+            {
+                return null;
+            }
+
+            if (!imagesById.TryGetValue(dto.ImageId.Value, out var image))
+            {
+                return null;
+            }
+
+            return new ImageProgramContent
             {
                 ContentType = ContentType.Image,
-                Order = order++,
-                ImageId = imageId,
+                Order = dto.Order,
+                GroupIndex = dto.GroupIndex,
+                ImageId = dto.ImageId.Value,
                 Image = image
-            });
+            };
         }
+
+        return null;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
@@ -107,6 +107,17 @@ public static class HippotherapyProgramSectionsBuilder
             };
         }
 
+        if (dto.ContentType == ContentType.Author)
+        {
+            return new AuthorProgramContent
+            {
+                ContentType = ContentType.Author,
+                Order = dto.Order,
+                GroupIndex = dto.GroupIndex,
+                Name = dto.Author!.Trim()
+            };
+        }
+
         return null;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ImageValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ImageValidationHelper.cs
@@ -3,6 +3,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -100,7 +101,9 @@ public static class ImageValidationHelper
         IRepositoryWrapper repositoryWrapper, List<CreateHippotherapyProgramSectionDto>? sections)
     {
         var sectionImageIds = (sections ?? [])
-            .SelectMany(s => s.ImageIds ?? []);
+            .SelectMany(s => s.Contents ?? [])
+            .Where(c => c.ContentType == ContentType.Image && c.ImageId.HasValue)
+            .Select(c => c.ImageId!.Value);
 
         return ValidateAndGetImagesByIdsAsync(repositoryWrapper, sectionImageIds);
     }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/HippotherapyProgramSections/HippotherapyProgramSectionsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/HippotherapyProgramSections/HippotherapyProgramSectionsProfile.cs
@@ -14,18 +14,28 @@ public class HippotherapyProgramSectionsProfile : Profile
         CreateMap<ProgramSectionContent, HippotherapyProgramSectionContentDto>()
             .Include<TitleProgramContent, HippotherapyProgramSectionContentDto>()
             .Include<DescriptionProgramContent, HippotherapyProgramSectionContentDto>()
-            .Include<ImageProgramContent, HippotherapyProgramSectionContentDto>();
+            .Include<ImageProgramContent, HippotherapyProgramSectionContentDto>()
+            .Include<AuthorProgramContent, HippotherapyProgramSectionContentDto>();
 
         CreateMap<TitleProgramContent, HippotherapyProgramSectionContentDto>()
             .ForMember(d => d.Description, opt => opt.Ignore())
-            .ForMember(d => d.Image, opt => opt.Ignore());
+            .ForMember(d => d.Image, opt => opt.Ignore())
+            .ForMember(d => d.Author, opt => opt.Ignore());
 
         CreateMap<DescriptionProgramContent, HippotherapyProgramSectionContentDto>()
             .ForMember(d => d.Title, opt => opt.Ignore())
-            .ForMember(d => d.Image, opt => opt.Ignore());
+            .ForMember(d => d.Image, opt => opt.Ignore())
+            .ForMember(d => d.Author, opt => opt.Ignore());
 
         CreateMap<ImageProgramContent, HippotherapyProgramSectionContentDto>()
             .ForMember(d => d.Title, opt => opt.Ignore())
-            .ForMember(d => d.Description, opt => opt.Ignore());
+            .ForMember(d => d.Description, opt => opt.Ignore())
+            .ForMember(d => d.Author, opt => opt.Ignore());
+
+        CreateMap<AuthorProgramContent, HippotherapyProgramSectionContentDto>()
+            .ForMember(d => d.Author, opt => opt.MapFrom(s => s.Name))
+            .ForMember(d => d.Title, opt => opt.Ignore())
+            .ForMember(d => d.Description, opt => opt.Ignore())
+            .ForMember(d => d.Image, opt => opt.Ignore());
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
@@ -1,103 +1,233 @@
 using FluentValidation;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.Validators.HippotherapyProgramSections;
 
-public class BaseHippotherapyProgramSectionValidator
-    : AbstractValidator<CreateHippotherapyProgramSectionDto>
+public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateHippotherapyProgramSectionDto>
 {
     public BaseHippotherapyProgramSectionValidator()
     {
         RuleFor(x => x.Template)
             .IsInEnum()
-            .WithMessage(ErrorMessagesConstants.PropertyMustBeValidEnum(
-                nameof(CreateHippotherapyProgramSectionDto.Template)))
-            .DependentRules(() =>
-            {
-                RuleFor(x => x.Order)
-                    .GreaterThanOrEqualTo(0)
-                    .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan(
-                        nameof(CreateHippotherapyProgramSectionDto.Order), -1));
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(CreateHippotherapyProgramSectionDto.Template)));
 
-                RuleFor(x => x.Titles)
-                    .Must(HasValidTitlesCount)
-                    .WithMessage(HippotherapyProgramSectionConstants.GetTitlesCountErrorMessage)
-                    .DependentRules(() =>
-                    {
-                        RuleForEach(x => x.Titles)
-                            .NotEmpty()
-                            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
-                                nameof(CreateHippotherapyProgramSectionDto.Titles)))
-                            .Must(HasValidTitleLength)
-                            .WithMessage(HippotherapyProgramSectionConstants.GetTitleLengthErrorMessage);
-                    });
+        RuleFor(x => x.Order)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan(nameof(CreateHippotherapyProgramSectionDto.Order), -1));
 
-                RuleFor(x => x.Descriptions)
-                    .Must(HasValidDescriptionsCount)
-                    .WithMessage(HippotherapyProgramSectionConstants.GetDescriptionsCountErrorMessage)
-                    .DependentRules(() =>
-                    {
-                        RuleForEach(x => x.Descriptions)
-                            .NotEmpty()
-                            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
-                                nameof(CreateHippotherapyProgramSectionDto.Descriptions)))
-                            .Must(HasValidDescriptionLength)
-                            .WithMessage(HippotherapyProgramSectionConstants.GetDescriptionLengthErrorMessage);
-                    });
+        RuleFor(x => x.Contents)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateHippotherapyProgramSectionDto.Contents)));
 
-                RuleFor(x => x.ImageIds)
-                    .Must(HasValidImagesCount)
-                    .WithMessage(HippotherapyProgramSectionConstants.GetImagesCountErrorMessage)
-                    .Must(imageIds => imageIds is null || imageIds.Distinct().Count() == imageIds.Count)
-                    .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
-                        nameof(CreateHippotherapyProgramSectionDto.ImageIds)))
-                    .DependentRules(() =>
-                    {
-                        RuleForEach(x => x.ImageIds)
-                            .GreaterThan(0)
-                            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
-                                nameof(CreateHippotherapyProgramSectionDto.ImageIds)));
-                    });
-            });
+        RuleFor(x => x).Custom(ValidateSection);
     }
 
-    private static HippotherapyProgramSectionConstants.TemplateRequirementsConfig GetReq(CreateHippotherapyProgramSectionDto section) =>
-        HippotherapyProgramSectionConstants.GetRequirements(section.Template);
-
-    private static bool HasValidTitlesCount(CreateHippotherapyProgramSectionDto section, ICollection<string>? titles) =>
-        HasValidCount(titles, GetReq(section).TitleCount);
-
-    private static bool HasValidDescriptionsCount(CreateHippotherapyProgramSectionDto section, ICollection<string>? descriptions) =>
-        HasValidCount(descriptions, GetReq(section).DescriptionCount);
-
-    private static bool HasValidImagesCount(CreateHippotherapyProgramSectionDto section, ICollection<long>? imageIds) =>
-        HasValidCount(imageIds, GetReq(section).ImageCount);
-
-    private static bool HasValidTitleLength(CreateHippotherapyProgramSectionDto section, string? title) =>
-        HasValidLength(title, GetReq(section).TitleLength);
-
-    private static bool HasValidDescriptionLength(CreateHippotherapyProgramSectionDto section, string? description) =>
-        HasValidLength(description, GetReq(section).DescriptionLength);
-
-    private static bool HasValidCount<T>(ICollection<T>? collection, (int Min, int Max) req)
+    private static void ValidateSection(
+        CreateHippotherapyProgramSectionDto section,
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx)
     {
-        var count = collection?.Count ?? 0;
-        if (req.Min == 0 && req.Max == 0)
+        if (!Enum.IsDefined(section.Template))
         {
-            return count == 0;
+            return;
         }
 
-        return collection is not null
-               && count >= req.Min
-               && count <= req.Max;
+        var contents = section.Contents;
+
+        var req = HippotherapyProgramSectionConstants.GetRequirements(section.Template);
+        var prop = nameof(CreateHippotherapyProgramSectionDto.Contents);
+
+        ValidateCounts(section, ctx, contents, req, prop);
+        ValidateUniqueness(ctx, contents, prop);
+        ValidateBasicValues(ctx, contents, prop);
+        ValidateTitles(section, ctx, contents, req, prop);
+        ValidateDescriptions(section, ctx, contents, req, prop);
+        ValidateImages(ctx, contents, prop);
+        ValidateGrouping(section, ctx, contents, req, prop);
     }
 
-    private static bool HasValidLength(string? text, (int Min, int Max) lengthRequirements)
+    private static void ValidateCounts(
+        CreateHippotherapyProgramSectionDto section,
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        string prop)
     {
-        var trimmed = text?.Trim();
-        return !string.IsNullOrEmpty(trimmed)
-               && trimmed.Length >= lengthRequirements.Min
-               && trimmed.Length <= lengthRequirements.Max;
+        if (!InRange(CountByType(contents, ContentType.Title), req.TitleCount))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetTitlesCountErrorMessage(section));
+        }
+
+        if (!InRange(CountByType(contents, ContentType.Description), req.DescriptionCount))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetDescriptionsCountErrorMessage(section));
+        }
+
+        if (!InRange(CountByType(contents, ContentType.Image), req.ImageCount))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetImagesCountErrorMessage(section));
+        }
+    }
+
+    private static void ValidateUniqueness(
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        string prop)
+    {
+        if (!HasUniqueOrders(contents))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateProgramSectionContentDto.Order)));
+        }
+
+        if (!HasUniqueImageIds(contents))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateProgramSectionContentDto.ImageId)));
+        }
+    }
+
+    private static void ValidateBasicValues(
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        string prop)
+    {
+        if (contents.Any(c => !Enum.IsDefined(c.ContentType)))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(CreateProgramSectionContentDto.ContentType)));
+        }
+
+        if (contents.Any(c => c.Order < 0))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyMustBeGreaterThan(nameof(CreateProgramSectionContentDto.Order), -1));
+        }
+
+        if (contents.Any(c => c.GroupIndex is < 0))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyMustBeGreaterThan(nameof(CreateProgramSectionContentDto.GroupIndex), -1));
+        }
+    }
+
+    private static void ValidateTitles(
+        CreateHippotherapyProgramSectionDto section,
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        string prop)
+    {
+        var titles = contents.Where(c => c.ContentType == ContentType.Title).ToList();
+
+        if (titles.Any(c => string.IsNullOrWhiteSpace(c.Title)))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Title)));
+        }
+
+        if (titles.Any(c => !HasValidLength(c.Title, req.TitleLength)))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetTitleLengthErrorMessage(section));
+        }
+    }
+
+    private static void ValidateDescriptions(
+        CreateHippotherapyProgramSectionDto section,
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        string prop)
+    {
+        var descriptions = contents.Where(c => c.ContentType == ContentType.Description).ToList();
+
+        if (descriptions.Any(c => string.IsNullOrWhiteSpace(c.Description)))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Description)));
+        }
+
+        if (descriptions.Any(c => !HasValidLength(c.Description, req.DescriptionLength)))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetDescriptionLengthErrorMessage(section));
+        }
+    }
+
+    private static void ValidateImages(
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        string prop)
+    {
+        var images = contents.Where(c => c.ContentType == ContentType.Image).ToList();
+
+        if (images.Any(c => c.ImageId is null or <= 0))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateProgramSectionContentDto.ImageId)));
+        }
+    }
+
+    private static void ValidateGrouping(
+        CreateHippotherapyProgramSectionDto section,
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        string prop)
+    {
+        var grouping = req.Grouping;
+        if (grouping is null)
+        {
+            return;
+        }
+
+        var grouped = contents.Where(c => grouping.PerGroupCounts.ContainsKey(c.ContentType)).ToList();
+
+        if (grouped.Any(c => c.GroupIndex is null))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetGroupIndexRequiredErrorMessage(section));
+            return;
+        }
+
+        var groups = grouped.GroupBy(c => c.GroupIndex!.Value).ToList();
+
+        if (!InRange(groups.Count, grouping.GroupCount))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetGroupCountErrorMessage(section, groups.Count));
+            return;
+        }
+
+        if (!GroupsMatchComposition(groups, grouping))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetGroupCompositionErrorMessage(section));
+        }
+    }
+
+    private static int CountByType(
+        List<CreateProgramSectionContentDto> contents,
+        ContentType type)
+        => contents.Count(c => c.ContentType == type);
+
+    private static bool HasUniqueOrders(List<CreateProgramSectionContentDto> contents)
+        => contents.Select(c => c.Order).Distinct().Count() == contents.Count;
+
+    private static bool HasUniqueImageIds(List<CreateProgramSectionContentDto> contents)
+    {
+        var ids = contents
+            .Where(c => c.ContentType == ContentType.Image && c.ImageId.HasValue)
+            .Select(c => c.ImageId!.Value)
+            .ToList();
+
+        return ids.Distinct().Count() == ids.Count;
+    }
+
+    private static bool GroupsMatchComposition(
+        List<IGrouping<int, CreateProgramSectionContentDto>> groups,
+        HippotherapyProgramSectionConstants.GroupingConfig grouping)
+    {
+        return !groups.Any(g =>
+            grouping.PerGroupCounts.Any(rule =>
+                !InRange(g.Count(x => x.ContentType == rule.Key), rule.Value)));
+    }
+
+    private static bool InRange(int actual, (int Min, int Max) req)
+        => (req.Min == 0 && req.Max == 0) ? actual == 0 : actual >= req.Min && actual <= req.Max;
+
+    private static bool HasValidLength(string? text, (int Min, int Max) req)
+    {
+        var t = text?.Trim();
+        return !string.IsNullOrEmpty(t) && t.Length >= req.Min && t.Length <= req.Max;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
@@ -44,6 +44,7 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
         ValidateTitles(section, ctx, contents, req, prop);
         ValidateDescriptions(section, ctx, contents, req, prop);
         ValidateImages(ctx, contents, prop);
+        ValidateAuthors(section, ctx, contents, req, prop);
         ValidateGrouping(section, ctx, contents, req, prop);
     }
 
@@ -67,6 +68,11 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
         if (!InRange(CountByType(contents, ContentType.Image), req.ImageCount))
         {
             ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetImagesCountErrorMessage(section));
+        }
+
+        if (!InRange(CountByType(contents, ContentType.Author), req.AuthorCount))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetAuthorsCountErrorMessage(section));
         }
     }
 
@@ -157,6 +163,36 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
         if (images.Any(c => c.ImageId is null or <= 0))
         {
             ctx.AddFailure(prop, ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateProgramSectionContentDto.ImageId)));
+        }
+    }
+
+    private static void ValidateAuthors(
+        CreateHippotherapyProgramSectionDto section,
+        ValidationContext<CreateHippotherapyProgramSectionDto> ctx,
+        List<CreateProgramSectionContentDto> contents,
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        string prop)
+    {
+        if (req.AuthorCount.Min == 0 && req.AuthorCount.Max == 0)
+        {
+            return;
+        }
+
+        var authors = contents.Where(c => c.ContentType == ContentType.Author).ToList();
+
+        if (authors.Count == 0)
+        {
+            return;
+        }
+
+        if (authors.Any(c => string.IsNullOrWhiteSpace(c.Author)))
+        {
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Author)));
+        }
+
+        if (authors.Any(c => !HasValidLength(c.Author, req.AuthorLength)))
+        {
+            ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetAuthorLengthErrorMessage(section));
         }
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
@@ -28,6 +28,11 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
         CreateHippotherapyProgramSectionDto section,
         ValidationContext<CreateHippotherapyProgramSectionDto> ctx)
     {
+        if (section.Contents is null)
+        {
+            return;
+        }
+
         if (!Enum.IsDefined(section.Template))
         {
             return;
@@ -36,7 +41,7 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
         var contents = section.Contents;
 
         var req = HippotherapyProgramSectionConstants.GetRequirements(section.Template);
-        var prop = nameof(CreateHippotherapyProgramSectionDto.Contents);
+        const string? prop = nameof(CreateHippotherapyProgramSectionDto.Contents);
 
         ValidateCounts(section, ctx, contents, req, prop);
         ValidateUniqueness(ctx, contents, prop);
@@ -180,11 +185,6 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
 
         var authors = contents.Where(c => c.ContentType == ContentType.Author).ToList();
 
-        if (authors.Count == 0)
-        {
-            return;
-        }
-
         if (authors.Any(c => string.IsNullOrWhiteSpace(c.Author)))
         {
             ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Author)));
@@ -225,7 +225,7 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
             return;
         }
 
-        if (!GroupsMatchComposition(groups, grouping))
+        if (!GroupsMatchComposition(grouped, grouping))
         {
             ctx.AddFailure(prop, HippotherapyProgramSectionConstants.GetGroupCompositionErrorMessage(section));
         }
@@ -250,11 +250,13 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
     }
 
     private static bool GroupsMatchComposition(
-        List<IGrouping<int, CreateProgramSectionContentDto>> groups,
+        IEnumerable<CreateProgramSectionContentDto> contents,
         HippotherapyProgramSectionConstants.GroupingConfig grouping)
     {
-        return !groups.Any(g =>
-            grouping.PerGroupCounts.Any(rule =>
+        return !contents
+            .Where(c => grouping.PerGroupCounts.ContainsKey(c.ContentType))
+            .GroupBy(c => c.GroupIndex!.Value)
+            .Any(g => grouping.PerGroupCounts.Any(rule =>
                 !InRange(g.Count(x => x.ContentType == rule.Key), rule.Value)));
     }
 

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ProgramSectionContentConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ProgramSectionContentConfig.cs
@@ -34,7 +34,8 @@ public class ProgramSectionContentConfig : IEntityTypeConfiguration<ProgramSecti
         builder.HasDiscriminator(c => c.ContentType)
             .HasValue<TitleProgramContent>(ContentType.Title)
             .HasValue<DescriptionProgramContent>(ContentType.Description)
-            .HasValue<ImageProgramContent>(ContentType.Image);
+            .HasValue<ImageProgramContent>(ContentType.Image)
+            .HasValue<AuthorProgramContent>(ContentType.Author);
     }
 }
 
@@ -66,5 +67,14 @@ public class ImageProgramContentConfig : IEntityTypeConfiguration<ImageProgramCo
         builder.HasOne(c => c.Image)
             .WithMany()
             .HasForeignKey(c => c.ImageId);
+    }
+}
+
+public class AuthorProgramContentConfig : IEntityTypeConfiguration<AuthorProgramContent>
+{
+    public void Configure(EntityTypeBuilder<AuthorProgramContent> builder)
+    {
+        builder.Property(c => c.Name)
+            .IsRequired();
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ProgramSectionContentConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ProgramSectionContentConfig.cs
@@ -23,6 +23,8 @@ public class ProgramSectionContentConfig : IEntityTypeConfiguration<ProgramSecti
         builder.Property(c => c.Order)
             .IsRequired();
 
+        builder.Property(c => c.GroupIndex);
+
         builder.HasOne(c => c.Section)
             .WithMany(s => s.Contents)
             .HasForeignKey(c => c.SectionId)

--- a/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramContents/AuthorProgramContent.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramContents/AuthorProgramContent.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+
+public class AuthorProgramContent : ProgramSectionContent
+{
+    public string Name { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramContents/ProgramSectionContent.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramContents/ProgramSectionContent.cs
@@ -12,5 +12,7 @@ public abstract class ProgramSectionContent
 
     public int Order { get; set; }
 
+    public int? GroupIndex { get; set; }
+
     public HippotherapyProgramSection Section { get; set; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.DAL/Enums/ContentType.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Enums/ContentType.cs
@@ -5,5 +5,6 @@ public enum ContentType
     Title,
     Description,
     Image,
-    Card
+    Card,
+    Author
 }

--- a/VictoryCenter/VictoryCenter.DAL/Enums/ProgramSectionTemplate.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Enums/ProgramSectionTemplate.cs
@@ -2,17 +2,25 @@ namespace VictoryCenter.DAL.Enums;
 
 public enum ProgramSectionTemplate
 {
-    QuadImagesBottom = 1,
+    QuadImagesBottom = 1,                  // T1
 
-    DualImagesBottom = 2,
+    DualImagesBottom = 2,                  // T2
 
-    TextOnly = 3,
+    TextOnly = 3,                          // T3
 
-    TripleImagesBottom = 4,
+    TripleImagesBottom = 4,                // T4
 
-    SingleImageBottom = 5,
+    SingleImageBottom = 5,                 // T5
 
-    SingleImageTop = 6,
+    SingleImageTop = 6,                    // T6
 
-    SingleImageRight = 7
+    SingleImageRight = 7,                  // T7
+
+    DualTitleDescriptionPairs = 8,         // Frame 633434
+
+    TripleTitleDescriptionPairs = 9,       // Frame 633378
+
+    QuadTitleDescriptionPairs = 10,        // Frame 633437
+
+    SingleTitleQuintupleDescription = 11,  // Frame 633435
 }

--- a/VictoryCenter/VictoryCenter.DAL/Enums/ProgramSectionTemplate.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Enums/ProgramSectionTemplate.cs
@@ -23,4 +23,6 @@ public enum ProgramSectionTemplate
     QuadTitleDescriptionPairs = 10,        // Frame 633437
 
     SingleTitleQuintupleDescription = 11,  // Frame 633435
+
+    SingleTitleDescriptionAuthorPairs = 12, // Frame 633433
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260112151642_AddGroupIndexToProgramSectionContents.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260112151642_AddGroupIndexToProgramSectionContents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260112151642_AddGroupIndexToProgramSectionContents")]
+    partial class AddGroupIndexToProgramSectionContents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260112151642_AddGroupIndexToProgramSectionContents.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260112151642_AddGroupIndexToProgramSectionContents.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGroupIndexToProgramSectionContents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GroupIndex",
+                table: "ProgramSectionContents",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupIndex",
+                table: "ProgramSectionContents");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260115220603_AddAuthorProgramContent.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260115220603_AddAuthorProgramContent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260115220603_AddAuthorProgramContent")]
+    partial class AddAuthorProgramContent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260115220603_AddAuthorProgramContent.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260115220603_AddAuthorProgramContent.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuthorProgramContent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Name",
+                table: "ProgramSectionContents",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Name",
+                table: "ProgramSectionContents");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HippotherapyProgramSectionsBuilderTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HippotherapyProgramSectionsBuilderTests.cs
@@ -191,9 +191,13 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = 1,
-            Titles = ["T"],
-            Descriptions = ["D"],
-            ImageIds = [10, 999]
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "T" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "D" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = 10 },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 3, ImageId = 999 }
+            ]
         };
 
         var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, imagesById);
@@ -213,9 +217,13 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = 1,
-            Titles = ["T"],
-            Descriptions = ["D"],
-            ImageIds = [10, 999]
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "T" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "D" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = 10 },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 3, ImageId = 999 }
+            ]
         };
 
         var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, imagesById);
@@ -233,9 +241,7 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = 1,
-            Titles = null!,
-            Descriptions = null!,
-            ImageIds = null!
+            Contents = null!
         };
 
         var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, new Dictionary<long, Image>());
@@ -255,18 +261,21 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = 2,
-            Titles = ["A"],
-            Descriptions = [],
-            ImageIds = []
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "A" }
+            ]
         };
 
         var dto2 = new CreateHippotherapyProgramSectionDto
         {
             Template = default,
             Order = 1,
-            Titles = [],
-            Descriptions = ["B"],
-            ImageIds = [10]
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 0, Description = "B" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 1, ImageId = 10 }
+            ]
         };
 
         var result = HippotherapyProgramSectionsBuilder.Build([dto1, dto2], createdAt, imagesById);
@@ -286,24 +295,52 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = 2,
-            Titles = ["A"],
-            Descriptions = [],
-            ImageIds = []
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "A" }
+            ]
         };
 
         var dto2 = new CreateHippotherapyProgramSectionDto
         {
             Template = default,
             Order = 1,
-            Titles = [],
-            Descriptions = ["B"],
-            ImageIds = [10]
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 0, Description = "B" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 1, ImageId = 10 }
+            ]
         };
 
         var result = HippotherapyProgramSectionsBuilder.Build([dto1, dto2], createdAt, imagesById);
         var contents = result[1].Contents.ToList();
 
         Assert.Equal(1, contents[1].Order);
+    }
+
+    [Fact]
+    public void Build_DtoContentsNotSortedByOrder_ResultContentsSortedByOrder()
+    {
+        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
+
+        var dto = new CreateHippotherapyProgramSectionDto
+        {
+            Template = default,
+            Order = 1,
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 2, Title = "T2" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "T0" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 1, Title = "T1" }
+            ]
+        };
+
+        var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, new Dictionary<long, Image>());
+        var contents = result[0].Contents.ToList();
+
+        Assert.Equal(0, contents[0].Order);
+        Assert.Equal(1, contents[1].Order);
+        Assert.Equal(2, contents[2].Order);
     }
 
     private static (List<HippotherapyProgramSection> result, Image image1, Image image2) BuildFullDto()
@@ -323,9 +360,15 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = 1,
-            Titles = ["  Title A  ", "Title B"],
-            Descriptions = ["  Desc 1 ", "Desc 2  "],
-            ImageIds = [10, 20]
+            Contents =
+            [
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "  Title A  " },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 1, Title = "Title B" },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 2, Description = "  Desc 1 " },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 3, Description = "Desc 2  " },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 4, ImageId = 10 },
+                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 5, ImageId = 20 }
+            ]
         };
 
         var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, imagesById);
@@ -338,9 +381,7 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             Template = default,
             Order = order,
-            Titles = [],
-            Descriptions = [],
-            ImageIds = []
+            Contents = []
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HippotherapyProgramSectionsBuilderTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HippotherapyProgramSectionsBuilderTests.cs
@@ -8,13 +8,12 @@ namespace VictoryCenter.UnitTests.HelperTests;
 
 public class HippotherapyProgramSectionsBuilderTests
 {
+    private static readonly DateTimeOffset CreatedAt = new(2025, 12, 17, 1, 2, 3, TimeSpan.Zero);
+
     [Fact]
     public void Build_SectionsNull_ReturnsEmpty()
     {
-        var result = HippotherapyProgramSectionsBuilder.Build(
-            null,
-            new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero),
-            new Dictionary<long, Image>());
+        var result = HippotherapyProgramSectionsBuilder.Build(null, CreatedAt, new Dictionary<long, Image>());
 
         Assert.Empty(result);
     }
@@ -22,22 +21,15 @@ public class HippotherapyProgramSectionsBuilderTests
     [Fact]
     public void Build_SectionsEmpty_ReturnsEmpty()
     {
-        var result = HippotherapyProgramSectionsBuilder.Build(
-            [],
-            new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero),
-            new Dictionary<long, Image>());
+        var result = HippotherapyProgramSectionsBuilder.Build([], CreatedAt, new Dictionary<long, Image>());
 
         Assert.Empty(result);
     }
 
     [Fact]
-    public void Build_TwoSections_ReturnsCountTwo()
+    public void Build_TwoSections_ReturnsTwo()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
-        var result = HippotherapyProgramSectionsBuilder.Build(
-            [MakeSectionDto(order: 1), MakeSectionDto(order: 2)],
-            createdAt,
-            new Dictionary<long, Image>());
+        var result = Build([Section(order: 1), Section(order: 2)]);
 
         Assert.Equal(2, result.Count);
     }
@@ -45,198 +37,32 @@ public class HippotherapyProgramSectionsBuilderTests
     [Fact]
     public void Build_SetsCreatedAt()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 1, 2, 3, TimeSpan.Zero);
-        var result = HippotherapyProgramSectionsBuilder.Build(
-            [MakeSectionDto(order: 7)],
-            createdAt,
-            new Dictionary<long, Image>());
+        var result = Build([Section(order: 7)]);
 
-        Assert.Equal(createdAt, result[0].CreatedAt);
+        Assert.Equal(CreatedAt, result[0].CreatedAt);
     }
 
     [Fact]
-    public void Build_MapsOrder()
+    public void Build_MapsSectionOrder()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 1, 2, 3, TimeSpan.Zero);
-        var result = HippotherapyProgramSectionsBuilder.Build(
-            [MakeSectionDto(order: 7)],
-            createdAt,
-            new Dictionary<long, Image>());
+        var result = Build([Section(order: 7)]);
 
         Assert.Equal(7, result[0].Order);
     }
 
     [Fact]
-    public void Build_MapsTemplate()
+    public void Build_MapsSectionTemplate()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 1, 2, 3, TimeSpan.Zero);
+        var dto = Section(order: 1) with { Template = ProgramSectionTemplate.SingleImageBottom };
 
-        var dto = MakeSectionDto(order: 1);
-        dto.Template = default;
+        var result = Build([dto]);
 
-        var result = HippotherapyProgramSectionsBuilder.Build(
-            [dto],
-            createdAt,
-            new Dictionary<long, Image>());
-
-        Assert.Equal(dto.Template, result[0].Template);
+        Assert.Equal(ProgramSectionTemplate.SingleImageBottom, result[0].Template);
     }
 
     [Fact]
-    public void Build_FullDto_ContentsCountIsSix()
+    public void Build_NullContents_ReturnsEmptyContents()
     {
-        var (result, _, _) = BuildFullDto();
-
-        Assert.Equal(6, result[0].Contents.ToList().Count);
-    }
-
-    [Fact]
-    public void Build_FullDto_Content0_IsTitleProgramContent()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.IsType<TitleProgramContent>(contents[0]);
-    }
-
-    [Fact]
-    public void Build_FullDto_Content2_IsDescriptionProgramContent()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.IsType<DescriptionProgramContent>(contents[2]);
-    }
-
-    [Fact]
-    public void Build_FullDto_Content4_IsImageProgramContent()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.IsType<ImageProgramContent>(contents[4]);
-    }
-
-    [Fact]
-    public void Build_FullDto_Content0_ContentTypeIsTitle()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(ContentType.Title, contents[0].ContentType);
-    }
-
-    [Fact]
-    public void Build_FullDto_Content2_ContentTypeIsDescription()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(ContentType.Description, contents[2].ContentType);
-    }
-
-    [Fact]
-    public void Build_FullDto_Content4_ContentTypeIsImage()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(ContentType.Image, contents[4].ContentType);
-    }
-
-    [Fact]
-    public void Build_FullDto_LastContentOrderIsFive()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(5, contents[5].Order);
-    }
-
-    [Fact]
-    public void Build_FullDto_TitleTrimApplied()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal("Title A", ((TitleProgramContent)contents[0]).Title);
-    }
-
-    [Fact]
-    public void Build_FullDto_DescriptionTrimApplied()
-    {
-        var (result, _, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal("Desc 1", ((DescriptionProgramContent)contents[2]).Description);
-    }
-
-    [Fact]
-    public void Build_FullDto_ImageReferenceSet()
-    {
-        var (result, image1, _) = BuildFullDto();
-        var contents = result[0].Contents.ToList();
-
-        Assert.Same(image1, ((ImageProgramContent)contents[4]).Image);
-    }
-
-    [Fact]
-    public void Build_SkipsMissingImages_ContentsCountIsThree()
-    {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
-        var image1 = MakeImage(10);
-        var imagesById = new Dictionary<long, Image> { [10] = image1 };
-
-        var dto = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 1,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "T" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "D" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = 10 },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 3, ImageId = 999 }
-            ]
-        };
-
-        var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, imagesById);
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(3, contents.Count);
-    }
-
-    [Fact]
-    public void Build_SkipsMissingImages_LastImageIdIsTen()
-    {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
-        var image1 = MakeImage(10);
-        var imagesById = new Dictionary<long, Image> { [10] = image1 };
-
-        var dto = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 1,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "T" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "D" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = 10 },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 3, ImageId = 999 }
-            ]
-        };
-
-        var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, imagesById);
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(10, ((ImageProgramContent)contents[2]).ImageId);
-    }
-
-    [Fact]
-    public void Build_DtoWithNullLists_ContentsEmpty()
-    {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
-
         var dto = new CreateHippotherapyProgramSectionDto
         {
             Template = default,
@@ -244,144 +70,215 @@ public class HippotherapyProgramSectionsBuilderTests
             Contents = null!
         };
 
-        var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, new Dictionary<long, Image>());
+        var result = Build([dto]);
         var contents = result[0].Contents.ToList();
 
         Assert.Empty(contents);
     }
 
     [Fact]
-    public void Build_MultipleSections_SecondSection_FirstContentOrderIsZero()
+    public void Build_SortsContentsByOrder()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
-        var image = MakeImage(10);
-        var imagesById = new Dictionary<long, Image> { [10] = image };
+        var dto = Section(
+            order: 1,
+            Title(order: 2, "T2"),
+            Title(order: 0, "T0"),
+            Title(order: 1, "T1"));
 
-        var dto1 = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 2,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "A" }
-            ]
-        };
+        var result = Build([dto]);
+        var orders = result[0].Contents.Select(x => x.Order).ToList();
 
-        var dto2 = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 1,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 0, Description = "B" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 1, ImageId = 10 }
-            ]
-        };
-
-        var result = HippotherapyProgramSectionsBuilder.Build([dto1, dto2], createdAt, imagesById);
-        var contents = result[1].Contents.ToList();
-
-        Assert.Equal(0, contents[0].Order);
+        Assert.True(orders.Count == 3 && orders[0] == 0 && orders[1] == 1 && orders[2] == 2);
     }
 
     [Fact]
-    public void Build_MultipleSections_SecondSection_SecondContentOrderIsOne()
+    public void Build_TrimsTitle()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
-        var image = MakeImage(10);
-        var imagesById = new Dictionary<long, Image> { [10] = image };
+        var dto = Section(order: 1, Title(order: 0, "  Title A  "), Description(order: 1, "Desc 1"));
 
-        var dto1 = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 2,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "A" }
-            ]
-        };
+        var result = Build([dto]);
+        var title = (TitleProgramContent)result[0].Contents.First(x => x.ContentType == ContentType.Title);
 
-        var dto2 = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 1,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 0, Description = "B" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 1, ImageId = 10 }
-            ]
-        };
-
-        var result = HippotherapyProgramSectionsBuilder.Build([dto1, dto2], createdAt, imagesById);
-        var contents = result[1].Contents.ToList();
-
-        Assert.Equal(1, contents[1].Order);
+        Assert.Equal("Title A", title.Title);
     }
 
     [Fact]
-    public void Build_DtoContentsNotSortedByOrder_ResultContentsSortedByOrder()
+    public void Build_TrimsDescription()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 0, 0, 0, TimeSpan.Zero);
+        var dto = Section(order: 1, Title(order: 0, "Title"), Description(order: 1, "  Desc 1 "));
 
-        var dto = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 1,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 2, Title = "T2" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "T0" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 1, Title = "T1" }
-            ]
-        };
+        var result = Build([dto]);
+        var description = (DescriptionProgramContent)result[0].Contents.First(x => x.ContentType == ContentType.Description);
 
-        var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, new Dictionary<long, Image>());
-        var contents = result[0].Contents.ToList();
-
-        Assert.Equal(0, contents[0].Order);
-        Assert.Equal(1, contents[1].Order);
-        Assert.Equal(2, contents[2].Order);
+        Assert.Equal("Desc 1", description.Description);
     }
 
-    private static (List<HippotherapyProgramSection> result, Image image1, Image image2) BuildFullDto()
+    [Fact]
+    public void Build_CreatesImageProgramContent()
     {
-        var createdAt = new DateTimeOffset(2025, 12, 17, 1, 2, 3, TimeSpan.Zero);
+        var image = MakeImage(10);
+        var dto = Section(order: 1, Title(order: 0, "Title"), Description(order: 1, "Desc 1"), Image(order: 2, 10));
+        var result = Build([dto], new Dictionary<long, Image> { [10] = image });
 
-        var image1 = MakeImage(10);
-        var image2 = MakeImage(20);
+        var content = result[0].Contents.First(x => x.ContentType == ContentType.Image);
 
-        var imagesById = new Dictionary<long, Image>
-        {
-            [10] = image1,
-            [20] = image2
-        };
-
-        var dto = new CreateHippotherapyProgramSectionDto
-        {
-            Template = default,
-            Order = 1,
-            Contents =
-            [
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "  Title A  " },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Title, Order = 1, Title = "Title B" },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 2, Description = "  Desc 1 " },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Description, Order = 3, Description = "Desc 2  " },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 4, ImageId = 10 },
-                new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 5, ImageId = 20 }
-            ]
-        };
-
-        var result = HippotherapyProgramSectionsBuilder.Build([dto], createdAt, imagesById);
-        return (result, image1, image2);
+        Assert.IsType<ImageProgramContent>(content);
     }
 
-    private static CreateHippotherapyProgramSectionDto MakeSectionDto(int order)
+    [Fact]
+    public void Build_SetsImageReference()
+    {
+        var image = MakeImage(10);
+        var dto = Section(order: 1, Title(order: 0, "Title"), Description(order: 1, "Desc 1"), Image(order: 2, 10));
+        var result = Build([dto], new Dictionary<long, Image> { [10] = image });
+
+        var content = (ImageProgramContent)result[0].Contents.First(x => x.ContentType == ContentType.Image);
+
+        Assert.Same(image, content.Image);
+    }
+
+    [Fact]
+    public void Build_SkipsMissingImages()
+    {
+        var image = MakeImage(10);
+
+        var dto = Section(
+            order: 1,
+            Title(order: 0, "Title"),
+            Description(order: 1, "Desc 1"),
+            Image(order: 2, 10),
+            Image(order: 3, 999));
+
+        var result = Build([dto], new Dictionary<long, Image> { [10] = image });
+
+        Assert.Equal(3, result[0].Contents.Count);
+    }
+
+    [Fact]
+    public void Build_SkipsImageWithInvalidId()
+    {
+        var dto = Section(
+            order: 1,
+            Title(order: 0, "Title"),
+            Description(order: 1, "Desc 1"),
+            new CreateProgramSectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = 0 });
+
+        var result = Build([dto]);
+
+        Assert.Equal(2, result[0].Contents.Count);
+    }
+
+    [Fact]
+    public void Build_SkipsUnknownContentType()
+    {
+        var dto = Section(
+            order: 1,
+            Title(order: 0, "Title"),
+            new CreateProgramSectionContentDto { ContentType = ContentType.Card, Order = 1 });
+
+        var result = Build([dto]);
+
+        Assert.Single(result[0].Contents);
+    }
+
+    [Fact]
+    public void Build_CreatesAuthorProgramContent()
+    {
+        var dto = Section(order: 1, Title(order: 0, "Title"), Author(order: 1, "Author Name"));
+
+        var result = Build([dto]);
+
+        var content = result[0].Contents.First(x => x.ContentType == ContentType.Author);
+
+        Assert.IsType<AuthorProgramContent>(content);
+    }
+
+    [Fact]
+    public void Build_TrimsAuthor()
+    {
+        var dto = Section(order: 1, Title(order: 0, "Title"), Author(order: 1, "  Member 1  "));
+
+        var result = Build([dto]);
+
+        var author = (AuthorProgramContent)result[0].Contents.First(x => x.ContentType == ContentType.Author);
+
+        Assert.Equal("Member 1", author.Name);
+    }
+
+    [Fact]
+    public void Build_MapsGroupIndex_ForAuthor()
+    {
+        var dto = Section(
+            order: 1,
+            Title(order: 0, "Title"),
+            new CreateProgramSectionContentDto { ContentType = ContentType.Author, Order = 1, GroupIndex = 2, Author = "Member" });
+
+        var result = Build([dto]);
+
+        var author = (AuthorProgramContent)result[0].Contents.First(x => x.ContentType == ContentType.Author);
+
+        Assert.Equal(2, author.GroupIndex);
+    }
+
+    private static List<HippotherapyProgramSection> Build(
+        List<CreateHippotherapyProgramSectionDto> sections,
+        IReadOnlyDictionary<long, Image>? imagesById = null)
+    {
+        return HippotherapyProgramSectionsBuilder.Build(
+            sections,
+            CreatedAt,
+            imagesById ?? new Dictionary<long, Image>());
+    }
+
+    private static CreateHippotherapyProgramSectionDto Section(
+        int order,
+        params CreateProgramSectionContentDto[] contents)
     {
         return new CreateHippotherapyProgramSectionDto
         {
             Template = default,
             Order = order,
-            Contents = []
+            Contents = [.. contents]
+        };
+    }
+
+    private static CreateProgramSectionContentDto Title(int order, string title)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Title,
+            Order = order,
+            Title = title
+        };
+    }
+
+    private static CreateProgramSectionContentDto Description(int order, string description)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Description,
+            Order = order,
+            Description = description
+        };
+    }
+
+    private static CreateProgramSectionContentDto Image(int order, long imageId)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Image,
+            Order = order,
+            ImageId = imageId
+        };
+    }
+
+    private static CreateProgramSectionContentDto Author(int order, string author)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Author,
+            Order = order,
+            Author = author
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/CreateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/CreateHippotherapyProgramTests.cs
@@ -174,7 +174,22 @@ public class CreateHippotherapyProgramTests
             {
                 Template = default,
                 Order = 0,
-                ImageIds = [1, 2]
+                Contents =
+                [
+                    new()
+                    {
+                        ContentType = ContentType.Image,
+                        Order = 0,
+                        ImageId = 1
+                    },
+                    new()
+                    {
+                        ContentType = ContentType.Image,
+                        Order = 1,
+                        ImageId = 2
+                    }
+
+                ]
             }
 
         ];

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/CreateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/CreateHippotherapyProgramTests.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using FluentResults;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.EntityFrameworkCore;
@@ -7,7 +6,7 @@ using Moq;
 using VictoryCenter.BLL.Commands.Admin.HippotherapyPrograms.Create;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
-using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -17,286 +16,265 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.HippotherapyPrograms;
 
 public class CreateHippotherapyProgramTests
 {
-    private readonly Mock<IMapper> _mapperMock;
-    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
-    private readonly Mock<IValidator<CreateHippotherapyProgramCommand>> _validatorMock;
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<IRepositoryWrapper> _repo = new();
+    private readonly Mock<IValidator<CreateHippotherapyProgramCommand>> _validator = new();
 
-    private readonly CreateHippotherapyProgramDto _createProgramDto = new()
-    {
-        Name = "TestName",
-        Description = "TestDescription",
-        Status = Status.Draft,
-        BackgroundImageId = 1,
-        PreviewImageId = 2,
-        CategoryIds = [1, 2],
-        Sections = []
-    };
-
-    private readonly HippotherapyProgram _programEntity = new()
-    {
-        Name = "TestName",
-        Description = "TestDescription",
-        Status = Status.Draft,
-        BackgroundImageId = 1,
-        PreviewImageId = 2,
-        Categories = [],
-        Sections = []
-    };
-
-    private readonly HippotherapyProgramDto _programDto = new()
-    {
-        Id = 1,
-        Name = "TestName",
-        Description = "TestDescription",
-        Status = Status.Draft,
-        Location = null,
-        ParticipantsCount = null,
-        MeetingsCount = null,
-        BackgroundImage = new ImageDto { BlobName = "BlobName", MimeType = "image/png" },
-        PreviewImage = new ImageDto { BlobName = "BlobName", MimeType = "image/png" },
-        Categories = []
-    };
-
-    private readonly List<HippotherapyProgramCategory> _programCategories =
+    private static readonly List<HippotherapyProgramCategory> Categories =
     [
-        new() { Id = 1, Name = "TestCategoryName1" },
-        new() { Id = 2, Name = "TestCategoryName2" }
+        new() { Id = 1, Name = "C1" },
+        new() { Id = 2, Name = "C2" }
     ];
 
-    private readonly List<Image> _images =
+    private static readonly List<Image> Images =
     [
-        new() { Id = 1, BlobName = "BlobName1", MimeType = "image/png" },
-        new() { Id = 2, BlobName = "BlobName2", MimeType = "image/png" }
+        new() { Id = 1, BlobName = "B1", MimeType = "image/png" },
+        new() { Id = 2, BlobName = "B2", MimeType = "image/png" }
     ];
 
-    public CreateHippotherapyProgramTests()
-    {
-        _mapperMock = new Mock<IMapper>();
-        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
-        _validatorMock = new Mock<IValidator<CreateHippotherapyProgramCommand>>();
-
-        SetUpValidatorAlwaysSuccess();
-        SetUpAutomapper();
-        SetUpRepositoryWrapper(saveResult: 1);
-    }
-
     [Fact]
-    public async Task Handle_ShouldCreateProgram()
+    public async Task Handle_ValidRequest_ReturnsSuccess()
     {
-        var result = await ExecuteAsync();
+        var sut = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(Command(Dto()), CancellationToken.None);
 
         Assert.True(result.IsSuccess);
-        Assert.Equal(_programEntity.Name, result.Value.Name);
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_SaveChangesFail()
+    public async Task Handle_SaveChangesReturnsZero_ReturnsFailedToCreateEntity()
     {
-        SetUpRepositoryWrapper(saveResult: -1);
+        var sut = CreateSut(saveChanges: 0);
 
-        var result = await ExecuteAsync();
+        var result = await sut.Handle(Command(Dto()), CancellationToken.None);
 
-        Assert.False(result.IsSuccess);
-        Assert.Equal(
-            ErrorMessagesConstants.FailedToCreateEntity(typeof(HippotherapyProgram)),
-            result.Errors[0].Message);
+        Assert.Equal(ErrorMessagesConstants.FailedToCreateEntity(typeof(HippotherapyProgram)), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenSomeCategoriesDoNotExist()
+    public async Task Handle_MissingCategory_ReturnsNotFoundError()
     {
-        var onlyOneCategory = new List<HippotherapyProgramCategory>
-        {
-            new() { Id = 1, Name = "OnlyExistingCategory" }
-        };
+        var sut = CreateSut(saveChanges: 1, categories: [Categories[0]]);
 
-        _repositoryWrapperMock
-            .Setup(r => r.HippotherapyProgramCategoriesRepository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
-            .ReturnsAsync(onlyOneCategory);
+        var result = await sut.Handle(Command(Dto(categoryIds: [1, 2])), CancellationToken.None);
 
-        var result = await ExecuteAsync();
-
-        Assert.False(result.IsSuccess);
-        Assert.Contains("HippotherapyProgramCategory", result.Errors[0].Message);
+        Assert.Contains(nameof(HippotherapyProgramCategory), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldCreateProgram_WhenImagesAreNull()
+    public async Task Handle_BackgroundImageNotFound_ReturnsNotFoundError()
     {
-        _createProgramDto.BackgroundImageId = null;
-        _createProgramDto.PreviewImageId = null;
+        var sut = CreateSut(saveChanges: 1);
 
-        _programEntity.BackgroundImageId = null;
-        _programEntity.PreviewImageId = null;
+        var result = await sut.Handle(Command(Dto(backgroundImageId: 999)), CancellationToken.None);
 
-        var result = await ExecuteAsync();
+        Assert.Contains(nameof(Image), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_PreviewImageNotFound_ReturnsNotFoundError()
+    {
+        var sut = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(Command(Dto(previewImageId: 999)), CancellationToken.None);
+
+        Assert.Contains(nameof(Image), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_SectionImageNotFound_ReturnsNotFoundError()
+    {
+        var sut = CreateSut(saveChanges: 1, images: [Images[0]]);
+
+        var dto = Dto(
+            backgroundImageId: null,
+            previewImageId: null,
+            sections:
+            [
+                CreateSection(
+                    0,
+                    CreateImageContent(0, 1),
+                    CreateImageContent(1, 2))
+            ]);
+
+        var result = await sut.Handle(Command(dto), CancellationToken.None);
+
+        Assert.Contains(nameof(Image), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ImagesAreNull_ReturnsSuccess()
+    {
+        var sut = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(Command(Dto(backgroundImageId: null, previewImageId: null)), CancellationToken.None);
 
         Assert.True(result.IsSuccess);
-        Assert.Equal(_programDto.Name, result.Value.Name);
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenBackgroundImageNotFound()
+    public async Task Handle_SaveChangesThrowsDbUpdateException_ReturnsDatabaseError()
     {
-        _createProgramDto.BackgroundImageId = 999;
-        _programEntity.BackgroundImageId = 999;
+        var sut = CreateSut(saveChanges: 1, throwOnSave: true);
 
-        var result = await ExecuteAsync();
+        var result = await sut.Handle(Command(Dto()), CancellationToken.None);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Image", result.Errors[0].Message);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldFail_WhenPreviewImageNotFound()
-    {
-        _createProgramDto.PreviewImageId = 999;
-        _programEntity.PreviewImageId = 999;
-
-        var result = await ExecuteAsync();
-
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Image", result.Errors[0].Message);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldFail_WhenSomeSectionImagesDoNotExist()
-    {
-        _createProgramDto.BackgroundImageId = null;
-        _createProgramDto.PreviewImageId = null;
-
-        _programEntity.BackgroundImageId = null;
-        _programEntity.PreviewImageId = null;
-
-        _createProgramDto.Sections =
-        [
-            new()
-            {
-                Template = default,
-                Order = 0,
-                Contents =
-                [
-                    new()
-                    {
-                        ContentType = ContentType.Image,
-                        Order = 0,
-                        ImageId = 1
-                    },
-                    new()
-                    {
-                        ContentType = ContentType.Image,
-                        Order = 1,
-                        ImageId = 2
-                    }
-
-                ]
-            }
-
-        ];
-
-        _repositoryWrapperMock
-            .Setup(r => r.ImageRepository.GetAllAsync(It.IsAny<QueryOptions<Image>>()))
-            .ReturnsAsync([_images[0]]);
-
-        var result = await ExecuteAsync();
-
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Image", result.Errors[0].Message);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldFail_DbUpdateException()
-    {
-        _repositoryWrapperMock
-            .Setup(r => r.SaveChangesAsync())
-            .ThrowsAsync(new DbUpdateException());
-
-        var result = await ExecuteAsync();
-
-        Assert.False(result.IsSuccess);
         Assert.Equal(
             ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(HippotherapyProgram)),
             result.Errors[0].Message);
     }
 
-    private Task<Result<HippotherapyProgramDto>> ExecuteAsync()
+    private CreateHippotherapyProgramHandler CreateSut(
+        int saveChanges,
+        List<HippotherapyProgramCategory>? categories = null,
+        List<Image>? images = null,
+        bool throwOnSave = false)
     {
-        var handler = CreateHandler();
-        return handler.Handle(CreateCommand(), CancellationToken.None);
+        SetUpValidatorSuccess();
+        SetUpMapper();
+        SetUpRepositories(saveChanges, categories ?? Categories, images ?? Images, throwOnSave);
+
+        return new CreateHippotherapyProgramHandler(_mapper.Object, _repo.Object, _validator.Object);
     }
 
-    private CreateHippotherapyProgramCommand CreateCommand()
-        => new(_createProgramDto);
-
-    private CreateHippotherapyProgramHandler CreateHandler()
-        => new(
-            _mapperMock.Object,
-            _repositoryWrapperMock.Object,
-            _validatorMock.Object);
-
-    private void SetUpAutomapper()
+    private void SetUpValidatorSuccess()
     {
-        _mapperMock
-            .Setup(m => m.Map<HippotherapyProgram>(It.IsAny<CreateHippotherapyProgramDto>()))
-            .Returns(_programEntity);
-
-        _mapperMock
-            .Setup(m => m.Map<HippotherapyProgramDto>(It.IsAny<HippotherapyProgram>()))
-            .Returns(_programDto);
-    }
-
-    private void SetUpValidatorAlwaysSuccess()
-    {
-        _validatorMock.Reset();
+        _validator.Reset();
 
         var ok = new ValidationResult();
 
-        _validatorMock
+        _validator
             .Setup(v => v.ValidateAsync(It.IsAny<CreateHippotherapyProgramCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ok);
 
-        _validatorMock
+        _validator
             .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<CreateHippotherapyProgramCommand>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ok);
     }
 
-    private void SetUpRepositoryWrapper(int saveResult)
+    private void SetUpMapper()
     {
-        _repositoryWrapperMock
+        _mapper.Reset();
+
+        _mapper
+            .Setup(m => m.Map<HippotherapyProgram>(It.IsAny<CreateHippotherapyProgramDto>()))
+            .Returns((CreateHippotherapyProgramDto dto) => new HippotherapyProgram
+            {
+                Name = dto.Name,
+                Description = dto.Description,
+                Status = dto.Status,
+                Location = dto.Location,
+                ParticipantsCount = dto.ParticipantsCount,
+                MeetingsCount = dto.MeetingsCount,
+                BackgroundImageId = dto.BackgroundImageId,
+                PreviewImageId = dto.PreviewImageId,
+                Categories = [],
+                Sections = []
+            });
+
+        _mapper
+            .Setup(m => m.Map<HippotherapyProgramDto>(It.IsAny<HippotherapyProgram>()))
+            .Returns((HippotherapyProgram p) => new HippotherapyProgramDto
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Description = p.Description,
+                Status = p.Status,
+                Location = p.Location,
+                ParticipantsCount = p.ParticipantsCount,
+                MeetingsCount = p.MeetingsCount,
+                BackgroundImage = null,
+                PreviewImage = null,
+                Categories = [],
+                Sections = []
+            });
+    }
+
+    private void SetUpRepositories(
+        int saveChanges,
+        List<HippotherapyProgramCategory> categories,
+        List<Image> images,
+        bool throwOnSave)
+    {
+        _repo.Reset();
+
+        _repo
             .Setup(r => r.HippotherapyProgramCategoriesRepository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
             .ReturnsAsync((QueryOptions<HippotherapyProgramCategory> options) =>
             {
                 var predicate = options.Filter?.Compile();
-                return predicate is null
-                    ? _programCategories
-                    : [.. _programCategories.Where(predicate)];
+                return predicate is null ? categories : [.. categories.Where(predicate)];
             });
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.ImageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Image>>()))
             .ReturnsAsync((QueryOptions<Image> options) =>
             {
                 var predicate = options.Filter?.Compile();
-                return predicate is null
-                    ? _images.FirstOrDefault()
-                    : _images.FirstOrDefault(predicate);
+                return predicate is null ? images.FirstOrDefault() : images.FirstOrDefault(predicate);
             });
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.ImageRepository.GetAllAsync(It.IsAny<QueryOptions<Image>>()))
             .ReturnsAsync((QueryOptions<Image> options) =>
             {
                 var predicate = options.Filter?.Compile();
-                return predicate is null
-                    ? _images
-                    : [.. _images.Where(predicate)];
+                return predicate is null ? images : [.. images.Where(predicate)];
             });
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.HippotherapyProgramsRepository.CreateAsync(It.IsAny<HippotherapyProgram>()));
 
-        _repositoryWrapperMock
-            .Setup(r => r.SaveChangesAsync())
-            .ReturnsAsync(saveResult);
+        if (throwOnSave)
+        {
+            _repo.Setup(r => r.SaveChangesAsync()).ThrowsAsync(new DbUpdateException());
+            return;
+        }
+
+        _repo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(saveChanges);
+    }
+
+    private static CreateHippotherapyProgramCommand Command(CreateHippotherapyProgramDto dto) => new(dto);
+
+    private static CreateHippotherapyProgramDto Dto(
+        string name = "N",
+        string description = "D",
+        Status status = Status.Draft,
+        long? backgroundImageId = 1,
+        long? previewImageId = 2,
+        List<long>? categoryIds = null,
+        List<CreateHippotherapyProgramSectionDto>? sections = null)
+    {
+        return new CreateHippotherapyProgramDto
+        {
+            Name = name,
+            Description = description,
+            Status = status,
+            BackgroundImageId = backgroundImageId,
+            PreviewImageId = previewImageId,
+            CategoryIds = categoryIds ?? [1, 2],
+            Sections = sections ?? []
+        };
+    }
+
+    private static CreateHippotherapyProgramSectionDto CreateSection(int order, params CreateProgramSectionContentDto[] contents)
+    {
+        return new CreateHippotherapyProgramSectionDto
+        {
+            Template = default,
+            Order = order,
+            Contents = [.. contents]
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateImageContent(int order, long imageId)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Image,
+            Order = order,
+            ImageId = imageId
+        };
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -180,7 +180,22 @@ public class UpdateHippotherapyProgramTests
             {
                 Template = default,
                 Order = 0,
-                ImageIds = [1, 2]
+                Contents =
+                [
+                    new CreateProgramSectionContentDto
+                    {
+                        ContentType = ContentType.Image,
+                        Order = 0,
+                        ImageId = 1
+                    },
+                    new CreateProgramSectionContentDto
+                    {
+                        ContentType = ContentType.Image,
+                        Order = 1,
+                        ImageId = 2
+                    }
+
+                ]
             }
 
         ];

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using FluentResults;
 using FluentValidation;
 using FluentValidation.Results;
 using Moq;
@@ -7,7 +6,6 @@ using VictoryCenter.BLL.Commands.Admin.HippotherapyPrograms.Update;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
-using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -17,289 +15,342 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.HippotherapyPrograms;
 
 public class UpdateHippotherapyProgramTests
 {
-    private readonly Mock<IMapper> _mapperMock;
-    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
-    private readonly Mock<IValidator<UpdateHippotherapyProgramCommand>> _validatorMock;
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<IRepositoryWrapper> _repo = new();
+    private readonly Mock<IValidator<UpdateHippotherapyProgramCommand>> _validator = new();
 
-    private readonly UpdateHippotherapyProgramDto _updateProgramDto = new()
-    {
-        Name = "NewProgramName",
-        Description = "NewProgramDescription",
-        Status = Status.Published,
-        BackgroundImageId = 1,
-        PreviewImageId = 2,
-        CategoryIds = [1, 2],
-        Sections = []
-    };
-
-    private readonly HippotherapyProgram _programEntity = new()
-    {
-        Id = 1,
-        Name = "OldProgramName",
-        Description = "OldProgramDescription",
-        Status = Status.Published,
-        BackgroundImageId = 1,
-        PreviewImageId = 2,
-        Categories = [],
-        Sections = []
-    };
-
-    private readonly HippotherapyProgramDto _programDto = new()
-    {
-        Id = 1,
-        Name = "MappedProgramName",
-        Description = "MappedProgramDescription",
-        Status = Status.Published,
-        BackgroundImage = new ImageDto { BlobName = "BlobName", MimeType = "image/png" },
-        PreviewImage = new ImageDto { BlobName = "BlobName", MimeType = "image/png" },
-        Categories = []
-    };
-
-    private readonly List<HippotherapyProgramCategory> _programCategories =
+    private static readonly List<HippotherapyProgramCategory> Categories =
     [
-        new() { Id = 1, Name = "TestCategoryName1" },
-        new() { Id = 2, Name = "TestCategoryName2" }
+        new() { Id = 1, Name = "C1" },
+        new() { Id = 2, Name = "C2" }
     ];
 
-    private readonly List<Image> _images =
+    private static readonly List<Image> Images =
     [
-        new() { Id = 1, BlobName = "BlobName1", MimeType = "image/png" },
-        new() { Id = 2, BlobName = "BlobName2", MimeType = "image/png" }
+        new() { Id = 1, BlobName = "B1", MimeType = "image/png" },
+        new() { Id = 2, BlobName = "B2", MimeType = "image/png" }
     ];
 
-    public UpdateHippotherapyProgramTests()
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesProgramName()
     {
-        _mapperMock = new Mock<IMapper>();
-        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
-        _validatorMock = new Mock<IValidator<UpdateHippotherapyProgramCommand>>();
+        var program = Program();
+        var sut = CreateSut(program: program, saveChanges: 1);
 
-        SetUpValidatorAlwaysSuccess();
-        SetUpAutomapper();
-        SetUpRepositoryWrapper(program: _programEntity, saveResult: 1);
+        await sut.Handle(Command(id: 1, dto: Dto(name: "NewName")), CancellationToken.None);
+
+        Assert.Equal("NewName", program.Name);
     }
 
     [Fact]
-    public async Task Handle_ShouldUpdateProgram()
+    public async Task Handle_ValidRequest_ReplacesCategories()
     {
-        var result = await ExecuteAsync(id: 1);
+        var program = Program(categories: [new HippotherapyProgramCategory { Id = 99, Name = "Old" }]);
+        var sut = CreateSut(program: program, saveChanges: 1);
 
-        Assert.True(result.IsSuccess);
-        Assert.Equal(_programDto.Name, result.Value.Name);
+        await sut.Handle(Command(id: 1, dto: Dto(categoryIds: [1, 2])), CancellationToken.None);
 
-        Assert.Equal(2, _programEntity.Categories.Count);
-        _repositoryWrapperMock.Verify(r => r.HippotherapyProgramsRepository.Update(It.IsAny<HippotherapyProgram>()), Times.Once);
-        _repositoryWrapperMock.Verify(r => r.SaveChangesAsync(), Times.Once);
+        Assert.Equal(2, program.Categories.Count);
     }
 
     [Fact]
-    public async Task Handle_ShouldFailUpdate_SaveFail()
+    public async Task Handle_ValidRequest_ReplacesSections()
     {
-        SetUpRepositoryWrapper(program: _programEntity, saveResult: -1);
+        var program = Program(sections: [new HippotherapyProgramSection { Template = default, Order = 99, CreatedAt = DateTimeOffset.UtcNow, Contents = [] }]);
+        var sut = CreateSut(program: program, saveChanges: 1);
 
-        var result = await ExecuteAsync(id: 1);
+        await sut.Handle(
+            Command(id: 1, dto: Dto(sections:
+            [
+                CreateSection(0),
+                CreateSection(1)
+            ])), CancellationToken.None);
 
-        Assert.False(result.IsSuccess);
+        Assert.Equal(2, program.Sections.Count);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesReturnsZero_ReturnsFailedToUpdateEntity()
+    {
+        var sut = CreateSut(program: Program(), saveChanges: 0);
+
+        var result = await sut.Handle(Command(id: 1, dto: Dto()), CancellationToken.None);
+
         Assert.Equal(ErrorMessagesConstants.FailedToUpdateEntity(typeof(HippotherapyProgram)), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldFailUpdate_NotFoundProgram()
+    public async Task Handle_ProgramNotFound_ReturnsNotFound()
     {
-        SetUpRepositoryWrapper(program: null, saveResult: 1);
+        var sut = CreateSut(program: null, saveChanges: 1);
 
-        var result = await ExecuteAsync(id: 1);
+        var result = await sut.Handle(Command(id: 1, dto: Dto()), CancellationToken.None);
 
-        Assert.False(result.IsSuccess);
         Assert.Equal(ErrorMessagesConstants.NotFound(1, typeof(HippotherapyProgram)), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldUpdateProgram_WhenImagesAreNull()
+    public async Task Handle_MissingCategory_ReturnsNotFoundError()
     {
-        _updateProgramDto.Status = Status.Draft;
+        var sut = CreateSut(program: Program(), saveChanges: 1, categories: [Categories[0]]);
 
-        _updateProgramDto.BackgroundImageId = null;
-        _updateProgramDto.PreviewImageId = null;
+        var result = await sut.Handle(Command(id: 1, dto: Dto(categoryIds: [1, 2])), CancellationToken.None);
 
-        var result = await ExecuteAsync(id: 1);
-
-        Assert.True(result.IsSuccess);
-        Assert.Equal(_programDto.Name, result.Value.Name);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldFailUpdate_WhenSomeCategoriesDoNotExist()
-    {
-        var onlyOneCategory = new List<HippotherapyProgramCategory>
-        {
-            new() { Id = 1, Name = "OnlyExistingCategory" }
-        };
-
-        _repositoryWrapperMock
-            .Setup(r => r.HippotherapyProgramCategoriesRepository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
-            .ReturnsAsync(onlyOneCategory);
-
-        var result = await ExecuteAsync(id: 1);
-
-        Assert.True(result.IsFailed);
         Assert.Contains(nameof(HippotherapyProgramCategory), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldFailUpdate_WhenBackgroundImageNotFound()
+    public async Task Handle_BackgroundImageNotFound_ReturnsNotFoundError()
     {
-        _updateProgramDto.BackgroundImageId = 999;
+        var sut = CreateSut(program: Program(), saveChanges: 1);
 
-        var result = await ExecuteAsync(id: 1);
+        var result = await sut.Handle(Command(id: 1, dto: Dto(backgroundImageId: 999)), CancellationToken.None);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Image", result.Errors[0].Message);
+        Assert.Contains(nameof(Image), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldFailUpdate_WhenPreviewImageNotFound()
+    public async Task Handle_PreviewImageNotFound_ReturnsNotFoundError()
     {
-        _updateProgramDto.PreviewImageId = 999;
+        var sut = CreateSut(program: Program(), saveChanges: 1);
 
-        var result = await ExecuteAsync(id: 1);
+        var result = await sut.Handle(Command(id: 1, dto: Dto(previewImageId: 999)), CancellationToken.None);
 
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Image", result.Errors[0].Message);
+        Assert.Contains(nameof(Image), result.Errors[0].Message);
     }
 
     [Fact]
-    public async Task Handle_ShouldFailUpdate_WhenSomeSectionImagesDoNotExist()
+    public async Task Handle_SectionImageNotFound_ReturnsNotFoundError()
     {
-        _updateProgramDto.Status = Status.Draft;
-        _updateProgramDto.BackgroundImageId = null;
-        _updateProgramDto.PreviewImageId = null;
+        var sut = CreateSut(program: Program(), saveChanges: 1, images: [Images[0]]);
 
-        _updateProgramDto.Sections =
-        [
-            new CreateHippotherapyProgramSectionDto
-            {
-                Template = default,
-                Order = 0,
-                Contents =
-                [
-                    new CreateProgramSectionContentDto
-                    {
-                        ContentType = ContentType.Image,
-                        Order = 0,
-                        ImageId = 1
-                    },
-                    new CreateProgramSectionContentDto
-                    {
-                        ContentType = ContentType.Image,
-                        Order = 1,
-                        ImageId = 2
-                    }
+        var dto = Dto(
+            status: Status.Draft,
+            backgroundImageId: null,
+            previewImageId: null,
+            sections:
+            [
+                CreateSection(
+                    0,
+                    CreateImageContent(0, 1),
+                    CreateImageContent(1, 2))
+            ]);
 
-                ]
-            }
+        var result = await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        ];
-
-        _repositoryWrapperMock
-            .Setup(r => r.ImageRepository.GetAllAsync(It.IsAny<QueryOptions<Image>>()))
-            .ReturnsAsync([_images[0]]);
-
-        var result = await ExecuteAsync(id: 1);
-
-        Assert.False(result.IsSuccess);
-        Assert.Contains("Image", result.Errors[0].Message);
+        Assert.Contains(nameof(Image), result.Errors[0].Message);
     }
 
-    private Task<Result<HippotherapyProgramDto>> ExecuteAsync(long id)
+    [Fact]
+    public async Task Handle_ImagesAreNull_ReturnsSuccess()
     {
-        var handler = CreateHandler();
-        return handler.Handle(CreateCommand(id), CancellationToken.None);
+        var sut = CreateSut(program: Program(), saveChanges: 1);
+
+        var result = await sut.Handle(Command(id: 1, dto: Dto(backgroundImageId: null, previewImageId: null)), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
     }
 
-    private UpdateHippotherapyProgramCommand CreateCommand(long id)
-        => new(_updateProgramDto, id);
-
-    private UpdateHippotherapyProgramHandler CreateHandler()
-        => new(
-            _mapperMock.Object,
-            _repositoryWrapperMock.Object,
-            _validatorMock.Object);
-
-    private void SetUpAutomapper()
+    [Fact]
+    public async Task Handle_ValidatorThrows_ReturnsValidationError()
     {
-        _mapperMock
+        var sut = CreateSut(program: Program(), saveChanges: 1);
+        SetUpValidatorToThrow("Name required");
+
+        var result = await sut.Handle(Command(id: 1, dto: Dto()), CancellationToken.None);
+
+        Assert.Equal("Name required", result.Errors[0].Message);
+    }
+
+    private UpdateHippotherapyProgramHandler CreateSut(
+        HippotherapyProgram? program,
+        int saveChanges,
+        List<HippotherapyProgramCategory>? categories = null,
+        List<Image>? images = null,
+        List<ValidationFailure>? validatorErrors = null)
+    {
+        SetUpValidator(validatorErrors);
+        SetUpMapper();
+        SetUpRepositories(program, saveChanges, categories ?? Categories, images ?? Images);
+
+        return new UpdateHippotherapyProgramHandler(_mapper.Object, _repo.Object, _validator.Object);
+    }
+
+    private void SetUpValidator(List<ValidationFailure>? failures)
+    {
+        _validator.Reset();
+
+        var result = failures is null
+            ? new ValidationResult()
+            : new ValidationResult(failures);
+
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<UpdateHippotherapyProgramCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<UpdateHippotherapyProgramCommand>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+    }
+
+    private void SetUpMapper()
+    {
+        _mapper.Reset();
+
+        _mapper
             .Setup(m => m.Map(It.IsAny<UpdateHippotherapyProgramDto>(), It.IsAny<HippotherapyProgram>()))
             .Returns((UpdateHippotherapyProgramDto src, HippotherapyProgram dest) =>
             {
                 dest.Name = src.Name;
                 dest.Description = src.Description;
                 dest.Status = src.Status;
+                dest.Location = src.Location;
+                dest.ParticipantsCount = src.ParticipantsCount;
+                dest.MeetingsCount = src.MeetingsCount;
                 dest.BackgroundImageId = src.BackgroundImageId;
                 dest.PreviewImageId = src.PreviewImageId;
                 return dest;
             });
 
-        _mapperMock
+        _mapper
             .Setup(m => m.Map<HippotherapyProgramDto>(It.IsAny<HippotherapyProgram>()))
-            .Returns(_programDto);
+            .Returns((HippotherapyProgram p) => new HippotherapyProgramDto
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Description = p.Description,
+                Status = p.Status,
+                Location = p.Location,
+                ParticipantsCount = p.ParticipantsCount,
+                MeetingsCount = p.MeetingsCount,
+                BackgroundImage = null,
+                PreviewImage = null,
+                Categories = [],
+                Sections = []
+            });
     }
 
-    private void SetUpValidatorAlwaysSuccess()
+    private void SetUpRepositories(
+        HippotherapyProgram? program,
+        int saveChanges,
+        List<HippotherapyProgramCategory> categories,
+        List<Image> images)
     {
-        _validatorMock.Reset();
+        _repo.Reset();
 
-        var ok = new ValidationResult();
-
-        _validatorMock
-            .Setup(v => v.ValidateAsync(It.IsAny<UpdateHippotherapyProgramCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ok);
-
-        _validatorMock
-            .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<UpdateHippotherapyProgramCommand>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ok);
-    }
-
-    private void SetUpRepositoryWrapper(HippotherapyProgram? program, int saveResult)
-    {
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgram>>()))
             .ReturnsAsync(program);
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.HippotherapyProgramCategoriesRepository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
             .ReturnsAsync((QueryOptions<HippotherapyProgramCategory> options) =>
             {
                 var predicate = options.Filter?.Compile();
-                return predicate is null
-                    ? _programCategories
-                    : [.. _programCategories.Where(predicate)];
+                return predicate is null ? categories : [.. categories.Where(predicate)];
             });
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.ImageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Image>>()))
             .ReturnsAsync((QueryOptions<Image> options) =>
             {
                 var predicate = options.Filter?.Compile();
-                return predicate is null
-                    ? _images.FirstOrDefault()
-                    : _images.FirstOrDefault(predicate);
+                return predicate is null ? images.FirstOrDefault() : images.FirstOrDefault(predicate);
             });
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.ImageRepository.GetAllAsync(It.IsAny<QueryOptions<Image>>()))
             .ReturnsAsync((QueryOptions<Image> options) =>
             {
                 var predicate = options.Filter?.Compile();
-                return predicate is null
-                    ? _images
-                    : [.. _images.Where(predicate)];
+                return predicate is null ? images : [.. images.Where(predicate)];
             });
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.HippotherapyProgramsRepository.Update(It.IsAny<HippotherapyProgram>()));
 
-        _repositoryWrapperMock
+        _repo
             .Setup(r => r.SaveChangesAsync())
-            .ReturnsAsync(saveResult);
+            .ReturnsAsync(saveChanges);
+    }
+
+    private void SetUpValidatorToThrow(string message)
+    {
+        _validator.Reset();
+
+        var failures = new List<ValidationFailure>
+        {
+            new("UpdateProgramDto.Name", message)
+        };
+
+        var ex = new ValidationException(failures);
+
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<UpdateHippotherapyProgramCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(ex);
+
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<UpdateHippotherapyProgramCommand>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(ex);
+    }
+
+    private static UpdateHippotherapyProgramCommand Command(long id, UpdateHippotherapyProgramDto dto) => new(dto, id);
+
+    private static UpdateHippotherapyProgramDto Dto(
+        string name = "Name",
+        string description = "Description",
+        Status status = Status.Published,
+        long? backgroundImageId = 1,
+        long? previewImageId = 2,
+        List<long>? categoryIds = null,
+        List<CreateHippotherapyProgramSectionDto>? sections = null)
+    {
+        return new UpdateHippotherapyProgramDto
+        {
+            Name = name,
+            Description = description,
+            Status = status,
+            BackgroundImageId = backgroundImageId,
+            PreviewImageId = previewImageId,
+            CategoryIds = categoryIds ?? [1, 2],
+            Sections = sections ?? []
+        };
+    }
+
+    private static HippotherapyProgram Program(
+        ICollection<HippotherapyProgramCategory>? categories = null,
+        ICollection<HippotherapyProgramSection>? sections = null)
+    {
+        return new HippotherapyProgram
+        {
+            Id = 1,
+            Name = "Old",
+            Description = "OldDesc",
+            Status = Status.Published,
+            BackgroundImageId = 1,
+            PreviewImageId = 2,
+            Categories = categories ?? [],
+            Sections = sections ?? []
+        };
+    }
+
+    private static CreateHippotherapyProgramSectionDto CreateSection(int order, params CreateProgramSectionContentDto[] contents)
+    {
+        return new CreateHippotherapyProgramSectionDto
+        {
+            Template = default,
+            Order = order,
+            Contents = [.. contents]
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateImageContent(int order, long imageId)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Image,
+            Order = order,
+            ImageId = imageId
+        };
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -135,7 +135,9 @@ public class UpdateHippotherapyProgramTests
 
         var result = await sut.Handle(Command(id: 1, dto: Dto(categoryIds: [1, 2])), CancellationToken.None);
 
-        Assert.Contains(nameof(HippotherapyProgramCategory), result.Errors.Select(e => e.Message));
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(2, typeof(HippotherapyProgramCategory)),
+            result.Errors.Select(e => e.Message));
     }
 
     [Fact]
@@ -145,7 +147,9 @@ public class UpdateHippotherapyProgramTests
 
         var result = await sut.Handle(Command(id: 1, dto: Dto(backgroundImageId: 999)), CancellationToken.None);
 
-        Assert.Contains(nameof(Image), result.Errors.Select(e => e.Message));
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(999, typeof(Image)),
+            result.Errors.Select(e => e.Message));
     }
 
     [Fact]
@@ -155,7 +159,9 @@ public class UpdateHippotherapyProgramTests
 
         var result = await sut.Handle(Command(id: 1, dto: Dto(previewImageId: 999)), CancellationToken.None);
 
-        Assert.Contains(nameof(Image), result.Errors.Select(e => e.Message));
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(999, typeof(Image)),
+            result.Errors.Select(e => e.Message));
     }
 
     [Fact]
@@ -177,7 +183,7 @@ public class UpdateHippotherapyProgramTests
 
         var result = await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        Assert.Contains(nameof(Image), result.Errors.Select(e => e.Message));
+        Assert.Contains(result.Errors.Select(e => e.Message), m => m.Contains("Image") && m.Contains("'2'"));
     }
 
     [Fact]
@@ -185,7 +191,9 @@ public class UpdateHippotherapyProgramTests
     {
         var sut = CreateSut(program: Program(), saveChanges: 1);
 
-        var result = await sut.Handle(Command(id: 1, dto: Dto(backgroundImageId: null, previewImageId: null)), CancellationToken.None);
+        var result = await sut.Handle(
+            Command(id: 1, dto: Dto(status: Status.Draft, backgroundImageId: null, previewImageId: null)),
+            CancellationToken.None);
 
         Assert.True(result.IsSuccess);
     }
@@ -193,28 +201,12 @@ public class UpdateHippotherapyProgramTests
     [Fact]
     public async Task Handle_ValidatorReturnsErrors_ReturnsFailed()
     {
-        var sut = CreateSut(
-            program: Program(),
-            saveChanges: 1,
-            validatorErrors:
-            [
-                new ValidationFailure("UpdateProgramDto.Name", "Name required")
-            ]);
-
-        var result = await sut.Handle(Command(id: 1, dto: Dto()), CancellationToken.None);
-
-        Assert.Contains("Name required", result.Errors.Select(e => e.Message));
-    }
-
-    [Fact]
-    public async Task Handle_ValidatorThrows_ReturnsValidationError()
-    {
         var sut = CreateSut(program: Program(), saveChanges: 1);
         SetUpValidatorToThrow("Name required");
 
         var result = await sut.Handle(Command(id: 1, dto: Dto()), CancellationToken.None);
 
-        Assert.Contains("Name required", result.Errors.Select(e => e.Message));
+        Assert.Contains(result.Errors.Select(e => e.Message), m => m.Contains("Name required"));
     }
 
     [Fact]
@@ -249,10 +241,9 @@ public class UpdateHippotherapyProgramTests
         HippotherapyProgram? program,
         int saveChanges,
         List<HippotherapyProgramCategory>? categories = null,
-        List<Image>? images = null,
-        List<ValidationFailure>? validatorErrors = null)
+        List<Image>? images = null)
     {
-        SetUpValidator(validatorErrors);
+        SetUpValidatorSuccess();
         SetUpMapper();
         SetUpRepositories(program, saveChanges, categories ?? Categories, images ?? Images);
         SetUpSlugService();
@@ -260,21 +251,19 @@ public class UpdateHippotherapyProgramTests
         return new UpdateHippotherapyProgramHandler(_mapper.Object, _repo.Object, _validator.Object, _slugService.Object);
     }
 
-    private void SetUpValidator(List<ValidationFailure>? failures)
+    private void SetUpValidatorSuccess()
     {
         _validator.Reset();
 
-        var result = failures is null
-            ? new ValidationResult()
-            : new ValidationResult(failures);
+        var ok = new ValidationResult();
 
         _validator
             .Setup(v => v.ValidateAsync(It.IsAny<UpdateHippotherapyProgramCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync(ok);
 
         _validator
             .Setup(v => v.ValidateAsync(It.IsAny<ValidationContext<UpdateHippotherapyProgramCommand>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(result);
+            .ReturnsAsync(ok);
     }
 
     private void SetUpMapper()

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
@@ -227,10 +227,8 @@ public class BaseHippotherapyProgramSectionValidatorTests
     [Fact]
     public void Validate_DualTitleDescriptionPairs_GroupIndexIsMissing_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs) with
-        {
-            Contents = [.. GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs).Contents.Select(c => c with { GroupIndex = null })]
-        };
+        var model = GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs);
+        model.Contents = [.. model.Contents.Select(c => c with { GroupIndex = null })];
 
         var result = _validator.TestValidate(model);
 
@@ -301,11 +299,8 @@ public class BaseHippotherapyProgramSectionValidatorTests
     [Fact]
     public void Validate_Template12_GroupIndexIsMissing_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs) with
-        {
-            Contents = [.. GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs).Contents.Select(c =>
-                c.ContentType == ContentType.Title ? c : c with { GroupIndex = null })]
-        };
+        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs);
+        model.Contents = [.. model.Contents.Select(c => c.ContentType == ContentType.Title ? c : c with { GroupIndex = null })];
 
         var result = _validator.TestValidate(model);
 
@@ -352,7 +347,6 @@ public class BaseHippotherapyProgramSectionValidatorTests
         if (req.Grouping is null)
         {
             AddUngroupedContents(req, contents, ref order);
-
             return BuildSectionDto(template, contents);
         }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
@@ -46,18 +46,17 @@ public class BaseHippotherapyProgramSectionValidatorTests
     }
 
     [Fact]
-    public void Validate_ContentsIsNull_ShouldHaveError()
+    public void Validate_ContentsIsEmpty_ShouldHaveError()
     {
         var model = GetValidModel(ProgramSectionTemplate.TextOnly) with
         {
-            Contents = null!
+            Contents = []
         };
 
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Contents)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(
-                nameof(CreateHippotherapyProgramSectionDto.Contents)));
+            .WithErrorMessage(HippotherapyProgramSectionConstants.GetTitlesCountErrorMessage(model));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
@@ -46,16 +46,31 @@ public class BaseHippotherapyProgramSectionValidatorTests
     }
 
     [Fact]
-    public void Validate_TitlesCountIsInvalid_ShouldHaveError()
+    public void Validate_ContentsIsNull_ShouldHaveError()
     {
         var model = GetValidModel(ProgramSectionTemplate.TextOnly) with
         {
-            Titles = []
+            Contents = null!
         };
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor(x => x.Titles)
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(CreateHippotherapyProgramSectionDto.Contents)));
+    }
+
+    [Fact]
+    public void Validate_TitlesCountIsInvalid_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.TextOnly) with
+        {
+            Contents = []
+        };
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
             .WithErrorMessage(HippotherapyProgramSectionConstants.GetTitlesCountErrorMessage(model));
     }
 
@@ -63,37 +78,49 @@ public class BaseHippotherapyProgramSectionValidatorTests
     public void Validate_TitleItemIsEmpty_ShouldHaveError()
     {
         var model = GetValidModel(ProgramSectionTemplate.TextOnly);
-        model.Titles[0] = "";
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Title);
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = ""
+        });
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor("Titles[0]")
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateHippotherapyProgramSectionDto.Titles)));
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Title)));
     }
 
     [Fact]
     public void Validate_TitleItemIsTooShort_ShouldHaveError()
     {
         var model = GetValidModel(ProgramSectionTemplate.TextOnly);
-        model.Titles[0] = new string('T', HippotherapyProgramSectionConstants.GetRequirements(model.Template).TitleLength.Min - 1);
+        var min = HippotherapyProgramSectionConstants.GetRequirements(model.Template).TitleLength.Min;
+
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Title);
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = new string('T', min - 1)
+        });
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor("Titles[0]")
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
             .WithErrorMessage(HippotherapyProgramSectionConstants.GetTitleLengthErrorMessage(model));
     }
 
     [Fact]
     public void Validate_DescriptionsCountIsInvalid_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.TextOnly) with
-        {
-            Descriptions = []
-        };
+        var model = GetValidModel(ProgramSectionTemplate.TextOnly);
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Description);
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor(x => x.Descriptions)
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
             .WithErrorMessage(HippotherapyProgramSectionConstants.GetDescriptionsCountErrorMessage(model));
     }
 
@@ -101,68 +128,123 @@ public class BaseHippotherapyProgramSectionValidatorTests
     public void Validate_DescriptionItemIsEmpty_ShouldHaveError()
     {
         var model = GetValidModel(ProgramSectionTemplate.TextOnly);
-        model.Descriptions[0] = " ";
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Description);
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Description,
+            Order = 1,
+            Description = " "
+        });
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor("Descriptions[0]")
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateHippotherapyProgramSectionDto.Descriptions)));
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Description)));
     }
 
     [Fact]
     public void Validate_DescriptionItemIsTooShort_ShouldHaveError()
     {
         var model = GetValidModel(ProgramSectionTemplate.TextOnly);
-        model.Descriptions[0] = new string('D', HippotherapyProgramSectionConstants.GetRequirements(model.Template).DescriptionLength.Min - 1);
+        var min = HippotherapyProgramSectionConstants.GetRequirements(model.Template).DescriptionLength.Min;
+
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Description);
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Description,
+            Order = 1,
+            Description = new string('D', min - 1)
+        });
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor("Descriptions[0]")
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
             .WithErrorMessage(HippotherapyProgramSectionConstants.GetDescriptionLengthErrorMessage(model));
     }
 
     [Fact]
-    public void Validate_ImageIdsCountIsInvalid_ShouldHaveError()
+    public void Validate_ImagesCountIsInvalid_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.TextOnly) with
+        var model = GetValidModel(ProgramSectionTemplate.TextOnly);
+        model.Contents.Add(new CreateProgramSectionContentDto
         {
-            ImageIds = [1]
-        };
+            ContentType = ContentType.Image,
+            Order = 2,
+            ImageId = 1
+        });
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor(x => x.ImageIds)
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
             .WithErrorMessage(HippotherapyProgramSectionConstants.GetImagesCountErrorMessage(model));
     }
 
     [Fact]
     public void Validate_ImageIdsContainDuplicates_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.DualImagesBottom) with
+        var model = GetValidModel(ProgramSectionTemplate.DualImagesBottom);
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Image);
+
+        model.Contents.Add(new CreateProgramSectionContentDto
         {
-            ImageIds = [1, 1]
-        };
+            ContentType = ContentType.Image,
+            Order = 2,
+            ImageId = 1
+        });
+
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Image,
+            Order = 3,
+            ImageId = 1
+        });
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor(x => x.ImageIds)
-            .WithErrorMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
-                nameof(CreateHippotherapyProgramSectionDto.ImageIds)));
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateProgramSectionContentDto.ImageId)));
     }
 
     [Fact]
     public void Validate_ImageIdIsNotPositive_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.DualImagesBottom) with
+        var model = GetValidModel(ProgramSectionTemplate.DualImagesBottom);
+        model.Contents.RemoveAll(c => c.ContentType == ContentType.Image);
+
+        model.Contents.Add(new CreateProgramSectionContentDto
         {
-            ImageIds = [0, 2]
+            ContentType = ContentType.Image,
+            Order = 2,
+            ImageId = 0
+        });
+
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Image,
+            Order = 3,
+            ImageId = 2
+        });
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateProgramSectionContentDto.ImageId)));
+    }
+
+    [Fact]
+    public void Validate_DualTitleDescriptionPairs_GroupIndexIsMissing_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs);
+
+        model = model with
+        {
+            Contents = [.. model.Contents.Select(c => c with { GroupIndex = null })]
         };
 
         var result = _validator.TestValidate(model);
 
-        result.ShouldHaveValidationErrorFor("ImageIds[0]")
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive(
-                nameof(CreateHippotherapyProgramSectionDto.ImageIds)));
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(HippotherapyProgramSectionConstants.GetGroupIndexRequiredErrorMessage(model));
     }
 
     [Fact]
@@ -178,16 +260,69 @@ public class BaseHippotherapyProgramSectionValidatorTests
     private static CreateHippotherapyProgramSectionDto GetValidModel(ProgramSectionTemplate template)
     {
         var req = HippotherapyProgramSectionConstants.GetRequirements(template);
+        var contents = new List<CreateProgramSectionContentDto>();
+        var order = 0;
+
+        for (var i = 0; i < req.TitleCount.Min; i++)
+        {
+            contents.Add(new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Title,
+                Order = order++,
+                Title = new string('T', req.TitleLength.Min)
+            });
+        }
+
+        for (var i = 0; i < req.DescriptionCount.Min; i++)
+        {
+            contents.Add(new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Description,
+                Order = order++,
+                Description = new string('D', req.DescriptionLength.Min)
+            });
+        }
+
+        for (var i = 0; i < req.ImageCount.Min; i++)
+        {
+            contents.Add(new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Image,
+                Order = order++,
+                ImageId = i + 1
+            });
+        }
+
+        if (req.Grouping is not null)
+        {
+            contents.Clear();
+            order = 0;
+
+            for (var g = 0; g < req.Grouping.GroupCount.Min; g++)
+            {
+                contents.Add(new CreateProgramSectionContentDto
+                {
+                    ContentType = ContentType.Title,
+                    Order = order++,
+                    GroupIndex = g,
+                    Title = new string('T', req.TitleLength.Min)
+                });
+
+                contents.Add(new CreateProgramSectionContentDto
+                {
+                    ContentType = ContentType.Description,
+                    Order = order++,
+                    GroupIndex = g,
+                    Description = new string('D', req.DescriptionLength.Min)
+                });
+            }
+        }
 
         return new CreateHippotherapyProgramSectionDto
         {
             Template = template,
             Order = 0,
-            Titles = [.. Enumerable.Range(1, req.TitleCount.Min).Select(_ => new string('T', req.TitleLength.Min))],
-            Descriptions = [.. Enumerable.Range(1, req.DescriptionCount.Min).Select(_ => new string('D', req.DescriptionLength.Min))],
-            ImageIds = req.ImageCount.Min == 0
-                ? []
-                : [.. Enumerable.Range(1, req.ImageCount.Min).Select(i => (long)i)]
+            Contents = contents
         };
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
@@ -8,12 +8,7 @@ namespace VictoryCenter.UnitTests.ValidatorsTests.HippotherapyProgramSections;
 
 public class BaseHippotherapyProgramSectionValidatorTests
 {
-    private readonly BaseHippotherapyProgramSectionValidator _validator;
-
-    public BaseHippotherapyProgramSectionValidatorTests()
-    {
-        _validator = new BaseHippotherapyProgramSectionValidator();
-    }
+    private readonly BaseHippotherapyProgramSectionValidator _validator = new();
 
     [Fact]
     public void Validate_TemplateIsInvalid_ShouldHaveError()
@@ -26,8 +21,7 @@ public class BaseHippotherapyProgramSectionValidatorTests
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Template)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeValidEnum(
-                nameof(CreateHippotherapyProgramSectionDto.Template)));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(CreateHippotherapyProgramSectionDto.Template)));
     }
 
     [Fact]
@@ -41,22 +35,7 @@ public class BaseHippotherapyProgramSectionValidatorTests
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Order)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan(
-                nameof(CreateHippotherapyProgramSectionDto.Order), -1));
-    }
-
-    [Fact]
-    public void Validate_ContentsIsEmpty_ShouldHaveError()
-    {
-        var model = GetValidModel(ProgramSectionTemplate.TextOnly) with
-        {
-            Contents = []
-        };
-
-        var result = _validator.TestValidate(model);
-
-        result.ShouldHaveValidationErrorFor(x => x.Contents)
-            .WithErrorMessage(HippotherapyProgramSectionConstants.GetTitlesCountErrorMessage(model));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan(nameof(CreateHippotherapyProgramSectionDto.Order), -1));
     }
 
     [Fact]
@@ -231,19 +210,127 @@ public class BaseHippotherapyProgramSectionValidatorTests
     }
 
     [Fact]
+    public void Validate_OrdersContainDuplicates_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.TextOnly);
+        var description = model.Contents.First(c => c.ContentType == ContentType.Description);
+
+        model.Contents.Remove(description);
+        model.Contents.Add(description with { Order = 0 });
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateProgramSectionContentDto.Order)));
+    }
+
+    [Fact]
     public void Validate_DualTitleDescriptionPairs_GroupIndexIsMissing_ShouldHaveError()
     {
-        var model = GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs);
-
-        model = model with
+        var model = GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs) with
         {
-            Contents = [.. model.Contents.Select(c => c with { GroupIndex = null })]
+            Contents = [.. GetValidModel(ProgramSectionTemplate.DualTitleDescriptionPairs).Contents.Select(c => c with { GroupIndex = null })]
         };
 
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Contents)
             .WithErrorMessage(HippotherapyProgramSectionConstants.GetGroupIndexRequiredErrorMessage(model));
+    }
+
+    [Fact]
+    public void Validate_TextOnly_WithAuthor_ShouldHaveAuthorsCountError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.TextOnly);
+        var maxOrder = model.Contents.Max(c => c.Order);
+
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Author,
+            Order = maxOrder + 1,
+            Author = "Author"
+        });
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(HippotherapyProgramSectionConstants.GetAuthorsCountErrorMessage(model));
+    }
+
+    [Fact]
+    public void Validate_Template12_ValidModel_ShouldNotHaveErrors()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs);
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_Template12_AuthorIsEmpty_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs);
+        var author = model.Contents.First(c => c.ContentType == ContentType.Author);
+
+        model.Contents.Remove(author);
+        model.Contents.Add(author with { Author = " " });
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateProgramSectionContentDto.Author)));
+    }
+
+    [Fact]
+    public void Validate_Template12_AuthorIsTooShort_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs);
+        var min = HippotherapyProgramSectionConstants.GetRequirements(model.Template).AuthorLength.Min;
+        var author = model.Contents.First(c => c.ContentType == ContentType.Author);
+
+        model.Contents.Remove(author);
+        model.Contents.Add(author with { Author = new string('A', min - 1) });
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(HippotherapyProgramSectionConstants.GetAuthorLengthErrorMessage(model));
+    }
+
+    [Fact]
+    public void Validate_Template12_GroupIndexIsMissing_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs) with
+        {
+            Contents = [.. GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs).Contents.Select(c =>
+                c.ContentType == ContentType.Title ? c : c with { GroupIndex = null })]
+        };
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(HippotherapyProgramSectionConstants.GetGroupIndexRequiredErrorMessage(model));
+    }
+
+    [Fact]
+    public void Validate_Template12_GroupCompositionIsInvalid_ShouldHaveError()
+    {
+        var model = GetValidModel(ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs);
+        var maxOrder = model.Contents.Max(c => c.Order);
+
+        model.Contents.Add(new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Author,
+            Order = maxOrder + 1,
+            GroupIndex = 0,
+            Author = "Extra author"
+        });
+
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(x => x.Contents)
+            .WithErrorMessage(HippotherapyProgramSectionConstants.GetGroupCompositionErrorMessage(model));
     }
 
     [Fact]
@@ -262,6 +349,165 @@ public class BaseHippotherapyProgramSectionValidatorTests
         var contents = new List<CreateProgramSectionContentDto>();
         var order = 0;
 
+        if (req.Grouping is null)
+        {
+            AddUngroupedContents(req, contents, ref order);
+
+            return BuildSectionDto(template, contents);
+        }
+
+        AddUngroupedNonGroupedTypes(req, contents, ref order);
+        AddGroupedContents(req, contents, ref order);
+
+        return BuildSectionDto(template, contents);
+    }
+
+    private static CreateHippotherapyProgramSectionDto BuildSectionDto(
+        ProgramSectionTemplate template,
+        List<CreateProgramSectionContentDto> contents)
+    {
+        return new CreateHippotherapyProgramSectionDto
+        {
+            Template = template,
+            Order = 0,
+            Contents = contents
+        };
+    }
+
+    private static void AddUngroupedContents(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
+        AddTitles(req, contents, ref order);
+        AddDescriptions(req, contents, ref order);
+        AddImages(req, contents, ref order);
+        AddAuthors(req, contents, ref order);
+    }
+
+    private static void AddUngroupedNonGroupedTypes(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
+        var groupedTypes = GetGroupedTypes(req);
+
+        if (!groupedTypes.Contains(ContentType.Title))
+        {
+            AddTitles(req, contents, ref order);
+        }
+
+        if (!groupedTypes.Contains(ContentType.Description))
+        {
+            AddDescriptions(req, contents, ref order);
+        }
+
+        if (!groupedTypes.Contains(ContentType.Image))
+        {
+            AddImages(req, contents, ref order);
+        }
+
+        if (!groupedTypes.Contains(ContentType.Author))
+        {
+            AddAuthors(req, contents, ref order);
+        }
+    }
+
+    private static HashSet<ContentType> GetGroupedTypes(HippotherapyProgramSectionConstants.TemplateRequirementsConfig req)
+    {
+        return [.. req.Grouping!.PerGroupCounts.Keys];
+    }
+
+    private static void AddGroupedContents(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
+        for (var g = 0; g < req.Grouping!.GroupCount.Min; g++)
+        {
+            AddGroupedByType(req, contents, ref order, ContentType.Title, g);
+            AddGroupedByType(req, contents, ref order, ContentType.Description, g);
+            AddGroupedByType(req, contents, ref order, ContentType.Image, g);
+            AddGroupedByType(req, contents, ref order, ContentType.Author, g);
+        }
+    }
+
+    private static void AddGroupedByType(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order,
+        ContentType type,
+        int groupIndex)
+    {
+        if (!req.Grouping!.PerGroupCounts.TryGetValue(type, out var count))
+        {
+            return;
+        }
+
+        for (var i = 0; i < count.Min; i++)
+        {
+            contents.Add(CreateGroupedContent(req, type, groupIndex, ref order));
+        }
+    }
+
+    private static CreateProgramSectionContentDto CreateGroupedContent(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        ContentType type,
+        int groupIndex,
+        ref int order)
+    {
+        if (type == ContentType.Title)
+        {
+            return new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Title,
+                Order = order++,
+                GroupIndex = groupIndex,
+                Title = new string('T', req.TitleLength.Min)
+            };
+        }
+
+        if (type == ContentType.Description)
+        {
+            return new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Description,
+                Order = order++,
+                GroupIndex = groupIndex,
+                Description = new string('D', req.DescriptionLength.Min)
+            };
+        }
+
+        if (type == ContentType.Image)
+        {
+            return new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Image,
+                Order = order++,
+                GroupIndex = groupIndex,
+                ImageId = 1
+            };
+        }
+
+        if (type == ContentType.Author)
+        {
+            return new CreateProgramSectionContentDto
+            {
+                ContentType = ContentType.Author,
+                Order = order++,
+                GroupIndex = groupIndex,
+                Author = new string('A', Math.Max(req.AuthorLength.Min, 1))
+            };
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(type), type, null);
+    }
+
+    private static void AddTitles(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
         for (var i = 0; i < req.TitleCount.Min; i++)
         {
             contents.Add(new CreateProgramSectionContentDto
@@ -271,7 +517,13 @@ public class BaseHippotherapyProgramSectionValidatorTests
                 Title = new string('T', req.TitleLength.Min)
             });
         }
+    }
 
+    private static void AddDescriptions(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
         for (var i = 0; i < req.DescriptionCount.Min; i++)
         {
             contents.Add(new CreateProgramSectionContentDto
@@ -281,7 +533,13 @@ public class BaseHippotherapyProgramSectionValidatorTests
                 Description = new string('D', req.DescriptionLength.Min)
             });
         }
+    }
 
+    private static void AddImages(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
         for (var i = 0; i < req.ImageCount.Min; i++)
         {
             contents.Add(new CreateProgramSectionContentDto
@@ -291,37 +549,21 @@ public class BaseHippotherapyProgramSectionValidatorTests
                 ImageId = i + 1
             });
         }
+    }
 
-        if (req.Grouping is not null)
+    private static void AddAuthors(
+        HippotherapyProgramSectionConstants.TemplateRequirementsConfig req,
+        List<CreateProgramSectionContentDto> contents,
+        ref int order)
+    {
+        for (var i = 0; i < req.AuthorCount.Min; i++)
         {
-            contents.Clear();
-            order = 0;
-
-            for (var g = 0; g < req.Grouping.GroupCount.Min; g++)
+            contents.Add(new CreateProgramSectionContentDto
             {
-                contents.Add(new CreateProgramSectionContentDto
-                {
-                    ContentType = ContentType.Title,
-                    Order = order++,
-                    GroupIndex = g,
-                    Title = new string('T', req.TitleLength.Min)
-                });
-
-                contents.Add(new CreateProgramSectionContentDto
-                {
-                    ContentType = ContentType.Description,
-                    Order = order++,
-                    GroupIndex = g,
-                    Description = new string('D', req.DescriptionLength.Min)
-                });
-            }
+                ContentType = ContentType.Author,
+                Order = order++,
+                Author = new string('A', Math.Max(req.AuthorLength.Min, 1))
+            });
         }
-
-        return new CreateHippotherapyProgramSectionDto
-        {
-            Template = template,
-            Order = 0,
-            Contents = contents
-        };
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyPrograms/CreateHippotherapyProgramValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyPrograms/CreateHippotherapyProgramValidatorTests.cs
@@ -32,7 +32,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.Name)
             .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(HippotherapyProgramDto.Name)));
     }
@@ -51,7 +53,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.Name)
             .WithErrorMessage(
                 ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
@@ -63,6 +67,7 @@ public class CreateHippotherapyProgramValidatorTests
     public void Validate_ShouldHaveError_WhenNameIsTooLong()
     {
         var name = new string('a', HippotherapyProgramConstants.MaxNameLength + 1);
+
         var command = new CreateHippotherapyProgramCommand(new CreateHippotherapyProgramDto
         {
             Name = name,
@@ -70,7 +75,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.Name)
             .WithErrorMessage(
                 ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
@@ -88,7 +95,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldNotHaveValidationErrorFor(p => p.CreateProgramDto.Name);
     }
 
@@ -107,8 +116,11 @@ public class CreateHippotherapyProgramValidatorTests
             BackgroundImageId = 1,
             PreviewImageId = 1
         };
+
         var command = new CreateHippotherapyProgramCommand(createProgramDto);
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(HippotherapyProgramDto.Description)));
     }
@@ -132,19 +144,19 @@ public class CreateHippotherapyProgramValidatorTests
                 PreviewImageId = 1
             });
 
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+        var result = _validator.TestValidate(command);
 
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.Description)
-            .WithErrorMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMinimumLengthOfNCharacters(
-                    nameof(HippotherapyProgramDto.Description),
-                    HippotherapyProgramConstants.MinDescriptionLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(HippotherapyProgramDto.Description),
+                HippotherapyProgramConstants.MinDescriptionLength));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
         var description = new string('a', HippotherapyProgramConstants.MaxDescriptionLength + 1);
+
         var command = new CreateHippotherapyProgramCommand(new CreateHippotherapyProgramDto
         {
             Name = "ValidName",
@@ -152,12 +164,13 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.Description)
-            .WithErrorMessage(ErrorMessagesConstants
-                .PropertyMustHaveAMaximumLengthOfNCharacters(
-                    nameof(HippotherapyProgramDto.Description),
-                    HippotherapyProgramConstants.MaxDescriptionLength));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(HippotherapyProgramDto.Description),
+                HippotherapyProgramConstants.MaxDescriptionLength));
     }
 
     [Fact]
@@ -170,7 +183,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldNotHaveValidationErrorFor(p => p.CreateProgramDto.Description);
     }
 
@@ -184,7 +199,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = []
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldHaveValidationErrorFor(p => p.CreateProgramDto.CategoryIds)
             .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(HippotherapyProgramDto.Categories)));
     }
@@ -199,7 +216,9 @@ public class CreateHippotherapyProgramValidatorTests
             Status = Status.Draft,
             CategoryIds = [1, 2, 3]
         });
-        TestValidationResult<CreateHippotherapyProgramCommand> result = _validator.TestValidate(command);
+
+        var result = _validator.TestValidate(command);
+
         result.ShouldNotHaveValidationErrorFor(p => p.CreateProgramDto.CategoryIds);
     }
 
@@ -218,9 +237,22 @@ public class CreateHippotherapyProgramValidatorTests
                 {
                     Template = ProgramSectionTemplate.TextOnly,
                     Order = -1,
-                    Titles = ["ValidTitle"],
-                    Descriptions = ["ValidDescription"],
-                    ImageIds = []
+                    Contents =
+                    [
+                        new CreateProgramSectionContentDto
+                        {
+                            ContentType = ContentType.Title,
+                            Order = 0,
+                            Title = "ValidTitle"
+                        },
+                        new CreateProgramSectionContentDto
+                        {
+                            ContentType = ContentType.Description,
+                            Order = 1,
+                            Description = "ValidDescription"
+                        }
+
+                    ]
                 }
 
             ]


### PR DESCRIPTION
## GitHub Tickets

### This PR includes the following tasks:
* **#1132**
* **#1131**
* **#1130**

## Summary of change
Implemented backend support for multi-template program sections. Expanded the ProgramSectionTemplate enum and added a GroupIndex field to the content model to support title-description pairs. Updated MediatR handlers, AutoMapper profiles, and validators to ensure correct persistence.

Key changes:
- Data Model: Added GroupIndex field to the program section content to support grouped title-description pairs.
- Constants: Defined TemplateRequirementsConfig and validation rules for new frames.
- Validation: Updated Validator to support conditional validation based on template type and grouping logic.
- MediatR: Modified commands and handlers to process and persist structured section content correctly.
- AutoMapper: Updated mapping profiles to handle the new GroupIndex field and section-to-DTO transformations.
- Testing: Added unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New section templates and an Author content type.
  * Sections now use a unified, ordered Contents list (titles, descriptions, images, authors) with optional group index.

* **Improvements**
  * Grouping support with per-group constraints and clearer validation/error messages for counts, lengths, and composition.
  * Better ordering, trimming, and skipping of missing/invalid images during section creation; expanded test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->