### PR TITLE
Change the number of characters in validation Who We Are - Feature/issue 1352

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/WhoWeAreConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/WhoWeAreConstants.cs
@@ -7,11 +7,11 @@ public static class WhoWeAreConstants
     public static readonly (int MinLen, int MaxLen) ValidationTitleRules = new(10, 50);
     public static Dictionary<SectionType, (int MinLen, int MaxLen)> ValidationDescriptionRules = new()
     {
-        { SectionType.Main, (10, 300) },
-        { SectionType.WhatWeDo, (10, 300) },
-        { SectionType.WhoWeSupport, (10, 300) },
-        { SectionType.Team, (10, 400) },
-        { SectionType.People, (10, 60) }
+        { SectionType.Main, (10, 600) },
+        { SectionType.WhatWeDo, (10, 600) },
+        { SectionType.WhoWeSupport, (10, 600) },
+        { SectionType.Team, (10, 800) },
+        { SectionType.People, (10, 200) }
     };
 
     public static string DtoHasWrongContentType(long dtoId, ContentType expected, ContentType received)

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/WhoWeAre/UpdateWhoWeAreContentValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/WhoWeAre/UpdateWhoWeAreContentValidatorTests.cs
@@ -104,7 +104,7 @@ public class UpdateWhoWeAreContentValidatorTests
             sectionType,
             new List<UpdateWhoWeAreContentDto>
             {
-                new() { ContentType = ContentType.Description, Description = new string('A', 401), Id = 1 }
+                new() { ContentType = ContentType.Description, Description = new string('A', 801), Id = 1 }
             });
 
         var result = _validator.TestValidate(command);


### PR DESCRIPTION
dev
## JIRA

https://github.com/ita-social-projects/VictoryCenter-Back/issues/1352


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Increased maximum character limits for description fields across multiple sections (Main, What We Do, Who We Support, Team, People), allowing users to enter substantially longer content and reducing previous truncation/validation rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->