### PR TITLE
Fixed background image in HippotherapyPrograms returning null on GET request

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyPrograms/GetByFilters/GetHippotherapyProgramsByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyPrograms/GetByFilters/GetHippotherapyProgramsByFiltersHandler.cs
@@ -38,6 +38,7 @@ public class GetHippotherapyProgramsByFiltersHandler : IRequestHandler<GetHippot
             Limit = request.RequestDto?.Limit is > 0 ? (int)request.RequestDto.Limit : 0,
             Filter = filter,
             Include = program => program
+                .Include(p => p.BackgroundImage)
                 .Include(p => p.PreviewImage)
                 .Include(p => p.Categories)
         };

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/HippotherapyProgramsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/HippotherapyProgramsController.cs
@@ -4,7 +4,6 @@ using VictoryCenter.BLL.Commands.Admin.HippotherapyPrograms.Delete;
 using VictoryCenter.BLL.Commands.Admin.HippotherapyPrograms.Update;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 using VictoryCenter.BLL.DTOs.Common;
-using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.BLL.Queries.Admin.HippotherapyPrograms.GetByFilters;
 using VictoryCenter.BLL.Queries.Admin.HippotherapyPrograms.GetById;
 using VictoryCenter.BLL.Queries.Admin.HippotherapyPrograms.Search;
@@ -14,13 +13,6 @@ namespace VictoryCenter.WebAPI.Controllers.Admin;
 
 public class HippotherapyProgramsController : AuthorizedApiController
 {
-    private readonly ISlugService _slugService;
-
-    public HippotherapyProgramsController(ISlugService slugService)
-    {
-        _slugService = slugService;
-    }
-
     [HttpGet]
     public async Task<IActionResult> GetFilteredPrograms([FromQuery] HippotherapyProgramsFilterDto requestDto)
     {
@@ -59,12 +51,5 @@ public class HippotherapyProgramsController : AuthorizedApiController
     public async Task<IActionResult> GetProgram([FromRoute] long id)
     {
         return HandleResult(await Mediator.Send(new GetHippotherapyProgramByIdQuery(id)));
-    }
-
-    [HttpGet("test/slug")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(string))]
-    public IActionResult GenerateSlug([FromQuery] string name)
-    {
-        return Ok(_slugService.GenerateSlug(name));
     }
 }


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1265)

## Description

This PR fixes an issue where the background image was not loading when retrieving info about a program. The cause was a missing include for the background image in the data retrieval logic.

An unrelated unused test endpoint was also removed.

## How it works
previously backgroundImage was null 

<img width="763" height="315" alt="image" src="https://github.com/user-attachments/assets/1a14c7f6-a87a-467b-92c6-5d62eb82a9bd" />


## Summary of changes

1. Added background image to the include statement to ensure it is loaded during program GET request
2. Removed unused test endpoint that was no longer needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data loading efficiency for hippotherapy program retrieval.

* **Chores**
  * Removed unused internal dependencies and test endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->