### PR TITLE
Feature/issue 1315 - Add ability to create, edit, delete and read localization for TeamCategory

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Create/CreateTeamCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Create/CreateTeamCategoryLocalizationCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Create;
+public record CreateTeamCategoryLocalizationCommand(CreateTeamCategoryLocalizationDto CreateTeamCategoryLocalizationDto)
+    : IRequest<Result<TeamCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Create/CreateTeamCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Create/CreateTeamCategoryLocalizationHandler.cs
@@ -10,13 +10,17 @@ using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 
 namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Create;
+
 public class CreateTeamCategoryLocalizationHandler : IRequestHandler<CreateTeamCategoryLocalizationCommand, Result<TeamCategoryLocalizationDto>>
 {
     private readonly IMapper _mapper;
     private readonly ILocalizationService<TeamCategory, TeamCategoryLocalization> _localizationService;
     private readonly IValidator<CreateTeamCategoryLocalizationCommand> _validator;
 
-    public CreateTeamCategoryLocalizationHandler(IMapper mapper, ILocalizationService<TeamCategory, TeamCategoryLocalization> localizationService, IValidator<CreateTeamCategoryLocalizationCommand> validator)
+    public CreateTeamCategoryLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<TeamCategory, TeamCategoryLocalization> localizationService,
+        IValidator<CreateTeamCategoryLocalizationCommand> validator)
     {
         _mapper = mapper;
         _localizationService = localizationService;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Create/CreateTeamCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Create/CreateTeamCategoryLocalizationHandler.cs
@@ -1,0 +1,54 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Create;
+public class CreateTeamCategoryLocalizationHandler : IRequestHandler<CreateTeamCategoryLocalizationCommand, Result<TeamCategoryLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<TeamCategory, TeamCategoryLocalization> _localizationService;
+    private readonly IValidator<CreateTeamCategoryLocalizationCommand> _validator;
+
+    public CreateTeamCategoryLocalizationHandler(IMapper mapper, ILocalizationService<TeamCategory, TeamCategoryLocalization> localizationService, IValidator<CreateTeamCategoryLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<TeamCategoryLocalizationDto>> Handle(CreateTeamCategoryLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            TeamCategoryLocalization entity = _mapper.Map<TeamCategoryLocalization>(request.CreateTeamCategoryLocalizationDto);
+            var result = await _localizationService.CreateEntityLocalizationAsync(entity);
+            TeamCategoryLocalizationDto responseDto = _mapper.Map<TeamCategoryLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(TeamCategoryLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(ErrorMessagesConstants.
+                FailedToCreateEntityInDatabase(typeof(TeamCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Delete/DeleteTeamCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Delete/DeleteTeamCategoryLocalizationCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Delete;
+public record DeleteTeamCategoryLocalizationCommand(long EntityId, long LanguageId)
+    : IRequest<Result<DeleteTeamCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Delete/DeleteTeamCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Delete/DeleteTeamCategoryLocalizationHandler.cs
@@ -1,0 +1,40 @@
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Delete;
+public class DeleteTeamCategoryLocalizationHandler : IRequestHandler<DeleteTeamCategoryLocalizationCommand, Result<DeleteTeamCategoryLocalizationDto>>
+{
+    private readonly ILocalizationService<TeamCategory, TeamCategoryLocalization> _localizationService;
+
+    public DeleteTeamCategoryLocalizationHandler(ILocalizationService<TeamCategory, TeamCategoryLocalization> localizationService)
+    {
+        _localizationService = localizationService;
+    }
+
+    public async Task<Result<DeleteTeamCategoryLocalizationDto>> Handle(DeleteTeamCategoryLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (entityId, languageId) = await _localizationService.DeleteEntityLocalizationAsync(request.EntityId, request.LanguageId);
+            return Result.Ok(new DeleteTeamCategoryLocalizationDto { EntityId = entityId, LanguageId = languageId });
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<DeleteTeamCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail(ErrorMessagesConstants.FailedToDeleteEntity(typeof(TeamCategoryLocalization)));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<DeleteTeamCategoryLocalizationDto>(ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(TeamCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Delete/DeleteTeamCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Delete/DeleteTeamCategoryLocalizationHandler.cs
@@ -30,7 +30,7 @@ public class DeleteTeamCategoryLocalizationHandler : IRequestHandler<DeleteTeamC
         }
         catch (InvalidOperationException)
         {
-            return Result.Fail(ErrorMessagesConstants.FailedToDeleteEntity(typeof(TeamCategoryLocalization)));
+            return Result.Fail<DeleteTeamCategoryLocalizationDto>(ErrorMessagesConstants.FailedToDeleteEntity(typeof(TeamCategoryLocalization)));
         }
         catch (DbUpdateException)
         {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Update/UpdateTeamCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Update/UpdateTeamCategoryLocalizationCommand.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Update;
+public record UpdateTeamCategoryLocalizationCommand(UpdateTeamCategoryLocalizationDto UpdateTeamCategoryLocalizationDto,
+    long EntityId,
+    long LanguageId)
+    : IRequest<Result<TeamCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Update/UpdateTeamCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Update/UpdateTeamCategoryLocalizationHandler.cs
@@ -16,7 +16,11 @@ public class UpdateTeamCategoryLocalizationHandler : IRequestHandler<UpdateTeamC
     private readonly ILocalizationService<TeamCategory, TeamCategoryLocalization> _localizationService;
     private readonly IValidator<UpdateTeamCategoryLocalizationCommand> _validator;
 
-    public UpdateTeamCategoryLocalizationHandler(IMapper mapper, ILocalizationService<TeamCategory, TeamCategoryLocalization> localizationService, IValidator<UpdateTeamCategoryLocalizationCommand> validator)
+    public UpdateTeamCategoryLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<TeamCategory,
+        TeamCategoryLocalization> localizationService,
+        IValidator<UpdateTeamCategoryLocalizationCommand> validator)
     {
         _mapper = mapper;
         _localizationService = localizationService;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Update/UpdateTeamCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/TeamCategories/Update/UpdateTeamCategoryLocalizationHandler.cs
@@ -1,0 +1,55 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Update;
+public class UpdateTeamCategoryLocalizationHandler : IRequestHandler<UpdateTeamCategoryLocalizationCommand, Result<TeamCategoryLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<TeamCategory, TeamCategoryLocalization> _localizationService;
+    private readonly IValidator<UpdateTeamCategoryLocalizationCommand> _validator;
+
+    public UpdateTeamCategoryLocalizationHandler(IMapper mapper, ILocalizationService<TeamCategory, TeamCategoryLocalization> localizationService, IValidator<UpdateTeamCategoryLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<TeamCategoryLocalizationDto>> Handle(UpdateTeamCategoryLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            TeamCategoryLocalization entity = _mapper.Map<TeamCategoryLocalization>(request.UpdateTeamCategoryLocalizationDto);
+            entity.EntityId = request.EntityId;
+            entity.LanguageId = request.LanguageId;
+            var result = await _localizationService.UpdateEntityLocalizationAsync(entity);
+            TeamCategoryLocalizationDto responseDto = _mapper.Map<TeamCategoryLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(ErrorMessagesConstants.FailedToUpdateEntity(typeof(TeamCategoryLocalization)));
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(ex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<TeamCategoryLocalizationDto>(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(TeamCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/Localization/TeamCategoryLocalizationConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/Localization/TeamCategoryLocalizationConstants.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.Constants.Localization;
+public static class TeamCategoryLocalizationConstants
+{
+    public static readonly int FullNameMinLength = 2;
+    public static readonly int FullNameMaxLength = 20;
+    public static readonly int DescriptionNameMinLength = 10;
+    public static readonly int DescriptionNameMaxLength = 200;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/Localization/TeamCategoryLocalizationConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/Localization/TeamCategoryLocalizationConstants.cs
@@ -1,8 +1,8 @@
 namespace VictoryCenter.BLL.Constants.Localization;
 public static class TeamCategoryLocalizationConstants
 {
-    public static readonly int FullNameMinLength = 2;
-    public static readonly int FullNameMaxLength = 20;
-    public static readonly int DescriptionNameMinLength = 10;
-    public static readonly int DescriptionNameMaxLength = 200;
+    public static readonly int NameMinLength = 2;
+    public static readonly int NameMaxLength = 20;
+    public static readonly int DescriptionMinLength = 10;
+    public static readonly int DescriptionMaxLength = 200;
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/CreateTeamCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/CreateTeamCategoryLocalizationDto.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+public class CreateTeamCategoryLocalizationDto : UpdateTeamCategoryLocalizationDto, ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/DeleteTeamCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/DeleteTeamCategoryLocalizationDto.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+public class DeleteTeamCategoryLocalizationDto : ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/TeamCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/TeamCategoryLocalizationDto.cs
@@ -6,9 +6,9 @@ public class TeamCategoryLocalizationDto
 {
     public long EntityId { get; init; }
     public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
-    public string FullName { get; set; } = null!;
+    public string Name { get; set; } = null!;
 
-    public string? Description { get; set; }
+    public string Description { get; set; } = null!;
 
     public TranslationStatus TranslationStatus { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/TeamCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/TeamCategoryLocalizationDto.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+public class TeamCategoryLocalizationDto
+{
+    public long EntityId { get; init; }
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+    public string FullName { get; set; } = null!;
+
+    public string? Description { get; set; }
+
+    public TranslationStatus TranslationStatus { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/UpdateTeamCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/UpdateTeamCategoryLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+public class UpdateTeamCategoryLocalizationDto
+{
+    public string FullName { get; set; } = null!;
+
+    public string? Description { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/UpdateTeamCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/TeamCategories/UpdateTeamCategoryLocalizationDto.cs
@@ -1,7 +1,7 @@
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
 public class UpdateTeamCategoryLocalizationDto
 {
-    public string FullName { get; set; } = null!;
+    public string Name { get; set; } = null!;
 
-    public string? Description { get; set; }
+    public string Description { get; set; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamCategories/CreateTeamCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamCategories/CreateTeamCategoryDto.cs
@@ -3,5 +3,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.TeamCategories;
 public record CreateTeamCategoryDto
 {
     public string Name { get; init; } = null!;
-    public string? Description { get; init; }
+    public string Description { get; init; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamCategories/TeamCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamCategories/TeamCategoryDto.cs
@@ -6,7 +6,7 @@ public record TeamCategoryDto
 {
     public long Id { get; init; }
     public string Name { get; init; } = null!;
-    public string? Description { get; init; }
+    public string Description { get; init; } = null!;
     public long TeamMembersCount { get; set; }
     public IEnumerable<TeamCategoryLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamCategories/TeamCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/TeamCategories/TeamCategoryDto.cs
@@ -1,3 +1,5 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
 namespace VictoryCenter.BLL.DTOs.Admin.TeamCategories;
 
 public record TeamCategoryDto
@@ -6,4 +8,5 @@ public record TeamCategoryDto
     public string Name { get; init; } = null!;
     public string? Description { get; init; }
     public long TeamMembersCount { get; set; }
+    public IEnumerable<TeamCategoryLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/TeamCategories/TeamCategoryLocalizationProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/TeamCategories/TeamCategoryLocalizationProfile.cs
@@ -1,0 +1,20 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Mapping.Localization.TeamCategories;
+public class TeamCategoryLocalizationProfile : Profile
+{
+    public TeamCategoryLocalizationProfile()
+    {
+        CreateMap<CreateTeamCategoryLocalizationDto, TeamCategoryLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateTeamCategoryLocalizationDto, TeamCategoryLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+
+        CreateMap<TeamCategoryLocalization, TeamCategoryLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByEntityId/GetTeamCategoryLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByEntityId/GetTeamCategoryLocalizationByEntityIdHandler.cs
@@ -1,0 +1,35 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByEntityId;
+public class GetTeamCategoryLocalizationByEntityIdHandler : IRequestHandler<GetTeamCategoryLocalizationByEntityIdQuery, Result<List<TeamCategoryLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetTeamCategoryLocalizationByEntityIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<List<TeamCategoryLocalizationDto>>> Handle(GetTeamCategoryLocalizationByEntityIdQuery request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<TeamCategoryLocalization>()
+        {
+            Filter = l => l.EntityId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+            AsNoTracking = true,
+        };
+
+        IEnumerable<TeamCategoryLocalization>? entities = await _repositoryWrapper.TeamCategoryLocalizationsRepository.GetAllAsync(queryOptions);
+        List<TeamCategoryLocalizationDto>? responseDto = _mapper.Map<List<TeamCategoryLocalizationDto>>(entities);
+        return Result.Ok(responseDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByEntityId/GetTeamCategoryLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByEntityId/GetTeamCategoryLocalizationByEntityIdHandler.cs
@@ -21,7 +21,7 @@ public class GetTeamCategoryLocalizationByEntityIdHandler : IRequestHandler<GetT
 
     public async Task<Result<List<TeamCategoryLocalizationDto>>> Handle(GetTeamCategoryLocalizationByEntityIdQuery request, CancellationToken cancellationToken)
     {
-        var queryOptions = new QueryOptions<TeamCategoryLocalization>()
+        var queryOptions = new QueryOptions<TeamCategoryLocalization>
         {
             Filter = l => l.EntityId == request.Id,
             Include = l => l.Include(loc => loc.Language),

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByEntityId/GetTeamCategoryLocalizationByEntityIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByEntityId/GetTeamCategoryLocalizationByEntityIdQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByEntityId;
+public record GetTeamCategoryLocalizationByEntityIdQuery(long Id)
+    : IRequest<Result<List<TeamCategoryLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByLanguageId/GetTeamCategoryLocalizationByLanguageIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByLanguageId/GetTeamCategoryLocalizationByLanguageIdHandler.cs
@@ -1,0 +1,35 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByLanguageId;
+public class GetTeamCategoryLocalizationByLanguageIdHandler : IRequestHandler<GetTeamCategoryLocalizationByLanguageIdQuery, Result<List<TeamCategoryLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetTeamCategoryLocalizationByLanguageIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<List<TeamCategoryLocalizationDto>>> Handle(GetTeamCategoryLocalizationByLanguageIdQuery request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<TeamCategoryLocalization>()
+        {
+            Filter = l => l.LanguageId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+            AsNoTracking = true,
+        };
+
+        IEnumerable<TeamCategoryLocalization>? entities = await _repositoryWrapper.TeamCategoryLocalizationsRepository.GetAllAsync(queryOptions);
+        List<TeamCategoryLocalizationDto>? responseDto = _mapper.Map<List<TeamCategoryLocalizationDto>>(entities);
+        return Result.Ok(responseDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByLanguageId/GetTeamCategoryLocalizationByLanguageIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByLanguageId/GetTeamCategoryLocalizationByLanguageIdHandler.cs
@@ -21,7 +21,7 @@ public class GetTeamCategoryLocalizationByLanguageIdHandler : IRequestHandler<Ge
 
     public async Task<Result<List<TeamCategoryLocalizationDto>>> Handle(GetTeamCategoryLocalizationByLanguageIdQuery request, CancellationToken cancellationToken)
     {
-        var queryOptions = new QueryOptions<TeamCategoryLocalization>()
+        var queryOptions = new QueryOptions<TeamCategoryLocalization>
         {
             Filter = l => l.LanguageId == request.Id,
             Include = l => l.Include(loc => loc.Language),

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByLanguageId/GetTeamCategoryLocalizationByLanguageIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/TeamCategories/GetByLanguageId/GetTeamCategoryLocalizationByLanguageIdQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByLanguageId;
+public record GetTeamCategoryLocalizationByLanguageIdQuery(long Id)
+    : IRequest<Result<List<TeamCategoryLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamCategories/GetAll/GetAllTeamCategoriesHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/TeamCategories/GetAll/GetAllTeamCategoriesHandler.cs
@@ -28,6 +28,7 @@ public class GetAllTeamCategoriesHandler : IRequestHandler<GetAllTeamCategoriesQ
             new QueryOptions<TeamCategory>
             {
                 Include = tc => tc.Include(tc => tc.TeamMembers)
+                 .Include(l => l.Localizations).ThenInclude(l => l.Language)
             });
         return Result.Ok(_mapper.Map<IEnumerable<TeamCategoryDto>>(entities));
     }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
@@ -8,10 +8,10 @@ public class BaseTeamCategoryLocalizationValidator : AbstractValidator<UpdateTea
 {
     public BaseTeamCategoryLocalizationValidator()
     {
-        RuleFor(x => x.FullName)
-            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.FullName)))
-            .MinimumLength(TeamCategoryLocalizationConstants.NameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.NameMinLength))
-            .MaximumLength(TeamCategoryLocalizationConstants.NameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.NameMaxLength));
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.Name)))
+            .MinimumLength(TeamCategoryLocalizationConstants.NameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Name), TeamCategoryLocalizationConstants.NameMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.NameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Name), TeamCategoryLocalizationConstants.NameMaxLength));
         RuleFor(x => x.Description)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.Description)))
             .MinimumLength(TeamCategoryLocalizationConstants.DescriptionMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMinLength))

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+
+namespace VictoryCenter.BLL.Validators.Localization.TeamCategories;
+public class BaseTeamCategoryLocalizationValidator : AbstractValidator<UpdateTeamCategoryLocalizationDto>
+{
+    public BaseTeamCategoryLocalizationValidator()
+    {
+        RuleFor(x => x.FullName)
+            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.FullName)))
+            .MinimumLength(TeamCategoryLocalizationConstants.FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.FullNameMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.FullNameMaxLength));
+        RuleFor(x => x.Description)
+            .MinimumLength(TeamCategoryLocalizationConstants.DescriptionNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionNameMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.DescriptionNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionNameMaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
@@ -10,11 +10,19 @@ public class BaseTeamCategoryLocalizationValidator : AbstractValidator<UpdateTea
     {
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.Name)))
-            .MinimumLength(TeamCategoryLocalizationConstants.NameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Name), TeamCategoryLocalizationConstants.NameMinLength))
-            .MaximumLength(TeamCategoryLocalizationConstants.NameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Name), TeamCategoryLocalizationConstants.NameMaxLength));
+            .MinimumLength(TeamCategoryLocalizationConstants.NameMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateTeamCategoryLocalizationDto.Name), TeamCategoryLocalizationConstants.NameMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.NameMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateTeamCategoryLocalizationDto.Name), TeamCategoryLocalizationConstants.NameMaxLength));
         RuleFor(x => x.Description)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.Description)))
-            .MinimumLength(TeamCategoryLocalizationConstants.DescriptionMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMinLength))
-            .MaximumLength(TeamCategoryLocalizationConstants.DescriptionMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMaxLength));
+            .MinimumLength(TeamCategoryLocalizationConstants.DescriptionMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.DescriptionMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMaxLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/BaseTeamCategoryLocalizationValidator.cs
@@ -10,10 +10,11 @@ public class BaseTeamCategoryLocalizationValidator : AbstractValidator<UpdateTea
     {
         RuleFor(x => x.FullName)
             .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.FullName)))
-            .MinimumLength(TeamCategoryLocalizationConstants.FullNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.FullNameMinLength))
-            .MaximumLength(TeamCategoryLocalizationConstants.FullNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.FullNameMaxLength));
+            .MinimumLength(TeamCategoryLocalizationConstants.NameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.NameMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.NameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.FullName), TeamCategoryLocalizationConstants.NameMaxLength));
         RuleFor(x => x.Description)
-            .MinimumLength(TeamCategoryLocalizationConstants.DescriptionNameMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionNameMinLength))
-            .MaximumLength(TeamCategoryLocalizationConstants.DescriptionNameMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionNameMaxLength));
+            .NotEmpty().WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateTeamCategoryLocalizationDto.Description)))
+            .MinimumLength(TeamCategoryLocalizationConstants.DescriptionMinLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMinLength))
+            .MaximumLength(TeamCategoryLocalizationConstants.DescriptionMaxLength).WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(nameof(UpdateTeamCategoryLocalizationDto.Description), TeamCategoryLocalizationConstants.DescriptionMaxLength));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/CreateTeamCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/CreateTeamCategoryLocalizationValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Create;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Validators.Localization.Base;
+
+namespace VictoryCenter.BLL.Validators.Localization.TeamCategories;
+public class CreateTeamCategoryLocalizationValidator : AbstractValidator<CreateTeamCategoryLocalizationCommand>
+{
+    public CreateTeamCategoryLocalizationValidator(BaseTeamCategoryLocalizationValidator baseTeamCategoryLocalizationValidator)
+    {
+        RuleFor(c => c.CreateTeamCategoryLocalizationDto)
+            .SetValidator(new LocalizationIdentityValidator<CreateTeamCategoryLocalizationDto>());
+        RuleFor(c => c.CreateTeamCategoryLocalizationDto)
+            .SetValidator(baseTeamCategoryLocalizationValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/UpdateTeamCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/TeamCategories/UpdateTeamCategoryLocalizationValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization.TeamCategories;
+public class UpdateTeamCategoryLocalizationValidator : AbstractValidator<UpdateTeamCategoryLocalizationCommand>
+{
+    public UpdateTeamCategoryLocalizationValidator(BaseTeamCategoryLocalizationValidator baseTeamCategoryLocalizationValidator)
+    {
+        RuleFor(x => x.UpdateTeamCategoryLocalizationDto)
+            .SetValidator(baseTeamCategoryLocalizationValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/TeamCategoryLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/TeamCategoryLocalizationConfig.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+public class TeamCategoryLocalizationConfig : EntityLocalizationConfig<TeamCategoryLocalization, TeamCategory>
+{
+    public override void Configure(EntityTypeBuilder<TeamCategoryLocalization> entity)
+    {
+        base.Configure(entity);
+
+        entity.Property(e => e.FullName)
+            .IsRequired();
+
+        entity.Property(e => e.Description);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/TeamCategoryLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/TeamCategoryLocalizationConfig.cs
@@ -12,6 +12,7 @@ public class TeamCategoryLocalizationConfig : EntityLocalizationConfig<TeamCateg
         entity.Property(e => e.FullName)
             .IsRequired();
 
-        entity.Property(e => e.Description);
+        entity.Property(e => e.Description)
+            .IsRequired();
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/TeamCategoryLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/TeamCategoryLocalizationConfig.cs
@@ -9,7 +9,7 @@ public class TeamCategoryLocalizationConfig : EntityLocalizationConfig<TeamCateg
     {
         base.Configure(entity);
 
-        entity.Property(e => e.FullName)
+        entity.Property(e => e.Name)
             .IsRequired();
 
         entity.Property(e => e.Description)

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -43,6 +43,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<TeamMemberLocalization> TeamMemberLocalizations { get; set; }
 
+    public DbSet<TeamCategoryLocalization> TeamCategoryLocalizations { get; set; }
+
     public DbSet<FaqQuestionLocalization> FaqLocalizations { get; set; }
 
     public DbSet<UahBankDetails> UahBankDetails { get; set; }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/TeamCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/TeamCategoryLocalization.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.DAL.Entities.Localization;
+public class TeamCategoryLocalization : LocalizationBase<TeamCategory>
+{
+    public string FullName { get; set; } = null!;
+
+    public string? Description { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/TeamCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/TeamCategoryLocalization.cs
@@ -1,7 +1,7 @@
 namespace VictoryCenter.DAL.Entities.Localization;
 public class TeamCategoryLocalization : LocalizationBase<TeamCategory>
 {
-    public string FullName { get; set; } = null!;
+    public string Name { get; set; } = null!;
 
-    public string? Description { get; set; }
+    public string Description { get; set; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/TeamCategory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/TeamCategory.cs
@@ -8,7 +8,7 @@ public class TeamCategory : BaseEntity, ITranslatedEntity<TeamCategoryLocalizati
 {
     public string Name { get; set; } = null!;
 
-    public string? Description { get; set; }
+    public string Description { get; set; } = null!;
 
     public ICollection<TeamMember> TeamMembers { get; set; } = [];
     public ICollection<TeamCategoryLocalization> Localizations { get; set; } = [];

--- a/VictoryCenter/VictoryCenter.DAL/Entities/TeamCategory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/TeamCategory.cs
@@ -1,12 +1,15 @@
 using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 
 namespace VictoryCenter.DAL.Entities;
 
-public class TeamCategory : BaseEntity
+public class TeamCategory : BaseEntity, ITranslatedEntity<TeamCategoryLocalization>
 {
     public string Name { get; set; } = null!;
 
     public string? Description { get; set; }
 
     public ICollection<TeamMember> TeamMembers { get; set; } = [];
+    public ICollection<TeamCategoryLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260126194144_AddedTeamCategoryLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260126194144_AddedTeamCategoryLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260126194144_AddedTeamCategoryLocalization")]
+    partial class AddedTeamCategoryLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260126194144_AddedTeamCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260126194144_AddedTeamCategoryLocalization.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedTeamCategoryLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TeamCategoryLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    FullName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamCategoryLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_TeamCategoryLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamCategoryLocalizations_TeamCategories_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "TeamCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamCategoryLocalizations_LanguageId",
+                table: "TeamCategoryLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TeamCategoryLocalizations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260129222707_AddDescriptionFieldRequiredForTeamCategoriesLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260129222707_AddDescriptionFieldRequiredForTeamCategoriesLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260129222707_AddDescriptionFieldRequiredForTeamCategoriesLocalization")]
+    partial class AddDescriptionFieldRequiredForTeamCategoriesLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260129222707_AddDescriptionFieldRequiredForTeamCategoriesLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260129222707_AddDescriptionFieldRequiredForTeamCategoriesLocalization.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDescriptionFieldRequiredForTeamCategoriesLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "TeamCategoryLocalizations",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "TeamCategoryLocalizations",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260130150628_UpdateTeamCategoryAndLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260130150628_UpdateTeamCategoryAndLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260130150628_UpdateTeamCategoryAndLocalization")]
+    partial class UpdateTeamCategoryAndLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260130150628_UpdateTeamCategoryAndLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260130150628_UpdateTeamCategoryAndLocalization.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateTeamCategoryAndLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "FullName",
+                table: "TeamCategoryLocalizations",
+                newName: "Name");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "TeamCategories",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Name",
+                table: "TeamCategoryLocalizations",
+                newName: "FullName");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "TeamCategories",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -14,6 +14,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreSections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Partners;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -39,6 +40,8 @@ public interface IRepositoryWrapper
     IPartnerRepository PartnerRepository { get; }
     IPartnerSectionsRepository PartnerSectionsRepository { get; }
     IPartnersPageBannersRepository PartnersPageBannersRepository { get; }
+
+    ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository { get; }
 
     IRepositoryBase<TEntity> GetRepository<TEntity>()
         where TEntity : class;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/TeamCategories/ITeamCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/TeamCategories/ITeamCategoryLocalizationsRepository.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
+public interface ITeamCategoryLocalizationsRepository : IRepositoryBase<TeamCategoryLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -32,6 +32,8 @@ using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreSections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.FaqQuestions;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamCategories;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -59,6 +61,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IPartnerRepository? _partnerRepository;
     private IPartnerSectionsRepository? _partnerSectionRepository;
     private IPartnersPageBannersRepository? _partnersPageBannersRepository;
+    private ITeamCategoryLocalizationsRepository? _teamCategoryLocalizationsRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -93,6 +96,8 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IPartnerRepository PartnerRepository => _partnerRepository ??= new PartnerRepository(_victoryCenterDbContext);
     public IPartnerSectionsRepository PartnerSectionsRepository => _partnerSectionRepository ??= new PartnerSectionsRepository(_victoryCenterDbContext);
     public IPartnersPageBannersRepository PartnersPageBannersRepository => _partnersPageBannersRepository ??= new PartnersPageBannersRepository(_victoryCenterDbContext);
+
+    public ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository => _teamCategoryLocalizationsRepository ??= new TeamCategoryLocalizationRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/TeamCategories/TeamCategoryLocalizationRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/TeamCategories/TeamCategoryLocalizationRepository.cs
@@ -1,0 +1,13 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.TeamCategories;
+public class TeamCategoryLocalizationRepository : RepositoryBase<TeamCategoryLocalization>, ITeamCategoryLocalizationsRepository
+{
+    public TeamCategoryLocalizationRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Create/CreateTeamCategoryLocalizationTest.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Create/CreateTeamCategoryLocalizationTest.cs
@@ -34,4 +34,48 @@ public class CreateTeamCategoryLocalizationTest : BaseTestClass
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.True(response.IsSuccessStatusCode);
     }
+
+    [Fact]
+    public async Task CreateTeamCategoryLocalization_Unauthorized_ShouldReturnNotFound()
+    {
+        var category = await Fixture.DbContext.TeamCategories.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2) ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var createTeamCategoryLocalizationDto = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 123,
+            LanguageId = language.Id,
+            Name = "Category Name",
+            Description = "Category Description"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createTeamCategoryLocalizationDto);
+
+        var response = await Fixture.HttpClient.PostAsync("/api/TeamCategoryLocalizations/", new StringContent(
+            serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateTeamCategoryLocalization_InvalidData_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+                       ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var createTeamCategoryLocalizationDto = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 4,
+            LanguageId = language.Id,
+            Name = "", // Передаємо пусту назву, що зазвичай викликає помилку валідації
+            Description = "Category Description"
+        };
+
+        var serializedDto = JsonConvert.SerializeObject(createTeamCategoryLocalizationDto);
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("/api/TeamCategoryLocalizations/", new StringContent(
+            serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Create/CreateTeamCategoryLocalizationTest.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Create/CreateTeamCategoryLocalizationTest.cs
@@ -17,8 +17,10 @@ public class CreateTeamCategoryLocalizationTest : BaseTestClass
     [Fact]
     public async Task CreateTeamCategoryLocalization_ShouldReturnOk()
     {
-        var category = await Fixture.DbContext.TeamCategories.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
-        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2) ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var category = await Fixture.DbContext.TeamCategories.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
         var createTeamCategoryLocalizationDto = new CreateTeamCategoryLocalizationDto
         {
             EntityId = 4,
@@ -36,10 +38,12 @@ public class CreateTeamCategoryLocalizationTest : BaseTestClass
     }
 
     [Fact]
-    public async Task CreateTeamCategoryLocalization_Unauthorized_ShouldReturnNotFound()
+    public async Task CreateTeamCategoryLocalization_ShouldReturnNotFound()
     {
-        var category = await Fixture.DbContext.TeamCategories.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
-        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2) ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var category = await Fixture.DbContext.TeamCategories.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
         var createTeamCategoryLocalizationDto = new CreateTeamCategoryLocalizationDto
         {
             EntityId = 123,
@@ -58,7 +62,6 @@ public class CreateTeamCategoryLocalizationTest : BaseTestClass
     [Fact]
     public async Task CreateTeamCategoryLocalization_InvalidData_ShouldReturnBadRequest()
     {
-        // Arrange
         var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
                        ?? throw new InvalidOperationException("Couldn't setup existing entity");
 
@@ -66,13 +69,12 @@ public class CreateTeamCategoryLocalizationTest : BaseTestClass
         {
             EntityId = 4,
             LanguageId = language.Id,
-            Name = "", // Передаємо пусту назву, що зазвичай викликає помилку валідації
+            Name = "",
             Description = "Category Description"
         };
 
         var serializedDto = JsonConvert.SerializeObject(createTeamCategoryLocalizationDto);
 
-        // Act
         var response = await Fixture.HttpClient.PostAsync("/api/TeamCategoryLocalizations/", new StringContent(
             serializedDto, Encoding.UTF8, "application/json"));
 

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Create/CreateTeamCategoryLocalizationTest.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Create/CreateTeamCategoryLocalizationTest.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.TeamCategoryLocalizations.Create;
+public class CreateTeamCategoryLocalizationTest : BaseTestClass
+{
+    public CreateTeamCategoryLocalizationTest(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreateTeamCategoryLocalization_ShouldReturnOk()
+    {
+        var category = await Fixture.DbContext.TeamCategories.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2) ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var createTeamCategoryLocalizationDto = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 4,
+            LanguageId = language.Id,
+            Name = "Category Name",
+            Description = "Category Description"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createTeamCategoryLocalizationDto);
+
+        var response = await Fixture.HttpClient.PostAsync("/api/TeamCategoryLocalizations/", new StringContent(
+            serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.IsSuccessStatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Delete/DeleteTeamCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Delete/DeleteTeamCategoryLocalizationTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.TeamCategoryLocalizations.Delete;
+public class DeleteTeamCategoryLocalizationTests : BaseTestClass
+{
+    public DeleteTeamCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task DeleteTeamCategoryLocalization_ShouldReturnOk()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long entityId = category.EntityId;
+        long languageId = category.LanguageId;
+
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/TeamCategoryLocalizations/{entityId}/{languageId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteTeamCategoryLocalization_ShouldReturnNotFound()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long entityId = 5;
+        long languageId = category.LanguageId;
+
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/TeamCategoryLocalizations/{entityId}/{languageId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/GetByEntityId/GetTeamCategoryLocalizationsByEntityId.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/GetByEntityId/GetTeamCategoryLocalizationsByEntityId.cs
@@ -3,6 +3,7 @@ using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
 
 namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.TeamCategoryLocalizations.GetByEntityId;
+
 public class GetTeamCategoryLocalizationsByEntityId : BaseTestClass
 {
     public GetTeamCategoryLocalizationsByEntityId(IntegrationTestDbFixture fixture)

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/GetByEntityId/GetTeamCategoryLocalizationsByEntityId.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/GetByEntityId/GetTeamCategoryLocalizationsByEntityId.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.TeamCategoryLocalizations.GetByEntityId;
+public class GetTeamCategoryLocalizationsByEntityId : BaseTestClass
+{
+    public GetTeamCategoryLocalizationsByEntityId(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetTeamCategoryLocalizationsByEntityId_ShouldReturnOk()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync(l => l.EntityId == 1) ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long entityId = category.EntityId;
+
+        var response = await Fixture.HttpClient.GetAsync($"/api/TeamCategoryLocalizations/entityId/{entityId}");
+
+        Assert.True(response.IsSuccessStatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/GetByLanguageId/GetTeamCategoryLocalizationsByLanguageIdTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/GetByLanguageId/GetTeamCategoryLocalizationsByLanguageIdTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.TeamCategoryLocalizations.GetByLanguageId;
+public class GetTeamCategoryLocalizationsByLanguageIdTests : BaseTestClass
+{
+    public GetTeamCategoryLocalizationsByLanguageIdTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetTeamCategoryLocalizationsByLanguageId_ShouldReturnOk()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync(l => l.LanguageId == 2) ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long languageId = category.LanguageId;
+
+        var response = await Fixture.HttpClient.GetAsync($"/api/TeamCategoryLocalizations/languageId/{languageId}");
+
+        Assert.True(response.IsSuccessStatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Update/UpdateTeamCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/TeamCategoryLocalizations/Update/UpdateTeamCategoryLocalizationTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.TeamCategoryLocalizations.Update;
+public class UpdateTeamCategoryLocalizationTests : BaseTestClass
+{
+    public UpdateTeamCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateTeamCategoryLocalization_ShouldReturnOk()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long entityId = category.EntityId;
+        long languageId = category.LanguageId;
+        var updateTeamCategoryLocalizationDto = new UpdateTeamCategoryLocalizationDto
+        {
+            Name = "Updated Name",
+            Description = "Updated Description"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateTeamCategoryLocalizationDto);
+
+        var response = await Fixture.HttpClient.PutAsync($"/api/TeamCategoryLocalizations/{entityId}/{languageId}", new StringContent(
+            serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateTeamCategoryLocalization_ShouldReturnNotFound()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long entityId = 999;
+        long languageId = category.LanguageId;
+        var updateTeamCategoryLocalizationDto = new UpdateTeamCategoryLocalizationDto
+        {
+            Name = "Updated Name",
+            Description = "Updated Description"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateTeamCategoryLocalizationDto);
+
+        var response = await Fixture.HttpClient.PutAsync($"/api/TeamCategoryLocalizations/{entityId}/{languageId}", new StringContent(
+            serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateTeamCategoryLocalization_ShouldReturnBadRequest()
+    {
+        var category = await Fixture.DbContext.TeamCategoryLocalizations.FirstOrDefaultAsync() ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        long entityId = category.EntityId;
+        long languageId = category.LanguageId;
+        var updateTeamCategoryLocalizationDto = new UpdateTeamCategoryLocalizationDto
+        {
+            Name = string.Empty,
+            Description = "Updated Description"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateTeamCategoryLocalizationDto);
+
+        var response = await Fixture.HttpClient.PutAsync($"/api/TeamCategoryLocalizations/{entityId}/{languageId}", new StringContent(
+            serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/TeamCategoryLocalizations/TeamCategoryLocalizationsSeeder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/TeamCategoryLocalizations/TeamCategoryLocalizationsSeeder.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.IntegrationTests.Utils.Seeders.Localizations.TeamCategoryLocalizations;
+public class TeamCategoryLocalizationsSeeder : BaseSeeder<DAL.Entities.Localization.TeamCategoryLocalization>
+{
+    public TeamCategoryLocalizationsSeeder(VictoryCenterDbContext dbContext, ILogger<TeamCategoryLocalizationsSeeder> logger)
+        : base(dbContext, logger)
+    {
+    }
+
+    public override int Order => (int)SeederExecutionOrder.TeamCategoryLocalizations;
+
+    public override string Name => nameof(TeamCategoryLocalizationsSeeder);
+
+    protected override Task<List<TeamCategoryLocalization>> GenerateEntitiesAsync()
+    {
+        var teamCategoryLocalizations = new List<TeamCategoryLocalization>
+        {
+            new()
+            {
+                EntityId = 1,
+                LanguageId = 2,
+                Name = "English Name",
+                Description = "English Description"
+            },
+            new()
+            {
+                EntityId = 1,
+                LanguageId = 3,
+                Name = "English Name 4",
+                Description = "English Description 4"
+            },
+            new()
+            {
+                EntityId = 2,
+                LanguageId = 2,
+                Name = "English Name 2",
+                Description = "English Description 2"
+            },
+            new()
+            {
+                EntityId = 3,
+                LanguageId = 2,
+                Name = "English Name 3",
+                Description = "English Description 3"
+            }
+        };
+        return Task.FromResult(teamCategoryLocalizations);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
@@ -15,4 +15,5 @@ public enum SeederExecutionOrder
     WhoWeAre,
     PartnersSections,
     PartnersPageBanner,
+    TeamCategoryLocalizations,
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
@@ -33,14 +33,4 @@
       <ProjectReference Include="..\VictoryCenter.WebAPI\VictoryCenter.WebAPI.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="ControllerTests\Localizations\LocalizationLanguages\" />
-      <Folder Include="ControllerTests\Localizations\FaqQuestionLocalizations\" />
-      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\GetByEntityId\" />
-      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\GetByLanguageId\" />
-      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\Delete\" />
-      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\Update\" />
-      <Folder Include="ControllerTests\Localizations\TeamMemberLocalizations\" />
-    </ItemGroup>
-
 </Project>

--- a/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
@@ -33,4 +33,14 @@
       <ProjectReference Include="..\VictoryCenter.WebAPI\VictoryCenter.WebAPI.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="ControllerTests\Localizations\LocalizationLanguages\" />
+      <Folder Include="ControllerTests\Localizations\FaqQuestionLocalizations\" />
+      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\GetByEntityId\" />
+      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\GetByLanguageId\" />
+      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\Delete\" />
+      <Folder Include="ControllerTests\Localizations\TeamCategoryLocalizations\Update\" />
+      <Folder Include="ControllerTests\Localizations\TeamMemberLocalizations\" />
+    </ItemGroup>
+
 </Project>

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/CreateTeamCategoriesLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/CreateTeamCategoriesLocalizationTests.cs
@@ -9,6 +9,7 @@ using VictoryCenter.BLL.Interfaces.Localization;
 using VictoryCenter.BLL.Validators.Localization.TeamCategories;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
+
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
 public class CreateTeamCategoriesLocalizationTests
 {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/CreateTeamCategoriesLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/CreateTeamCategoriesLocalizationTests.cs
@@ -32,12 +32,6 @@ public class CreateTeamCategoriesLocalizationTests
         Name = "Назва категорії",
         Description = "Опис категорії",
         Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" },
-        Entity = new()
-        {
-            Id = 1,
-            Name = "Original Name",
-            Description = "Original Description",
-        }
     };
 
     private readonly TeamCategoryLocalizationDto _teamCategoryLocalizationDto = new()
@@ -148,7 +142,7 @@ public class CreateTeamCategoriesLocalizationTests
         _mockMapper.Setup(m => m.Map<TeamCategoryLocalizationDto>(_teamCategoryLocalization))
             .Returns(_teamCategoryLocalizationDto);
 
-        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_teamCategoryLocalization))
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_teamCategoryLocalization))
             .ReturnsAsync(_teamCategoryLocalization);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/CreateTeamCategoriesLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/CreateTeamCategoriesLocalizationTests.cs
@@ -1,0 +1,154 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.TeamCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
+public class CreateTeamCategoriesLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>> _mockLocalizationService;
+    private readonly IValidator<CreateTeamCategoryLocalizationCommand> _validator;
+    private readonly CreateTeamCategoryLocalizationHandler _handler;
+
+    private readonly CreateTeamCategoryLocalizationDto _createTeamCategoryLocalizationDto = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Localized Name",
+        Description = "Localized Description"
+    };
+
+    private readonly TeamCategoryLocalization _teamCategoryLocalization = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Назва категорії",
+        Description = "Опис категорії",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" },
+        Entity = new()
+        {
+            Id = 1,
+            Name = "Original Name",
+            Description = "Original Description",
+        }
+    };
+
+    private readonly TeamCategoryLocalizationDto _teamCategoryLocalizationDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new() { Id = 2, Code = "en" },
+        Name = "Localized Name",
+        Description = "Localized Description"
+    };
+    public CreateTeamCategoriesLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>>();
+        _validator = new CreateTeamCategoryLocalizationValidator(new BaseTeamCategoryLocalizationValidator());
+        _handler = new CreateTeamCategoryLocalizationHandler(_mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateTeamCategoryLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var result = await _handler.Handle(
+            new CreateTeamCategoryLocalizationCommand(_createTeamCategoryLocalizationDto),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_teamCategoryLocalizationDto.Name, result.Value.Name);
+        Assert.Equal(_teamCategoryLocalizationDto.LocalizationInfoDto.Id, result.Value.LocalizationInfoDto.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnValidationErrors_WhenDataIsInvalid()
+    {
+        var invalidDto = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 0,
+            LanguageId = 0,
+            Name = "",
+            Description = ""
+        };
+        var result = await _handler.Handle(
+            new CreateTeamCategoryLocalizationCommand(invalidDto),
+            CancellationToken.None);
+        Assert.False(result.IsSuccess);
+        Assert.Contains("EntityId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("LanguageId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("Name is required", result.Errors.Select(e => e.Message));
+        Assert.Contains("Description is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_createTeamCategoryLocalizationDto))
+            .Returns(_teamCategoryLocalization);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_teamCategoryLocalization))
+            .ThrowsAsync(new KeyNotFoundException("Not found"));
+
+        var result = await _handler.Handle(
+            new CreateTeamCategoryLocalizationCommand(_createTeamCategoryLocalizationDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_createTeamCategoryLocalizationDto))
+            .Returns(_teamCategoryLocalization);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_teamCategoryLocalization))
+            .ThrowsAsync(new InvalidOperationException());
+        var result = await _handler.Handle(
+            new CreateTeamCategoryLocalizationCommand(_createTeamCategoryLocalizationDto),
+            CancellationToken.None);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToCreateEntity(typeof(TeamCategoryLocalization)), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_createTeamCategoryLocalizationDto))
+            .Returns(_teamCategoryLocalization);
+
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalizationDto>(_teamCategoryLocalization))
+            .Returns(_teamCategoryLocalizationDto);
+
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_teamCategoryLocalization))
+            .ThrowsAsync(new DbUpdateException());
+
+        var result = await _handler.Handle(
+            new CreateTeamCategoryLocalizationCommand(_createTeamCategoryLocalizationDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(TeamCategoryLocalization)), result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_createTeamCategoryLocalizationDto))
+            .Returns(_teamCategoryLocalization);
+
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalizationDto>(_teamCategoryLocalization))
+            .Returns(_teamCategoryLocalizationDto);
+
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_teamCategoryLocalization))
+            .ReturnsAsync(_teamCategoryLocalization);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/DeleteTeamCategoriesLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/DeleteTeamCategoriesLocalizationTests.cs
@@ -7,7 +7,7 @@ using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
-public class DeleteTeamCategoriesLozalizaionTests
+public class DeleteTeamCategoriesLocalizationTests
 {
     private readonly Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>> _mockLocalizationService;
     private readonly DeleteTeamCategoryLocalizationHandler _handler;
@@ -18,7 +18,7 @@ public class DeleteTeamCategoriesLozalizaionTests
         Name = "Upd Localized Name",
         Description = "Upd Localized Description",
     };
-    public DeleteTeamCategoriesLozalizaionTests()
+    public DeleteTeamCategoriesLocalizationTests()
     {
         _mockLocalizationService = new Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>>();
         _handler = new DeleteTeamCategoryLocalizationHandler(_mockLocalizationService.Object);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/DeleteTeamCategoriesLozalizaionTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/DeleteTeamCategoriesLozalizaionTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Delete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
+public class DeleteTeamCategoriesLozalizaionTests
+{
+    private readonly Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>> _mockLocalizationService;
+    private readonly DeleteTeamCategoryLocalizationHandler _handler;
+    private readonly TeamCategoryLocalization _localizedTeamCategoryLocalization = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Upd Localized Name",
+        Description = "Upd Localized Description",
+    };
+    public DeleteTeamCategoriesLozalizaionTests()
+    {
+        _mockLocalizationService = new Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>>();
+        _handler = new DeleteTeamCategoryLocalizationHandler(_mockLocalizationService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteTeamCategoryLocalization_Successfully()
+    {
+        // Arrange
+        _mockLocalizationService.Setup(x => x.DeleteEntityLocalizationAsync(It.IsAny<long>(), It.IsAny<long>()))
+            .ReturnsAsync((_localizedTeamCategoryLocalization.EntityId, _localizedTeamCategoryLocalization.LanguageId));
+        var command = new DeleteTeamCategoryLocalizationCommand(_localizedTeamCategoryLocalization.EntityId, _localizedTeamCategoryLocalization.LanguageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        // Arrange
+        _mockLocalizationService.Setup(x => x.DeleteEntityLocalizationAsync(It.IsAny<long>(), It.IsAny<long>()))
+            .ThrowsAsync(new KeyNotFoundException("Localization not found."));
+        var command = new DeleteTeamCategoryLocalizationCommand(_localizedTeamCategoryLocalization.EntityId, _localizedTeamCategoryLocalization.LanguageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Localization not found.", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        // Arrange
+        _mockLocalizationService.Setup(x => x.DeleteEntityLocalizationAsync(It.IsAny<long>(), It.IsAny<long>()))
+            .ThrowsAsync(new DbUpdateException());
+        var command = new DeleteTeamCategoryLocalizationCommand(_localizedTeamCategoryLocalization.EntityId, _localizedTeamCategoryLocalization.LanguageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(TeamCategoryLocalization)), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        // Arrange
+        _mockLocalizationService.Setup(x => x.DeleteEntityLocalizationAsync(It.IsAny<long>(), It.IsAny<long>()))
+            .ThrowsAsync(new InvalidOperationException());
+        var command = new DeleteTeamCategoryLocalizationCommand(_localizedTeamCategoryLocalization.EntityId, _localizedTeamCategoryLocalization.LanguageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToDeleteEntity(typeof(TeamCategoryLocalization)), result.Errors[0].Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/GetTeamCategoriesLocalizationByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/GetTeamCategoriesLocalizationByEntityIdTests.cs
@@ -1,0 +1,119 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByEntityId;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
+public class GetTeamCategoriesLocalizationByEntityIdTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly GetTeamCategoryLocalizationByEntityIdHandler _handler;
+    private readonly List<TeamCategoryLocalization> _localizationsEntities = new()
+    {
+        new TeamCategoryLocalization
+        {
+            EntityId = 5,
+            LanguageId = 1,
+            Language = new LocalizationLanguage
+            {
+                Id = 1,
+                Code = "en",
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            Name = "Category A",
+            Description = "Description A",
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        new TeamCategoryLocalization
+        {
+            EntityId = 5,
+            LanguageId = 2,
+            Language = new LocalizationLanguage
+            {
+                Id = 2,
+                Code = "fr",
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            Name = "Catégorie A",
+            Description = "Description A en français",
+            CreatedAt = DateTimeOffset.UtcNow
+        }
+    };
+    private readonly List<TeamCategoryLocalizationDto> _localizationsDtos = new()
+    {
+        new TeamCategoryLocalizationDto
+        {
+            EntityId = 5,
+            LocalizationInfoDto = new LocalizationInfoDto
+            {
+                Id = 1,
+                Code = "en"
+            },
+            Name = "Category A",
+            Description = "Description A",
+        },
+        new TeamCategoryLocalizationDto
+        {
+            EntityId = 5,
+            LocalizationInfoDto = new LocalizationInfoDto
+            {
+                Id = 2,
+                Code = "fr"
+            },
+            Name = "Catégorie A",
+            Description = "Description A en français",
+        }
+    };
+
+    public GetTeamCategoriesLocalizationByEntityIdTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _handler = new GetTeamCategoryLocalizationByEntityIdHandler(_mockMapper.Object, _mockRepositoryWrapper.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnLocalizedTeamCategories_WhenEntityIdExists()
+    {
+        // Arrange
+        SetupRepositoryWrapper(_localizationsEntities);
+        SetupMapper(_localizationsDtos);
+
+        var query = new GetTeamCategoryLocalizationByEntityIdQuery(5);
+        var result = await _handler.Handle(query, CancellationToken.None);
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenEntityIdDoesNotExist()
+    {
+        // Arrange
+        SetupRepositoryWrapper(new List<TeamCategoryLocalization>());
+        SetupMapper(new List<TeamCategoryLocalizationDto>());
+        var query = new GetTeamCategoryLocalizationByEntityIdQuery(999);
+        var result = await _handler.Handle(query, CancellationToken.None);
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    private void SetupRepositoryWrapper(IEnumerable<TeamCategoryLocalization> entitiesToReturn)
+    {
+        _mockRepositoryWrapper.Setup(repo =>
+            repo.TeamCategoryLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<TeamCategoryLocalization>>()))
+            .ReturnsAsync(entitiesToReturn);
+    }
+
+    private void SetupMapper(IEnumerable<TeamCategoryLocalizationDto> dtosToReturn)
+    {
+        _mockMapper.Setup(mapper =>
+            mapper.Map<List<TeamCategoryLocalizationDto>>(It.IsAny<IEnumerable<TeamCategoryLocalization>>()))
+            .Returns(dtosToReturn.ToList());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/GetTeamCategoriesLocalizationByLanguageId.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/GetTeamCategoriesLocalizationByLanguageId.cs
@@ -1,0 +1,120 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByLanguageId;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
+public class GetTeamCategoriesLocalizationByLanguageId
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly GetTeamCategoryLocalizationByLanguageIdHandler _handler;
+    private readonly List<TeamCategoryLocalization> _localizationsEntities = new()
+    {
+        new TeamCategoryLocalization
+        {
+            EntityId = 5,
+            LanguageId = 2,
+            Language = new LocalizationLanguage
+            {
+                Id = 2,
+                Code = "en",
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            Name = "Category A",
+            Description = "Description A",
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        new TeamCategoryLocalization
+        {
+            EntityId = 5,
+            LanguageId = 2,
+            Language = new LocalizationLanguage
+            {
+                Id = 2,
+                Code = "fr",
+                CreatedAt = DateTimeOffset.UtcNow
+            },
+            Name = "Category A",
+            Description = "Description A",
+            CreatedAt = DateTimeOffset.UtcNow
+        }
+    };
+    private readonly List<TeamCategoryLocalizationDto> _localizationsDtos = new()
+    {
+        new TeamCategoryLocalizationDto
+        {
+            EntityId = 5,
+            LocalizationInfoDto = new LocalizationInfoDto
+            {
+                Id = 2,
+                Code = "en"
+            },
+            Name = "Category A",
+            Description = "Description A",
+        },
+        new TeamCategoryLocalizationDto
+        {
+            EntityId = 5,
+            LocalizationInfoDto = new LocalizationInfoDto
+            {
+                Id = 2,
+                Code = "en"
+            },
+            Name = "Category A",
+            Description = "Description A",
+        }
+    };
+
+    public GetTeamCategoriesLocalizationByLanguageId()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _handler = new GetTeamCategoryLocalizationByLanguageIdHandler(_mockMapper.Object, _mockRepositoryWrapper.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnLocalizedTeamCategories_WhenLanguageIdExists()
+    {
+        SetupRepositoryWrapper(_localizationsEntities);
+        SetupMapper(_localizationsDtos);
+
+        var query = new GetTeamCategoryLocalizationByLanguageIdQuery(2);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmplyList_WhenLanguageIdNotExist()
+    {
+        SetupRepositoryWrapper(new List<TeamCategoryLocalization>());
+        SetupMapper(new List<TeamCategoryLocalizationDto>());
+
+        var query = new GetTeamCategoryLocalizationByLanguageIdQuery(10);
+
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    private void SetupRepositoryWrapper(IEnumerable<TeamCategoryLocalization> entitiesToReturn)
+    {
+        _mockRepositoryWrapper.Setup(repo =>
+            repo.TeamCategoryLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<TeamCategoryLocalization>>()))
+            .ReturnsAsync(entitiesToReturn);
+    }
+
+    private void SetupMapper(IEnumerable<TeamCategoryLocalizationDto> dtosToReturn)
+    {
+        _mockMapper.Setup(mapper =>
+            mapper.Map<List<TeamCategoryLocalizationDto>>(It.IsAny<IEnumerable<TeamCategoryLocalization>>()))
+            .Returns(dtosToReturn.ToList());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/GetTeamCategoriesLocalizationByLanguageId.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/GetTeamCategoriesLocalizationByLanguageId.cs
@@ -91,7 +91,7 @@ public class GetTeamCategoriesLocalizationByLanguageId
     }
 
     [Fact]
-    public async Task Handle_ShouldReturnEmplyList_WhenLanguageIdNotExist()
+    public async Task Handle_ShouldReturnEmptyList_WhenLanguageIdNotExist()
     {
         SetupRepositoryWrapper(new List<TeamCategoryLocalization>());
         SetupMapper(new List<TeamCategoryLocalizationDto>());

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/UpdateTeamCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/TeamCategories/UpdateTeamCategoryLocalizationTests.cs
@@ -1,0 +1,149 @@
+using AutoMapper;
+using FluentValidation;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.TeamCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.TeamCategories;
+public class UpdateTeamCategoryLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>> _mockLocalizationService;
+    private readonly IValidator<UpdateTeamCategoryLocalizationCommand> _validator;
+    private readonly UpdateTeamCategoryLocalizationHandler _handler;
+
+    private readonly UpdateTeamCategoryLocalizationDto _updateTeamCategoryLocalizationDto = new()
+    {
+        Name = "Upd Localized Name",
+        Description = "Upd Localized Description"
+    };
+
+    private readonly TeamCategoryLocalization _oldTeamCategoryLocalization = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Old Name",
+        Description = "Old Description",
+    };
+    private readonly TeamCategoryLocalization _localizedTeamCategoryLocalization = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Upd Localized Name",
+        Description = "Upd Localized Description",
+    };
+    private readonly TeamCategoryLocalizationDto _teamCategoryLocalizationDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new() { Id = 2, Code = "en" },
+        Name = "Upd Localized Name",
+        Description = "Upd Localized Description"
+    };
+    private readonly long _entityId = 1;
+    private readonly long _languageId = 2;
+    public UpdateTeamCategoryLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<TeamCategory, TeamCategoryLocalization>>();
+        _validator = new UpdateTeamCategoryLocalizationValidator(new BaseTeamCategoryLocalizationValidator());
+        _handler = new UpdateTeamCategoryLocalizationHandler(_mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateTeamCategoryLocalization_Successfully()
+    {
+        // Arrange
+        SetupDependencies();
+        long entityId = _oldTeamCategoryLocalization.EntityId;
+        long languageId = _oldTeamCategoryLocalization.LanguageId;
+        var command = new UpdateTeamCategoryLocalizationCommand(_updateTeamCategoryLocalizationDto, entityId, languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_teamCategoryLocalizationDto.Name, result.Value.Name);
+        Assert.Equal(_teamCategoryLocalizationDto.Description, result.Value.Description);
+        Assert.Equal(_entityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFailed()
+    {
+        var invalidDto = new UpdateTeamCategoryLocalizationDto
+        {
+            Name = "",
+            Description = ""
+        };
+
+        var command = new UpdateTeamCategoryLocalizationCommand(invalidDto, _entityId, _entityId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Name is required", result.Errors.Select(e => e.Message));
+        Assert.Contains("Description is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_KeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_updateTeamCategoryLocalizationDto))
+            .Returns(_localizedTeamCategoryLocalization);
+
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_localizedTeamCategoryLocalization))
+            .ThrowsAsync(new KeyNotFoundException("Not found"));
+
+        var command = new UpdateTeamCategoryLocalizationCommand(_updateTeamCategoryLocalizationDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_updateTeamCategoryLocalizationDto))
+            .Returns(_localizedTeamCategoryLocalization);
+
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_localizedTeamCategoryLocalization))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new UpdateTeamCategoryLocalizationCommand(_updateTeamCategoryLocalizationDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToUpdateEntity(typeof(TeamCategoryLocalization)), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_updateTeamCategoryLocalizationDto))
+            .Returns(_localizedTeamCategoryLocalization);
+
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_localizedTeamCategoryLocalization))
+            .ThrowsAsync(new Microsoft.EntityFrameworkCore.DbUpdateException());
+
+        var command = new UpdateTeamCategoryLocalizationCommand(_updateTeamCategoryLocalizationDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(TeamCategoryLocalization)), result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalization>(_updateTeamCategoryLocalizationDto))
+            .Returns(_localizedTeamCategoryLocalization);
+
+        _mockMapper.Setup(m => m.Map<TeamCategoryLocalizationDto>(_localizedTeamCategoryLocalization))
+            .Returns(_teamCategoryLocalizationDto);
+
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_localizedTeamCategoryLocalization))
+            .ReturnsAsync(_localizedTeamCategoryLocalization);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/TeamCategories/BaseTeamCategoryLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/TeamCategories/BaseTeamCategoryLocalizationValidatorTests.cs
@@ -23,7 +23,7 @@ public class BaseTeamCategoryLocalizationValidatorTests
         {
             EntityId = 1,
             LanguageId = 2,
-            Name = name ?? string.Empty,
+            Name = name!,
             Description = "Valid Description"
         };
         var result = _validator.TestValidate(model);
@@ -43,7 +43,7 @@ public class BaseTeamCategoryLocalizationValidatorTests
             EntityId = 1,
             LanguageId = 2,
             Name = "Valid Name",
-            Description = description ?? string.Empty
+            Description = description!
         };
         var result = _validator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(c => c.Description);

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/TeamCategories/BaseTeamCategoryLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/TeamCategories/BaseTeamCategoryLocalizationValidatorTests.cs
@@ -1,0 +1,83 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Validators.Localization.TeamCategories;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.TeamCategories;
+public class BaseTeamCategoryLocalizationValidatorTests
+{
+    private readonly BaseTeamCategoryLocalizationValidator _validator;
+
+    public BaseTeamCategoryLocalizationValidatorTests()
+    {
+        _validator = new BaseTeamCategoryLocalizationValidator();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("e")]
+    public void Validate_ShouldHaveError_WhenName_IsInvalid(string? name)
+    {
+        var model = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            Name = name ?? string.Empty,
+            Description = "Valid Description"
+        };
+        var result = _validator.TestValidate(model);
+
+        result.ShouldHaveValidationErrorFor(c => c.Name);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("Desc")]
+    public void Validate_ShouldHaveError_WhenDescription_IsInvalid(string? description)
+    {
+        var model = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            Name = "Valid Name",
+            Description = description ?? string.Empty
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Description);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenNameAndDescription_IsMaxed()
+    {
+        var name = new string('a', 21);
+        var description = new string('b', 201);
+        var model = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            Name = name,
+            Description = description
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Name);
+        result.ShouldHaveValidationErrorFor(c => c.Description);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenModel_IsValid()
+    {
+        var model = new CreateTeamCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            Name = "Valid Name",
+            Description = "Valid Description"
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(c => c.Name);
+        result.ShouldNotHaveValidationErrorFor(c => c.Description);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/TeamCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/TeamCategoryLocalizationsController.cs
@@ -19,7 +19,7 @@ public class TeamCategoryLocalizationsController : AuthorizedApiController
     }
 
     [HttpPut("{entityId:long}/{languageId:long}")]
-    [ProducesResponseType(typeof(UpdateTeamCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(TeamCategoryLocalizationDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateTeamCategoryLocalization(

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/TeamCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/TeamCategoryLocalizationsController.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Delete;
+using VictoryCenter.BLL.Commands.Admin.Localization.TeamCategories.Update;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin.Localization;
+
+public class TeamCategoryLocalizationsController : AuthorizedApiController
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(TeamCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateTeamCategoryLocalization([FromBody] CreateTeamCategoryLocalizationDto createTeamCategoryLocalizationDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateTeamCategoryLocalizationCommand(createTeamCategoryLocalizationDto)));
+    }
+
+    [HttpPut("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(UpdateTeamCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateTeamCategoryLocalization(
+        [FromBody] UpdateTeamCategoryLocalizationDto updateTeamCategoryLocalizationDto,
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(new UpdateTeamCategoryLocalizationCommand(updateTeamCategoryLocalizationDto, EntityId, LanguageId)));
+    }
+
+    [HttpDelete("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(DeleteTeamCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteTeamCategoryLocalization(
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(new DeleteTeamCategoryLocalizationCommand(EntityId, LanguageId)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/Localization/TeamCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/Localization/TeamCategoryLocalizationsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.DTOs.Admin.Localization.TeamCategories;
+using VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByEntityId;
+using VictoryCenter.BLL.Queries.Admin.Localization.TeamCategories.GetByLanguageId;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Public.Localization;
+
+public class TeamCategoryLocalizationsController : BaseApiController
+{
+    [HttpGet("entityId/{id:long}")]
+    [ProducesResponseType(typeof(List<TeamCategoryLocalizationDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetByEntityId(long id)
+    {
+        return HandleResult(await Mediator.Send(new GetTeamCategoryLocalizationByEntityIdQuery(id)));
+    }
+
+    [HttpGet("languageId/{id:long}")]
+    [ProducesResponseType(typeof(List<TeamCategoryLocalizationDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetByLanguageId(long id)
+    {
+        return HandleResult(await Mediator.Send(new GetTeamCategoryLocalizationByLanguageIdQuery(id)));
+    }
+}


### PR DESCRIPTION
## GitHub Tickets

* [GitHub Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1272)
* [GitHub Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1276)
* [GitHub Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1315)
* [GitHub Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1318)
* [GitHub Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1319)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-language localization for team categories: create, update, delete translations and retrieve translations by category or language via new API endpoints.
  * Team category listings now include per-language localization data.

* **Tests**
  * Added unit and integration tests covering create, update, delete, and retrieval flows plus validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->