### PR TITLE
Feature/issue 1053 - Add ability to filter by TranslationStatusFilter and also set outdated TranlationStatus after edit FAQ

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/FaqQuestions/Update/UpdateFaqQuestionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/FaqQuestions/Update/UpdateFaqQuestionHandler.cs
@@ -8,6 +8,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.FaqQuestions;
 using VictoryCenter.BLL.Interfaces.ReorderService;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -42,7 +43,10 @@ public class UpdateFaqQuestionHandler : IRequestHandler<UpdateFaqQuestionCommand
                 new QueryOptions<FaqQuestion>
                 {
                     Filter = entity => entity.Id == request.Id,
-                    Include = e => e.Include(q => q.Placements),
+                    Include = e => e
+                        .Include(q => q.Placements)
+                        .Include(q => q.Localizations)
+                            .ThenInclude(l => l.Language),
                 });
 
             if (entityToUpdate is null)
@@ -50,78 +54,82 @@ public class UpdateFaqQuestionHandler : IRequestHandler<UpdateFaqQuestionCommand
                 return Result.Fail<FaqQuestionDto>(ErrorMessagesConstants.NotFound(request.Id, typeof(FaqQuestion)));
             }
 
-            _mapper.Map(request.UpdateFaqQuestionDto, entityToUpdate);
-
-            using TransactionScope scope = _repositoryWrapper.BeginTransaction();
-
-            int affectedRows = 0;
-
-            _repositoryWrapper.FaqQuestionsRepository.Update(entityToUpdate);
-            affectedRows += await _repositoryWrapper.SaveChangesAsync();
-
-            var questionPlacements = entityToUpdate.Placements.ToList();
-            var allPageIds = (await _repositoryWrapper.VisitorPagesRepository.GetAllAsync()).Select(p => p.Id).ToList();
-            var existingPageIds = questionPlacements.Select(p => p.PageId).ToList();
-            var removedPageIds = existingPageIds.Except(request.UpdateFaqQuestionDto.PageIds).ToList();
-            var addedPageIds = request.UpdateFaqQuestionDto.PageIds.Except(existingPageIds).ToList();
-
-            if (removedPageIds.Count > 0)
+            using (TransactionScope scope = _repositoryWrapper.BeginTransaction())
             {
-                var deletedPlacements = questionPlacements.Where(p => removedPageIds.Contains(p.PageId)).ToList();
-                _repositoryWrapper.FaqPlacementsRepository.DeleteRange(deletedPlacements);
+                int affectedRows = 0;
+                SetTranslationsToOutdated(request, entityToUpdate);
+
+                _mapper.Map(request.UpdateFaqQuestionDto, entityToUpdate);
+
+                _repositoryWrapper.FaqQuestionsRepository.Update(entityToUpdate);
                 affectedRows += await _repositoryWrapper.SaveChangesAsync();
 
-                foreach (var pageId in removedPageIds)
+                var questionPlacements = entityToUpdate.Placements.ToList();
+                var allPageIds = (await _repositoryWrapper.VisitorPagesRepository.GetAllAsync()).Select(p => p.Id).ToList();
+                var existingPageIds = questionPlacements.Select(p => p.PageId).ToList();
+                var removedPageIds = existingPageIds.Except(request.UpdateFaqQuestionDto.PageIds).ToList();
+                var addedPageIds = request.UpdateFaqQuestionDto.PageIds.Except(existingPageIds).ToList();
+
+                if (removedPageIds.Count > 0)
                 {
-                    await _reorderService.RenumberPriorityAsync<FaqPlacement>(
-                        groupSelector: fp => fp.PageId == pageId);
-                }
+                    var deletedPlacements = questionPlacements.Where(p => removedPageIds.Contains(p.PageId)).ToList();
+                    _repositoryWrapper.FaqPlacementsRepository.DeleteRange(deletedPlacements);
+                    affectedRows += await _repositoryWrapper.SaveChangesAsync();
 
-                affectedRows += await _repositoryWrapper.SaveChangesAsync();
-            }
-
-            if (addedPageIds.Count > 0)
-            {
-                // Validate that all pages exist
-                var missingPageIds = addedPageIds.Except(allPageIds).ToList();
-                if (missingPageIds.Any())
-                {
-                    return Result.Fail<FaqQuestionDto>(FaqConstants.SomePagesNotFound);
-                }
-
-                var newPlacements = new List<FaqPlacement>();
-
-                foreach (var pageId in addedPageIds)
-                {
-                    var nextPriority = await _reorderService.GetNextDisplayOrderAsync<FaqPlacement>(fp => fp.PageId == pageId);
-                    var newPlacement = new FaqPlacement
+                    foreach (var pageId in removedPageIds)
                     {
-                        PageId = pageId,
-                        QuestionId = entityToUpdate.Id,
-                        Priority = nextPriority
-                    };
-                    newPlacements.Add(newPlacement);
+                        await _reorderService.RenumberPriorityAsync<FaqPlacement>(
+                            groupSelector: fp => fp.PageId == pageId);
+                    }
+
+                    affectedRows += await _repositoryWrapper.SaveChangesAsync();
                 }
 
-                await _repositoryWrapper.FaqPlacementsRepository.CreateRangeAsync(newPlacements);
-                affectedRows += await _repositoryWrapper.SaveChangesAsync();
-            }
-
-            if (affectedRows > 0)
-            {
-                FaqQuestion? resultEntity = await _repositoryWrapper.FaqQuestionsRepository.GetFirstOrDefaultAsync(
-                    new QueryOptions<FaqQuestion>
+                if (addedPageIds.Count > 0)
+                {
+                    // Validate that all pages exist
+                    var missingPageIds = addedPageIds.Except(allPageIds).ToList();
+                    if (missingPageIds.Any())
                     {
-                        Filter = entity => entity.Id == request.Id,
-                        Include = e => e.Include(q => q.Placements),
-                    });
+                        return Result.Fail<FaqQuestionDto>(FaqConstants.SomePagesNotFound);
+                    }
 
-                scope.Complete();
-                FaqQuestionDto? resultDto = _mapper.Map<FaqQuestion, FaqQuestionDto>(resultEntity!);
-                return Result.Ok(resultDto);
+                    var newPlacements = new List<FaqPlacement>();
+
+                    foreach (var pageId in addedPageIds)
+                    {
+                        var nextPriority = await _reorderService.GetNextDisplayOrderAsync<FaqPlacement>(fp => fp.PageId == pageId);
+                        var newPlacement = new FaqPlacement
+                        {
+                            PageId = pageId,
+                            QuestionId = entityToUpdate.Id,
+                            Priority = nextPriority
+                        };
+                        newPlacements.Add(newPlacement);
+                    }
+
+                    await _repositoryWrapper.FaqPlacementsRepository.CreateRangeAsync(newPlacements);
+                    affectedRows += await _repositoryWrapper.SaveChangesAsync();
+                }
+
+                if (affectedRows > 0)
+                {
+                    FaqQuestion? resultEntity = await _repositoryWrapper.FaqQuestionsRepository.GetFirstOrDefaultAsync(
+                        new QueryOptions<FaqQuestion>
+                        {
+                            Filter = entity => entity.Id == request.Id,
+                            Include = e => e.Include(q => q.Placements)
+                            .Include(q => q.Localizations)
+                                .ThenInclude(l => l.Language),
+                        });
+
+                    scope.Complete();
+                    FaqQuestionDto? resultDto = _mapper.Map<FaqQuestion, FaqQuestionDto>(resultEntity!);
+                    return Result.Ok(resultDto);
+                }
+
+                return Result.Fail<FaqQuestionDto>(ErrorMessagesConstants.FailedToUpdateEntity(typeof(FaqQuestion)));
             }
-
-            return Result.Fail<FaqQuestionDto>(ErrorMessagesConstants.FailedToUpdateEntity(typeof(FaqQuestion)));
         }
         catch (ValidationException vex)
         {
@@ -130,6 +138,18 @@ public class UpdateFaqQuestionHandler : IRequestHandler<UpdateFaqQuestionCommand
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException)
         {
             return Result.Fail<FaqQuestionDto>(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(FaqQuestion)));
+        }
+    }
+
+    private static void SetTranslationsToOutdated(UpdateFaqQuestionCommand request, FaqQuestion entityToUpdate)
+    {
+        if (!string.Equals(request.UpdateFaqQuestionDto.QuestionText, entityToUpdate.QuestionText) ||
+            !string.Equals(request.UpdateFaqQuestionDto.AnswerText, entityToUpdate.AnswerText))
+        {
+            foreach (var loc in entityToUpdate.Localizations)
+            {
+                loc.TranslationStatus = TranslationStatus.Outdated;
+            }
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/FaqQuestions/FaqQuestionsFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/FaqQuestions/FaqQuestionsFilterDto.cs
@@ -1,8 +1,12 @@
 using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+using VictoryCenter.BLL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.FaqQuestions;
 
-public record FaqQuestionsFilterDto : BaseFilterDto
+public record FaqQuestionsFilterDto : BaseFilterDto, ITranslationStatusFilterDto
 {
     public long? PageId { get; init; }
+
+    public TranslationStatusFilter? TranslationStatusFilter { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/FaqQuestions/GetByFilters/GetFaqQuestionsByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/FaqQuestions/GetByFilters/GetFaqQuestionsByFiltersHandler.cs
@@ -5,7 +5,9 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.FaqQuestions;
 using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Enums;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -26,8 +28,17 @@ public class GetFaqQuestionsByFiltersHandler : IRequestHandler<GetFaqQuestionsBy
     {
         var status = request.FaqQuestionsFilterDto.Status;
         var pageId = request.FaqQuestionsFilterDto.PageId;
+        var translationStatusFilter = request.FaqQuestionsFilterDto.TranslationStatusFilter;
+        var languageCount = await _repository.LocalizationLanguagesRepository.CountAsync();
+        languageCount -= 1;
         Expression<Func<FaqQuestion, bool>> filter =
-            (fq) => (status == null || fq.Status == status) && (pageId == null || fq.Placements.Any(p => p.PageId == pageId));
+            (fq) => (status == null || fq.Status == status) && (pageId == null || fq.Placements.Any(p => p.PageId == pageId)) &&
+            (translationStatusFilter == null ||
+            translationStatusFilter == TranslationStatusFilter.All ||
+            (translationStatusFilter == TranslationStatusFilter.Outdated &&
+            fq.Localizations.Any(l => l.TranslationStatus == TranslationStatus.Outdated)) ||
+            (translationStatusFilter == TranslationStatusFilter.Missing &&
+            fq.Localizations.Count < languageCount));
 
         var queryOptions = new QueryOptions<FaqQuestion>
         {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/FaqQuestions/GetFaqQuestionsByFiltersTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/FaqQuestions/GetFaqQuestionsByFiltersTests.cs
@@ -1,8 +1,11 @@
 using AutoMapper;
 using Moq;
+using VictoryCenter.BLL.Enums;
 using VictoryCenter.BLL.DTOs.Admin.FaqQuestions;
+using VictoryCenter.BLL.DTOs.Admin.Localization.FaqQuestions;
 using VictoryCenter.BLL.Queries.Admin.FaqQuestions.GetByFilters;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -65,7 +68,7 @@ public class GetFaqQuestionsByFiltersTests
     public async Task Handle_FilterByStatus_ShouldReturnSuccessfully()
     {
         // Arrange
-        var status = Status.Draft;
+        var status = DAL.Enums.Status.Draft;
         var faqQuestionList = GetFaqQuestionList();
         var faqQuestionDtoList = GetFaqQuestionDtoList()
             .Where(q => q.Status == status)
@@ -135,7 +138,7 @@ public class GetFaqQuestionsByFiltersTests
     public async Task Handle_FilterByStatusAndPageId_ShouldReturnSuccessfully()
     {
         // Arrange
-        var status = Status.Draft;
+        var status = DAL.Enums.Status.Draft;
         var page = new VisitorPage { Id = 1, Title = "Page 1" };
         var faqQuestionList = GetFaqQuestionList();
         var faqPlacementList = GetPlacementList();
@@ -168,6 +171,84 @@ public class GetFaqQuestionsByFiltersTests
         Assert.Equal(faqQuestionDtoList, result.Value.Items);
     }
 
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatusFilterMising()
+    {
+        int localizationLanguageCount = 1;
+        var faqQuestionList = GetFaqQuestionList();
+        var faqQuestionDtoList = GetFaqQuestionDtoList()
+            .Where(t => t.Localizations.Count() < localizationLanguageCount)
+            .ToArray();
+
+        SetupRepository(faqQuestionList, faqQuestionList.Count);
+        SetupMapper(faqQuestionDtoList);
+
+        var filtersDto = new FaqQuestionsFilterDto
+        {
+            Offset = 0,
+            Limit = 0,
+            TranslationStatusFilter = TranslationStatusFilter.Missing
+        };
+        var handler = new GetFaqQuestionsByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
+
+        var result = await handler.Handle(new GetFaqQuestionsByFiltersQuery(filtersDto), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Value);
+        Assert.Equal(faqQuestionDtoList, result.Value.Items);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatusFilterOutdated()
+    {
+        var faqQuestionList = GetFaqQuestionList();
+        var faqQuestionDtoList = GetFaqQuestionDtoList()
+            .Where(t => t.Localizations.Any(l => l.TranslationStatus == TranslationStatus.Outdated))
+            .ToArray();
+
+        SetupRepository(faqQuestionList, faqQuestionList.Count);
+        SetupMapper(faqQuestionDtoList);
+
+        var filtersDto = new FaqQuestionsFilterDto
+        {
+            Offset = 0,
+            Limit = 0,
+            TranslationStatusFilter = TranslationStatusFilter.Outdated
+        };
+        var handler = new GetFaqQuestionsByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
+
+        var result = await handler.Handle(new GetFaqQuestionsByFiltersQuery(filtersDto), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Value);
+        Assert.Equal(faqQuestionDtoList, result.Value.Items);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessfully_FilterTranslationStatusFilterAll()
+    {
+        var faqQuestionList = GetFaqQuestionList();
+        var faqQuestionDtoList = GetFaqQuestionDtoList()
+            .ToArray();
+
+        SetupRepository(faqQuestionList, faqQuestionList.Count);
+        SetupMapper(faqQuestionDtoList);
+
+        var filtersDto = new FaqQuestionsFilterDto
+        {
+            Offset = 0,
+            Limit = 0,
+            TranslationStatusFilter = TranslationStatusFilter.All
+        };
+        var handler = new GetFaqQuestionsByFiltersHandler(_mockMapper.Object, _mockRepository.Object);
+
+        var result = await handler.Handle(new GetFaqQuestionsByFiltersQuery(filtersDto), CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Value);
+        Assert.Equal(faqQuestionDtoList, result.Value.Items);
+    }
+
     private static List<FaqQuestion> GetFaqQuestionList()
     {
         var faqQuestionList = new List<FaqQuestion>
@@ -177,59 +258,86 @@ public class GetFaqQuestionsByFiltersTests
                 Id = 4,
                 QuestionText = new('4', 15),
                 AnswerText = new('4', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 Placements = [
                     new FaqPlacement { PageId = 1, QuestionId = 4, Priority = 3 },
                     new FaqPlacement { PageId = 2, QuestionId = 4, Priority = 3 },
                     new FaqPlacement { PageId = 3, QuestionId = 4, Priority = 1 },
                     ],
-                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-40)
             },
             new()
             {
                 Id = 2,
                 QuestionText = new('2', 15),
                 AnswerText = new('2', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 Placements = [
                     new FaqPlacement { PageId = 1, QuestionId = 2, Priority = 2 },
                     new FaqPlacement { PageId = 2, QuestionId = 2, Priority = 1 },
                     ],
-                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-20)
+                Localizations = [
+                    new FaqQuestionLocalization
+                    {
+                        EntityId = 2,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Outdated,
+                    },
+                ],
             },
             new()
             {
                 Id = 3,
                 QuestionText = new('3', 15),
                 AnswerText = new('3', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 Placements = [
                     new FaqPlacement { PageId = 2, QuestionId = 3, Priority = 2 },
                     ],
-                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-30)
+                Localizations = [
+                    new FaqQuestionLocalization
+                    {
+                        EntityId = 3,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Outdated,
+                    },
+                ],
             },
             new()
             {
                 Id = 5,
                 QuestionText = new('5', 15),
                 AnswerText = new('5', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 Placements = [
                     new FaqPlacement { PageId = 2, QuestionId = 5, Priority = 4 },
                     new FaqPlacement { PageId = 3, QuestionId = 5, Priority = 2 },
                     ],
-                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-50)
+                Localizations = [
+                    new FaqQuestionLocalization
+                    {
+                        EntityId = 5,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    },
+                ],
             },
             new()
             {
                 Id = 1,
                 QuestionText = new('1', 15),
                 AnswerText = new('1', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 Placements = [
                     new FaqPlacement { PageId = 1, QuestionId = 1, Priority = 1 },
                     ],
-                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-10)
+                Localizations = [
+                    new FaqQuestionLocalization
+                    {
+                        EntityId = 1,
+                        LanguageId = 2,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    },
+                ],
             },
         };
 
@@ -245,39 +353,67 @@ public class GetFaqQuestionsByFiltersTests
                 Id = 1,
                 QuestionText = new('1', 15),
                 AnswerText = new('1', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 PageIds = [1],
+                Localizations = [
+                    new FaqQuestionLocalizationDto
+                    {
+                        EntityId = 1,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    },
+                ],
             },
             new()
             {
                 Id = 3,
                 QuestionText = new('3', 15),
                 AnswerText = new('3', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 PageIds = [2],
+                Localizations = [
+                    new FaqQuestionLocalizationDto
+                    {
+                        EntityId = 3,
+                        TranslationStatus = TranslationStatus.Outdated,
+                    },
+                ],
             },
             new()
             {
                 Id = 2,
                 QuestionText = new('2', 15),
                 AnswerText = new('2', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 PageIds = [1, 2],
+                Localizations = [
+                    new FaqQuestionLocalizationDto
+                    {
+                        EntityId = 2,
+                        TranslationStatus = TranslationStatus.Outdated,
+                    },
+                ],
             },
             new()
             {
                 Id = 5,
                 QuestionText = new('5', 15),
                 AnswerText = new('5', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 PageIds = [2, 3],
+                Localizations = [
+                    new FaqQuestionLocalizationDto
+                    {
+                        EntityId = 5,
+                        TranslationStatus = TranslationStatus.Relevant,
+                    },
+                ],
             },
             new()
             {
                 Id = 4,
                 QuestionText = new('4', 15),
                 AnswerText = new('4', 60),
-                Status = Status.Draft,
+                Status = DAL.Enums.Status.Draft,
                 PageIds = [1, 2, 3],
             },
         };
@@ -309,6 +445,9 @@ public class GetFaqQuestionsByFiltersTests
 
     private void SetupRepository(List<FaqQuestion> faqQuestions, int count)
     {
+        _mockRepository.Setup(repositoryWrapper => repositoryWrapper.LocalizationLanguagesRepository.CountAsync(
+            It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(2);
         _mockRepository.Setup(repositoryWrapper => repositoryWrapper.FaqQuestionsRepository.GetAllAsync(
              It.IsAny<QueryOptions<FaqQuestion>>()))
             .ReturnsAsync(faqQuestions);


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1053)

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added translation status filtering for FAQ questions, allowing users to filter by Missing, Outdated, or All statuses.
  * Improved FAQ question updates with enhanced placement management and transaction support.

* **Tests**
  * Expanded test coverage for translation localization behavior in FAQ questions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->