### PR TITLE
fix: add Swift validation only digits or letters for Correspondent and Foreign bank details

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/CorrespondentBankDetailsConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/CorrespondentBankDetailsConstants.cs
@@ -4,6 +4,8 @@ public static class CorrespondentBankDetailsConstants
 {
     public static readonly int NameMaxLength = 200;
     public static readonly int AccountMaxLength = 20;
+    public static readonly string SwiftExpression = @"^[a-zA-Z0-9]+$";
+    public static readonly string SwiftMustContainOnlyLettersAndDigits = "Swift code must contain only letters and digits";
     public static class Swift
     {
         public static readonly int MaxLength = 11;

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ForeignBankDetailsConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ForeignBankDetailsConstants.cs
@@ -5,6 +5,8 @@ public static class ForeignBankDetailsConstants
     public static readonly string OnlyUsdOrEurMessage = "Currency must be USD or EUR";
     public static readonly string UkrainianIbanMustStartWithUaFollowedByDigits = "IBAN must start with UA followed by digits only";
     public static readonly string UahIbanExpression = @"^UA\d+$";
+    public static readonly string SwiftExpression = @"^[a-zA-Z0-9]+$";
+    public static readonly string SwiftMustContainOnlyLettersAndDigits = "Swift code must contain only letters and digits";
 
     public static readonly int NameMaxLength = 200;
     public static readonly int ReceiverMaxLength = 200;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Donate/CorrespondentBankDetails/BaseCorrespondentBankDetailsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Donate/CorrespondentBankDetails/BaseCorrespondentBankDetailsDtoValidator.cs
@@ -21,7 +21,9 @@ public class BaseCorrespondentBankDetailsDtoValidator : AbstractValidator<BaseCo
             .WithMessage(ErrorMessagesConstants
                 .PropertyMustHaveAMinimumLengthOfNCharacters(
                     nameof(CorrespondentBankDetailsDto.Swift),
-                    CorrespondentBankDetailsConstants.Swift.MinLength));
+                    CorrespondentBankDetailsConstants.Swift.MinLength))
+            .Matches(CorrespondentBankDetailsConstants.SwiftExpression)
+            .WithMessage(CorrespondentBankDetailsConstants.SwiftMustContainOnlyLettersAndDigits);
 
         RuleFor(dto => dto.ForeignIban)
             .MaximumLength(CorrespondentBankDetailsConstants.ForeignIban.MaxLength)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Donate/ForeignBankDetails/BaseForeignBankDetailsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Donate/ForeignBankDetails/BaseForeignBankDetailsDtoValidator.cs
@@ -20,7 +20,9 @@ public class BaseForeignBankDetailsDtoValidator : AbstractValidator<BaseForeignB
             .WithMessage(ErrorMessagesConstants
                 .PropertyMustHaveAMinimumLengthOfNCharacters(
                     nameof(ForeignBankDetailsDto.Swift),
-                    ForeignBankDetailsConstants.Swift.MinLength));
+                    ForeignBankDetailsConstants.Swift.MinLength))
+            .Matches(ForeignBankDetailsConstants.SwiftExpression)
+            .WithMessage(ForeignBankDetailsConstants.SwiftMustContainOnlyLettersAndDigits);
 
         RuleFor(dto => dto.UkrainianIban)
             .NotEmpty()


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/orgs/ita-social-projects/projects/64/views/18?sliceBy%5Bvalue%5D=L1ght1234&pane=issue&itemId=146250706&issue=ita-social-projects%7CVictoryCenter-Back%7C1069)

## Summary of change

added Swift validation for Correspondent and Foreign bank details

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Swift code validation now enforces alphanumeric-only format with improved error messaging when invalid codes are entered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->