### PR TITLE
Feature/issue - 1272 Change localization translation status to outdated when update team category

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Update/UpdateTeamCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Update/UpdateTeamCategoryHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.TeamCategories;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -44,20 +45,21 @@ public class UpdateTeamCategoryHandler : IRequestHandler<UpdateTeamCategoryComma
                 return Result.Fail<TeamCategoryDto>(TeamCategoryConstants.DuplicateCategoryName);
             }
 
-            var categoryEntity =
-                await _repositoryWrapper.TeamCategoriesRepository.GetFirstOrDefaultAsync(new QueryOptions<TeamCategory>
-                {
-                    Filter = entity => entity.Id == request.Id
-                });
+            var entityToUpdate = await _repositoryWrapper.TeamCategoriesRepository.GetFirstOrDefaultAsync(new QueryOptions<TeamCategory>
+            {
+                Filter = entity => entity.Id == request.Id,
+                Include = tc => tc.Include(tc => tc.TeamMembers)
+                        .Include(tm => tm.Localizations).ThenInclude(l => l.Language)
+            });
 
-            if (categoryEntity is null)
+            if (entityToUpdate is null)
             {
                 return Result.Fail<TeamCategoryDto>(ErrorMessagesConstants.NotFound(request.Id, typeof(TeamCategory)));
             }
 
-            var entityToUpdate = _mapper.Map<UpdateTeamCategoryDto, TeamCategory>(request.UpdateTeamCategoryDto);
-            entityToUpdate.Id = request.Id;
-            entityToUpdate.CreatedAt = categoryEntity.CreatedAt;
+            SetTranslationsToOutdated(request, entityToUpdate);
+
+            _mapper.Map(request.UpdateTeamCategoryDto, entityToUpdate);
 
             _repositoryWrapper.TeamCategoriesRepository.Update(entityToUpdate);
 
@@ -68,6 +70,7 @@ public class UpdateTeamCategoryHandler : IRequestHandler<UpdateTeamCategoryComma
                     {
                         Filter = tc => tc.Id == request.Id,
                         Include = tc => tc.Include(tc => tc.TeamMembers)
+                        .Include(tm => tm.Localizations).ThenInclude(l => l.Language)
                     });
 
                 var resultDto = _mapper.Map<TeamCategory, TeamCategoryDto>(updatedEntity!);
@@ -79,6 +82,18 @@ public class UpdateTeamCategoryHandler : IRequestHandler<UpdateTeamCategoryComma
         catch (ValidationException ex)
         {
             return Result.Fail<TeamCategoryDto>(ex.Message);
+        }
+    }
+
+    private static void SetTranslationsToOutdated(UpdateTeamCategoryCommand request, TeamCategory entityToUpdate)
+    {
+        if (!string.Equals(request.UpdateTeamCategoryDto.Name, entityToUpdate.Name) ||
+            !string.Equals(request.UpdateTeamCategoryDto.Description, entityToUpdate.Description))
+        {
+            foreach (var loc in entityToUpdate.Localizations)
+            {
+                loc.TranslationStatus = TranslationStatus.Outdated;
+            }
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/UpdateTeamCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/UpdateTeamCategoryTests.cs
@@ -171,41 +171,21 @@ public class UpdateTeamCategoryTests
 
     private void SetupRepositoryWrapper(TeamCategory? categoryToReturn = null, int saveResult = 1, TeamCategory? duplicateCategory = null)
     {
-        var entityWithSameNameDifferentId = new TeamCategory
-        {
-            Id = 999,
-            Name = "Updated Name",
-            Description = "Some other description"
-        };
-
-        var entityWithSameId = new TeamCategory
-        {
-            Id = _testExistingCategory.Id,
-            Name = "Different Name",
-            Description = "Different description"
-        };
-
         _mockRepositoryWrapper.Setup(x => x.TeamCategoriesRepository.GetFirstOrDefaultAsync(
-                It.Is<QueryOptions<TeamCategory>>(q =>
-                    q.Filter != null &&
-                    q.Include == null &&
-                    q.Filter.Compile()(entityWithSameNameDifferentId) &&
-                    !q.Filter.Compile()(entityWithSameId))))
-            .ReturnsAsync(duplicateCategory);
-
-        _mockRepositoryWrapper.Setup(x => x.TeamCategoriesRepository.GetFirstOrDefaultAsync(
-                It.Is<QueryOptions<TeamCategory>>(q =>
-                    q.Filter != null &&
-                    q.Include == null &&
-                    q.Filter.Compile()(entityWithSameId) &&
-                    !q.Filter.Compile()(entityWithSameNameDifferentId))))
-            .ReturnsAsync(categoryToReturn);
+                    It.Is<QueryOptions<TeamCategory>>(q =>
+                        q.Filter != null &&
+                        q.Filter.ToString().Contains("Name") &&
+                        q.Filter.ToString().Contains("Id") &&
+                        q.Include == null)))
+                .ReturnsAsync(duplicateCategory);
 
         _mockRepositoryWrapper.Setup(x => x.TeamCategoriesRepository.GetFirstOrDefaultAsync(
                 It.Is<QueryOptions<TeamCategory>>(q => q.Include != null)))
-            .ReturnsAsync(categoryToReturn ?? _testUpdatedCategory);
+            .ReturnsAsync(categoryToReturn);
 
         _mockRepositoryWrapper.Setup(x => x.SaveChangesAsync())
             .ReturnsAsync(saveResult);
+
+        _mockRepositoryWrapper.Setup(x => x.TeamCategoriesRepository.Update(It.IsAny<TeamCategory>()));
     }
 }


### PR DESCRIPTION
## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation status management for team category updates. When a category's name or description changes, related translations are now marked as outdated so they can be refreshed.

* **Tests**
  * Updated unit tests to better validate duplicate detection and update behavior for team categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->