### PR TITLE
Add Налаштування медіа tab in admin panel for Reporting page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
+
+public record UpdateReportMediaSettingsCommand(UpdateReportMediaSettingsDto Dto)
+    : IRequest<Result<ReportMediaSettingsDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
@@ -1,0 +1,140 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using Image = VictoryCenter.DAL.Entities.Image;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
+
+public class UpdateReportMediaSettingsHandler : IRequestHandler<UpdateReportMediaSettingsCommand, Result<ReportMediaSettingsDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly IValidator<UpdateReportMediaSettingsCommand> _validator;
+
+    public UpdateReportMediaSettingsHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, IValidator<UpdateReportMediaSettingsCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<ReportMediaSettingsDto>> Handle(UpdateReportMediaSettingsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var collectedFundsImageExists = await _repositoryWrapper.ImageRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<Image>
+                {
+                    Filter = i => i.Id == request.Dto.CollectedFundsBlock.ImageId,
+                    AsNoTracking = true
+                });
+
+            if (collectedFundsImageExists == null)
+            {
+                return Result.Fail<ReportMediaSettingsDto>(
+                    ErrorMessagesConstants.NotFound(request.Dto.CollectedFundsBlock.ImageId, typeof(Image)));
+            }
+
+            var changedLivesImageExists = await _repositoryWrapper.ImageRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<Image>
+                {
+                    Filter = i => i.Id == request.Dto.ChangedLivesBlock.ImageId,
+                    AsNoTracking = true
+                });
+
+            if (changedLivesImageExists == null)
+            {
+                return Result.Fail<ReportMediaSettingsDto>(
+                    ErrorMessagesConstants.NotFound(request.Dto.ChangedLivesBlock.ImageId, typeof(Image)));
+            }
+
+            var collectedFundsRepository = _repositoryWrapper.GetRepository<CollectedFundsBlock>();
+            var collectedFundsEntity = await collectedFundsRepository.GetFirstOrDefaultAsync();
+
+            if (collectedFundsEntity == null)
+            {
+                collectedFundsEntity = new CollectedFundsBlock
+                {
+                    Title = request.Dto.CollectedFundsBlock.Title,
+                    CollectedAmount = request.Dto.CollectedFundsBlock.CollectedFunds,
+                    ImageId = request.Dto.CollectedFundsBlock.ImageId,
+                };
+                await collectedFundsRepository.CreateAsync(collectedFundsEntity);
+            }
+            else
+            {
+                collectedFundsEntity.Title = request.Dto.CollectedFundsBlock.Title;
+                collectedFundsEntity.CollectedAmount = request.Dto.CollectedFundsBlock.CollectedFunds;
+                collectedFundsEntity.ImageId = request.Dto.CollectedFundsBlock.ImageId;
+                collectedFundsRepository.Update(collectedFundsEntity);
+            }
+
+            var changedLivesRepository = _repositoryWrapper.GetRepository<ChangedLivesBlock>();
+            var changedLivesEntity = await changedLivesRepository.GetFirstOrDefaultAsync();
+
+            if (changedLivesEntity == null)
+            {
+                changedLivesEntity = new ChangedLivesBlock
+                {
+                    Title = request.Dto.ChangedLivesBlock.Title,
+                    ChangedLivesCount = request.Dto.ChangedLivesBlock.ChangedLives,
+                    ImageId = request.Dto.ChangedLivesBlock.ImageId,
+                };
+                await changedLivesRepository.CreateAsync(changedLivesEntity);
+            }
+            else
+            {
+                changedLivesEntity.Title = request.Dto.ChangedLivesBlock.Title;
+                changedLivesEntity.ChangedLivesCount = request.Dto.ChangedLivesBlock.ChangedLives;
+                changedLivesEntity.ImageId = request.Dto.ChangedLivesBlock.ImageId;
+                changedLivesRepository.Update(changedLivesEntity);
+            }
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<ReportMediaSettingsDto>(
+                    ErrorMessagesConstants.FailedToUpdateEntity(typeof(CollectedFundsBlock)));
+            }
+
+            var updatedCollectedFunds = await collectedFundsRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<CollectedFundsBlock>
+                {
+                    Filter = x => x.Id == collectedFundsEntity.Id,
+                    Include = q => q.Include(x => x.Image!)
+                });
+
+            var updatedChangedLives = await changedLivesRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<ChangedLivesBlock>
+                {
+                    Filter = x => x.Id == changedLivesEntity.Id,
+                    Include = q => q.Include(x => x.Image!)
+                });
+
+            var resultDto = new ReportMediaSettingsDto
+            {
+                CollectedFundsBlock = _mapper.Map<CollectedFundsBlockDto>(updatedCollectedFunds),
+                ChangedLivesBlock = _mapper.Map<ChangedLivesBlockDto>(updatedChangedLives)
+            };
+
+            return Result.Ok(resultDto);
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<ReportMediaSettingsDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<ReportMediaSettingsDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(CollectedFundsBlock)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ChangedLivesBlockConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ChangedLivesBlockConstants.cs
@@ -1,0 +1,10 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class ChangedLivesBlockConstants
+{
+    public static readonly int TitleMaxLength = 20;
+    public static readonly int TitleMinLength = 10;
+
+    public static readonly int ChangeLivesMinValue = 0;
+    public static readonly int ChangeLivesMaxValue = 10;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ChangedLivesBlockConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ChangedLivesBlockConstants.cs
@@ -5,6 +5,6 @@ public static class ChangedLivesBlockConstants
     public static readonly int TitleMaxLength = 20;
     public static readonly int TitleMinLength = 10;
 
-    public static readonly int ChangeLivesMinValue = 0;
-    public static readonly int ChangeLivesMaxValue = 10;
+    public static readonly int ChangeLivesMinDigits = 0;
+    public static readonly int ChangeLivesMaxDigits = 10;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/CollectedFundsBlockConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/CollectedFundsBlockConstants.cs
@@ -5,6 +5,6 @@ public static class CollectedFundsBlockConstants
     public static readonly int TitleMaxLength = 50;
     public static readonly int TitleMinLength = 10;
 
-    public static readonly int CollectedAmountMinValue = 0;
-    public static readonly int CollectedAmountMaxValue = 15;
+    public static readonly int CollectedAmountMinDigits = 0;
+    public static readonly int CollectedAmountMaxDigits = 15;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/CollectedFundsBlockConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/CollectedFundsBlockConstants.cs
@@ -1,0 +1,10 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class CollectedFundsBlockConstants
+{
+    public static readonly int TitleMaxLength = 50;
+    public static readonly int TitleMinLength = 10;
+
+    public static readonly int CollectedAmountMinValue = 0;
+    public static readonly int CollectedAmountMaxValue = 15;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -166,4 +166,14 @@ public static class ErrorMessagesConstants
     {
         return $"{property} must contain only digits";
     }
+
+    public static string PropertyMustBeGreaterThanOrEqualToN(string property, long value)
+    {
+        return $"{property} must be greater than or equal to {value}";
+    }
+
+    public static string PropertyMustBeLessThanOrEqualToN(string property, long value)
+    {
+        return $"{property} must be less than or equal to {value}";
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/ChangedLivesBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/ChangedLivesBlockDto.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+public record ChangedLivesBlockDto
+{
+    public string Title { get; init; } = null!;
+    public int ChangedLives { get; init; }
+    public ImageDto? Image { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/CollectedFundsBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/CollectedFundsBlockDto.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+public record CollectedFundsBlockDto
+{
+    public string Title { get; init; } = null!;
+    public int CollectedAmount { get; init; }
+    public ImageDto? Image { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/CollectedFundsBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/CollectedFundsBlockDto.cs
@@ -5,6 +5,6 @@ namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
 public record CollectedFundsBlockDto
 {
     public string Title { get; init; } = null!;
-    public int CollectedAmount { get; init; }
+    public long CollectedAmount { get; init; }
     public ImageDto? Image { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/ReportMediaSettingsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/ReportMediaSettingsDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+public record ReportMediaSettingsDto
+{
+    public CollectedFundsBlockDto CollectedFundsBlock { get; set; }
+    public ChangedLivesBlockDto ChangedLivesBlock { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateChangedLivesBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateChangedLivesBlockDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+public record UpdateChangedLivesBlockDto
+{
+    public string Title { get; init; } = null!;
+    public int ChangedLives { get; init; }
+    public long ImageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateCollectedFundsBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateCollectedFundsBlockDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+public record UpdateCollectedFundsBlockDto
+{
+    public string Title { get; init; } = null!;
+    public int CollectedFunds { get; init; }
+    public long ImageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateCollectedFundsBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateCollectedFundsBlockDto.cs
@@ -3,6 +3,6 @@ namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
 public record UpdateCollectedFundsBlockDto
 {
     public string Title { get; init; } = null!;
-    public int CollectedFunds { get; init; }
+    public long CollectedFunds { get; init; }
     public long ImageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateReportMediaSettingsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateReportMediaSettingsDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+public record UpdateReportMediaSettingsDto
+{
+    public UpdateCollectedFundsBlockDto CollectedFundsBlock { get; set; }
+    public UpdateChangedLivesBlockDto ChangedLivesBlock { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ValidationHelpers.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ValidationHelpers.cs
@@ -1,0 +1,14 @@
+namespace VictoryCenter.BLL.Helpers;
+
+public static class ValidationHelpers
+{
+    public static Func<long, bool> HaveMaximumDigits(int maxDigits)
+    {
+        return value => value.ToString().Length <= maxDigits;
+    }
+
+    public static Func<int, bool> HaveMaximumDigitsInt(int maxDigits)
+    {
+        return value => value.ToString().Length <= maxDigits;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/ReportMediaSettings/ReportMediaSettingsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/ReportMediaSettings/ReportMediaSettingsProfile.cs
@@ -8,8 +8,11 @@ public class ReportMediaSettingsProfile : Profile
 {
     public ReportMediaSettingsProfile()
     {
-        CreateMap<ChangedLivesBlock, ChangedLivesBlockDto>();
-        CreateMap<CollectedFundsBlock, CollectedFundsBlockDto>();
+        CreateMap<ChangedLivesBlock, ChangedLivesBlockDto>()
+            .ForMember(dest => dest.ChangedLives, opt => opt.MapFrom(src => src.ChangedLivesCount));
+
+        CreateMap<CollectedFundsBlock, CollectedFundsBlockDto>()
+            .ForMember(dest => dest.CollectedAmount, opt => opt.MapFrom(src => src.CollectedAmount));
 
         CreateMap<UpdateChangedLivesBlockDto, ChangedLivesBlock>()
             .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/ReportMediaSettings/ReportMediaSettingsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/ReportMediaSettings/ReportMediaSettingsProfile.cs
@@ -1,0 +1,26 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Mapping.ReportMediaSettings;
+
+public class ReportMediaSettingsProfile : Profile
+{
+    public ReportMediaSettingsProfile()
+    {
+        CreateMap<ChangedLivesBlock, ChangedLivesBlockDto>();
+        CreateMap<CollectedFundsBlock, CollectedFundsBlockDto>();
+
+        CreateMap<UpdateChangedLivesBlockDto, ChangedLivesBlock>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.Image, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ChangedLivesCount, opt => opt.MapFrom(src => src.ChangedLives));
+
+        CreateMap<UpdateCollectedFundsBlockDto, CollectedFundsBlock>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.Image, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.CollectedAmount, opt => opt.MapFrom(src => src.CollectedFunds));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportMediaSettings/GetAll/GetReportMediaSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportMediaSettings/GetAll/GetReportMediaSettingsHandler.cs
@@ -1,0 +1,51 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.ReportMediaSettings.GetAll;
+public class GetReportMediaSettingsHandler
+    : IRequestHandler<GetReportMediaSettingsQuery, Result<ReportMediaSettingsDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+
+    public GetReportMediaSettingsHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<ReportMediaSettingsDto>> Handle(
+        GetReportMediaSettingsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var collectedFundsEntity = await _repositoryWrapper
+            .GetRepository<CollectedFundsBlock>()
+            .GetFirstOrDefaultAsync(new QueryOptions<CollectedFundsBlock>
+            {
+                Include = q => q.Include(b => b.Image!)
+            });
+
+        var changedLivesEntity = await _repositoryWrapper
+            .GetRepository<ChangedLivesBlock>()
+            .GetFirstOrDefaultAsync(new QueryOptions<ChangedLivesBlock>
+            {
+                Include = q => q.Include(b => b.Image!)
+            });
+
+        var resultDto = new ReportMediaSettingsDto
+        {
+            CollectedFundsBlock = _mapper.Map<CollectedFundsBlockDto>(collectedFundsEntity),
+            ChangedLivesBlock = _mapper.Map<ChangedLivesBlockDto>(changedLivesEntity)
+        };
+
+        return Result.Ok(resultDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportMediaSettings/GetAll/GetReportMediaSettingsQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportMediaSettings/GetAll/GetReportMediaSettingsQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+
+namespace VictoryCenter.BLL.Queries.Admin.ReportMediaSettings.GetAll;
+
+public record GetReportMediaSettingsQuery : IRequest<Result<ReportMediaSettingsDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportMediaSettings/Commands/UpdateReportMediaSettingsCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportMediaSettings/Commands/UpdateReportMediaSettingsCommandValidator.cs
@@ -23,12 +23,12 @@ public class UpdateReportMediaSettingsCommandValidator : AbstractValidator<Updat
         RuleFor(x => x.Dto.ChangedLivesBlock.ChangedLives)
             .NotNull()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateChangedLivesBlockDto.ChangedLives)))
-            .GreaterThanOrEqualTo(ChangedLivesBlockConstants.ChangeLivesMinValue)
+            .GreaterThanOrEqualTo(ChangedLivesBlockConstants.ChangeLivesMinDigits)
             .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN(
-                nameof(UpdateChangedLivesBlockDto.ChangedLives), ChangedLivesBlockConstants.ChangeLivesMinValue))
-            .Must((command, value) => ValidationHelpers.HaveMaximumDigitsInt(ChangedLivesBlockConstants.ChangeLivesMaxValue)(value))
+                nameof(UpdateChangedLivesBlockDto.ChangedLives), ChangedLivesBlockConstants.ChangeLivesMinDigits))
+            .Must((command, value) => ValidationHelpers.HaveMaximumDigitsInt(ChangedLivesBlockConstants.ChangeLivesMaxDigits)(value))
             .WithMessage(ErrorMessagesConstants.PropertyMustBeLessThanOrEqualToN(
-                nameof(UpdateChangedLivesBlockDto.ChangedLives), ChangedLivesBlockConstants.ChangeLivesMaxValue));
+                nameof(UpdateChangedLivesBlockDto.ChangedLives), ChangedLivesBlockConstants.ChangeLivesMaxDigits));
 
         RuleFor(x => x.Dto.ChangedLivesBlock.ImageId)
             .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateChangedLivesBlockDto.ImageId)));
@@ -46,12 +46,12 @@ public class UpdateReportMediaSettingsCommandValidator : AbstractValidator<Updat
         RuleFor(x => x.Dto.CollectedFundsBlock.CollectedFunds)
             .NotNull()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateCollectedFundsBlockDto.CollectedFunds)))
-            .GreaterThanOrEqualTo(CollectedFundsBlockConstants.CollectedAmountMinValue)
+            .GreaterThanOrEqualTo(CollectedFundsBlockConstants.CollectedAmountMinDigits)
             .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN(
-                nameof(UpdateCollectedFundsBlockDto.CollectedFunds), CollectedFundsBlockConstants.CollectedAmountMinValue))
-            .Must((command, value) => ValidationHelpers.HaveMaximumDigits(CollectedFundsBlockConstants.CollectedAmountMaxValue)(value))
+                nameof(UpdateCollectedFundsBlockDto.CollectedFunds), CollectedFundsBlockConstants.CollectedAmountMinDigits))
+            .Must((command, value) => ValidationHelpers.HaveMaximumDigits(CollectedFundsBlockConstants.CollectedAmountMaxDigits)(value))
             .WithMessage(ErrorMessagesConstants.PropertyMustBeLessThanOrEqualToN(
-                nameof(UpdateCollectedFundsBlockDto.CollectedFunds), CollectedFundsBlockConstants.CollectedAmountMaxValue));
+                nameof(UpdateCollectedFundsBlockDto.CollectedFunds), CollectedFundsBlockConstants.CollectedAmountMaxDigits));
 
         RuleFor(x => x.Dto.CollectedFundsBlock.ImageId)
             .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateCollectedFundsBlockDto.ImageId)));

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportMediaSettings/Commands/UpdateReportMediaSettingsCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportMediaSettings/Commands/UpdateReportMediaSettingsCommandValidator.cs
@@ -1,0 +1,59 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.BLL.Helpers;
+
+namespace VictoryCenter.BLL.Validators.ReportMediaSettings.Commands;
+
+public class UpdateReportMediaSettingsCommandValidator : AbstractValidator<UpdateReportMediaSettingsCommand>
+{
+    public UpdateReportMediaSettingsCommandValidator()
+    {
+        RuleFor(x => x.Dto.ChangedLivesBlock.Title)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateChangedLivesBlockDto.Title)))
+            .MinimumLength(ChangedLivesBlockConstants.TitleMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateChangedLivesBlockDto.Title), ChangedLivesBlockConstants.TitleMinLength))
+            .MaximumLength(ChangedLivesBlockConstants.TitleMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateChangedLivesBlockDto.Title), ChangedLivesBlockConstants.TitleMaxLength));
+
+        RuleFor(x => x.Dto.ChangedLivesBlock.ChangedLives)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateChangedLivesBlockDto.ChangedLives)))
+            .GreaterThanOrEqualTo(ChangedLivesBlockConstants.ChangeLivesMinValue)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN(
+                nameof(UpdateChangedLivesBlockDto.ChangedLives), ChangedLivesBlockConstants.ChangeLivesMinValue))
+            .Must((command, value) => ValidationHelpers.HaveMaximumDigitsInt(ChangedLivesBlockConstants.ChangeLivesMaxValue)(value))
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeLessThanOrEqualToN(
+                nameof(UpdateChangedLivesBlockDto.ChangedLives), ChangedLivesBlockConstants.ChangeLivesMaxValue));
+
+        RuleFor(x => x.Dto.ChangedLivesBlock.ImageId)
+            .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateChangedLivesBlockDto.ImageId)));
+
+        RuleFor(x => x.Dto.CollectedFundsBlock.Title)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateCollectedFundsBlockDto.Title)))
+            .MinimumLength(CollectedFundsBlockConstants.TitleMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateCollectedFundsBlockDto.Title), CollectedFundsBlockConstants.TitleMinLength))
+            .MaximumLength(CollectedFundsBlockConstants.TitleMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateCollectedFundsBlockDto.Title), CollectedFundsBlockConstants.TitleMaxLength));
+
+        RuleFor(x => x.Dto.CollectedFundsBlock.CollectedFunds)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateCollectedFundsBlockDto.CollectedFunds)))
+            .GreaterThanOrEqualTo(CollectedFundsBlockConstants.CollectedAmountMinValue)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN(
+                nameof(UpdateCollectedFundsBlockDto.CollectedFunds), CollectedFundsBlockConstants.CollectedAmountMinValue))
+            .Must((command, value) => ValidationHelpers.HaveMaximumDigits(CollectedFundsBlockConstants.CollectedAmountMaxValue)(value))
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeLessThanOrEqualToN(
+                nameof(UpdateCollectedFundsBlockDto.CollectedFunds), CollectedFundsBlockConstants.CollectedAmountMaxValue));
+
+        RuleFor(x => x.Dto.CollectedFundsBlock.ImageId)
+            .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateCollectedFundsBlockDto.ImageId)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ChangedLivesBlockConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ChangedLivesBlockConfig.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+internal class ChangedLivesBlockConfig : IEntityTypeConfiguration<ChangedLivesBlock>
+{
+    public void Configure(EntityTypeBuilder<ChangedLivesBlock> entity)
+    {
+        entity
+            .HasKey(x => x.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Title)
+            .IsRequired();
+
+        entity
+            .Property(e => e.ChangedLivesCount)
+            .IsRequired();
+
+        entity
+            .Property(e => e.ImageId);
+
+        entity
+            .HasOne(e => e.Image)
+            .WithOne()
+            .HasForeignKey<ChangedLivesBlock>(e => e.ImageId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/CollectedFundsBlockConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/CollectedFundsBlockConfig.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+internal class CollectedFundsBlockConfig : IEntityTypeConfiguration<CollectedFundsBlock>
+{
+    public void Configure(EntityTypeBuilder<CollectedFundsBlock> entity)
+    {
+        entity
+            .HasKey(x => x.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Title)
+            .IsRequired();
+
+        entity
+            .Property(e => e.CollectedAmount)
+            .IsRequired();
+
+        entity
+            .Property(e => e.ImageId);
+
+        entity
+            .HasOne(e => e.Image)
+            .WithOne()
+            .HasForeignKey<CollectedFundsBlock>(e => e.ImageId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -61,6 +61,10 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<PartnersPageBanner> PartnersPageBanners { get; set; }
 
+    public DbSet<ChangedLivesBlock> ChangedLivesBlocks { get; set; }
+
+    public DbSet<CollectedFundsBlock> CollectedFundsBlocks { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ChangedLivesBlock.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ChangedLivesBlock.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+public class ChangedLivesBlock : BaseEntity
+{
+    public string Title { get; set; }
+    public int ChangedLivesCount { get; set; }
+    public long ImageId { get; set; }
+    public Image Image { get; set; } = null;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/CollectedFundsBlock.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/CollectedFundsBlock.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+public class CollectedFundsBlock : BaseEntity
+{
+    public string Title { get; set; }
+    public int CollectedAmount { get; set; }
+    public long ImageId { get; set; }
+    public Image Image { get; set; } = null;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/CollectedFundsBlock.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/CollectedFundsBlock.cs
@@ -4,7 +4,7 @@ namespace VictoryCenter.DAL.Entities;
 public class CollectedFundsBlock : BaseEntity
 {
     public string Title { get; set; }
-    public int CollectedAmount { get; set; }
+    public long CollectedAmount { get; set; }
     public long ImageId { get; set; }
     public Image Image { get; set; } = null;
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260209144355_ReportMedia.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260209144355_ReportMedia.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260209144355_ReportMedia")]
+    partial class ReportMedia
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260209144355_ReportMedia.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260209144355_ReportMedia.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReportMedia : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChangedLivesBlocks",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ChangedLivesCount = table.Column<int>(type: "int", nullable: false),
+                    ImageId = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChangedLivesBlocks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChangedLivesBlocks_Images_ImageId",
+                        column: x => x.ImageId,
+                        principalSchema: "media",
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CollectedFundsBlocks",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CollectedAmount = table.Column<int>(type: "int", nullable: false),
+                    ImageId = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CollectedFundsBlocks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CollectedFundsBlocks_Images_ImageId",
+                        column: x => x.ImageId,
+                        principalSchema: "media",
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChangedLivesBlocks_ImageId",
+                table: "ChangedLivesBlocks",
+                column: "ImageId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CollectedFundsBlocks_ImageId",
+                table: "CollectedFundsBlocks",
+                column: "ImageId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChangedLivesBlocks");
+
+            migrationBuilder.DropTable(
+                name: "CollectedFundsBlocks");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260212124426_AddReportMediaSettings.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260212124426_AddReportMediaSettings.Designer.cs
@@ -12,8 +12,8 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    [Migration("20260209144355_ReportMedia")]
-    partial class ReportMedia
+    [Migration("20260212124426_AddReportMediaSettings")]
+    partial class AddReportMediaSettings
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -287,8 +287,8 @@ namespace VictoryCenter.DAL.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
-                    b.Property<int>("CollectedAmount")
-                        .HasColumnType("int");
+                    b.Property<long>("CollectedAmount")
+                        .HasColumnType("bigint");
 
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("datetimeoffset");

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260212124426_AddReportMediaSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260212124426_AddReportMediaSettings.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace VictoryCenter.DAL.Migrations
 {
     /// <inheritdoc />
-    public partial class ReportMedia : Migration
+    public partial class AddReportMediaSettings : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -41,7 +41,7 @@ namespace VictoryCenter.DAL.Migrations
                     Id = table.Column<long>(type: "bigint", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    CollectedAmount = table.Column<int>(type: "int", nullable: false),
+                    CollectedAmount = table.Column<long>(type: "bigint", nullable: false),
                     ImageId = table.Column<long>(type: "bigint", nullable: false),
                     CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
                 },

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/VictoryCenterDbContextModelSnapshot.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/VictoryCenterDbContextModelSnapshot.cs
@@ -284,8 +284,8 @@ namespace VictoryCenter.DAL.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
 
-                    b.Property<int>("CollectedAmount")
-                        .HasColumnType("int");
+                    b.Property<long>("CollectedAmount")
+                        .HasColumnType("bigint");
 
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("datetimeoffset");

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -15,6 +15,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreSections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Partners;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportMediaSettings;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -42,6 +43,10 @@ public interface IRepositoryWrapper
     IPartnersPageBannersRepository PartnersPageBannersRepository { get; }
 
     ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository { get; }
+
+    IChangedLivesBlockRepository ChangedLivesBlockRepository { get; }
+
+    ICollectedFundsBlockRepository CollectedFundsBlockRepository { get; }
 
     IRepositoryBase<TEntity> GetRepository<TEntity>()
         where TEntity : class;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/ReportMediaSettings/IChangedLivesBlockRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/ReportMediaSettings/IChangedLivesBlockRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.ReportMediaSettings;
+
+public interface IChangedLivesBlockRepository : IRepositoryBase<ChangedLivesBlock>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/ReportMediaSettings/ICollectedFundsBlockRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/ReportMediaSettings/ICollectedFundsBlockRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.ReportMediaSettings;
+
+public interface ICollectedFundsBlockRepository : IRepositoryBase<CollectedFundsBlock>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -7,10 +7,13 @@ using VictoryCenter.DAL.Repositories.Interfaces.FaqPlacements;
 using VictoryCenter.DAL.Repositories.Interfaces.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.HippotherapyPrograms;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.Media;
 using VictoryCenter.DAL.Repositories.Interfaces.Partners;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportMediaSettings;
 using VictoryCenter.DAL.Repositories.Interfaces.TeamCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.VisitorPages;
@@ -21,19 +24,18 @@ using VictoryCenter.DAL.Repositories.Realizations.FaqPlacements;
 using VictoryCenter.DAL.Repositories.Realizations.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Realizations.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Realizations.HippotherapyPrograms;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.Languages;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Realizations.Media;
 using VictoryCenter.DAL.Repositories.Realizations.Partners;
+using VictoryCenter.DAL.Repositories.Realizations.ReportMediaSettings;
 using VictoryCenter.DAL.Repositories.Realizations.TeamCategories;
 using VictoryCenter.DAL.Repositories.Realizations.TeamMembers;
 using VictoryCenter.DAL.Repositories.Realizations.VisitorPages;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreSections;
-using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
-using VictoryCenter.DAL.Repositories.Realizations.Localization.FaqQuestions;
-using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
-using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamCategories;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -62,6 +64,8 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IPartnerSectionsRepository? _partnerSectionRepository;
     private IPartnersPageBannersRepository? _partnersPageBannersRepository;
     private ITeamCategoryLocalizationsRepository? _teamCategoryLocalizationsRepository;
+    private ICollectedFundsBlockRepository? _collectedFundsBlockRepository;
+    private IChangedLivesBlockRepository? _changedLivesBlockRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -98,6 +102,10 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IPartnersPageBannersRepository PartnersPageBannersRepository => _partnersPageBannersRepository ??= new PartnersPageBannersRepository(_victoryCenterDbContext);
 
     public ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository => _teamCategoryLocalizationsRepository ??= new TeamCategoryLocalizationRepository(_victoryCenterDbContext);
+
+    public ICollectedFundsBlockRepository CollectedFundsBlockRepository => _collectedFundsBlockRepository ??= new CollectedFundsBlockRepository(_victoryCenterDbContext);
+
+    public IChangedLivesBlockRepository ChangedLivesBlockRepository => _changedLivesBlockRepository ??= new ChangedLivesBlockRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportMediaSettings/ChangedLivesBlockRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportMediaSettings/ChangedLivesBlockRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportMediaSettings;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.ReportMediaSettings;
+
+public class ChangedLivesBlockRepository : RepositoryBase<ChangedLivesBlock>, IChangedLivesBlockRepository
+{
+    public ChangedLivesBlockRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportMediaSettings/CollectedFundsBlockRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportMediaSettings/CollectedFundsBlockRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportMediaSettings;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.ReportMediaSettings;
+
+public class CollectedFundsBlockRepository : RepositoryBase<CollectedFundsBlock>, ICollectedFundsBlockRepository
+{
+    public CollectedFundsBlockRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Report/GetReportMediaSettings/GetReportMediaSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Report/GetReportMediaSettings/GetReportMediaSettingsTests.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using System.Text.Json;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Report.GetReportMediaSettings;
+public class GetReportMediaSettingsTests : BaseTestClass
+{
+    private readonly Uri _endpointUri = new("/api/Report/report", UriKind.Relative);
+
+    public GetReportMediaSettingsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetReportMediaSettings_ShouldReturnReportSettings()
+    {
+        // Act
+        var response = await Fixture.HttpClient.GetAsync(_endpointUri);
+        var responseString = await response.Content.ReadAsStringAsync();
+        var responseContent = JsonSerializer.Deserialize<ReportMediaSettingsDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(responseContent);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Report/UpdateReportMediaSettings/UpdateReportMediaSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Report/UpdateReportMediaSettings/UpdateReportMediaSettingsTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Report.UpdateReportMediaSettings;
+public class UpdateReportMediaSettingsTests : BaseTestClass
+{
+    private readonly Uri _endpointUri = new("/api/Report/report", UriKind.Relative);
+
+    public UpdateReportMediaSettingsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateReportMediaSettings_WithValidData_ShouldReturnOkAndUpdateEntity()
+    {
+        // Arrange
+        var image1 = await Fixture.DbContext.Images.OrderBy(i => i.Id).FirstAsync();
+        var image2 = await Fixture.DbContext.Images.OrderByDescending(i => i.Id).FirstAsync();
+
+        var updateDto = new UpdateReportMediaSettingsDto
+        {
+            CollectedFundsBlock = new UpdateCollectedFundsBlockDto
+            {
+                Title = "Updated Funds Title",
+                CollectedFunds = 500000,
+                ImageId = image1.Id
+            },
+            ChangedLivesBlock = new UpdateChangedLivesBlockDto
+            {
+                Title = "Updated Lives Title",
+                ChangedLives = 2500,
+                ImageId = image2.Id
+            }
+        };
+
+        var serializedDto = JsonSerializer.Serialize(updateDto);
+        var content = new StringContent(serializedDto, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync(_endpointUri, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        var collectedFundsEntity = await Fixture.DbContext.CollectedFundsBlocks.FirstAsync();
+        var changedLivesEntity = await Fixture.DbContext.ChangedLivesBlocks.FirstAsync();
+
+        Assert.Equal(updateDto.CollectedFundsBlock.Title, collectedFundsEntity.Title);
+        Assert.Equal(updateDto.CollectedFundsBlock.CollectedFunds, collectedFundsEntity.CollectedAmount);
+        Assert.Equal(updateDto.CollectedFundsBlock.ImageId, collectedFundsEntity.ImageId);
+
+        Assert.Equal(updateDto.ChangedLivesBlock.Title, changedLivesEntity.Title);
+        Assert.Equal(updateDto.ChangedLivesBlock.ChangedLives, changedLivesEntity.ChangedLivesCount);
+        Assert.Equal(updateDto.ChangedLivesBlock.ImageId, changedLivesEntity.ImageId);
+    }
+
+    [Fact]
+    public async Task UpdateReportMediaSettings_WithNonExistentImageId_ShouldReturnNotFound()
+    {
+        // Arrange
+        // Get the maximum existing image ID and use a non-existent ID
+        var maxImageId = await Fixture.DbContext.Images.MaxAsync(i => (long?)i.Id) ?? 0;
+        var nonExistentImageId = maxImageId + 1000; // Use a large non-existent ID
+
+        var updateDto = new UpdateReportMediaSettingsDto
+        {
+            CollectedFundsBlock = new UpdateCollectedFundsBlockDto
+            {
+                Title = "Funds Title",
+                CollectedFunds = 1000,
+                ImageId = nonExistentImageId
+            },
+            ChangedLivesBlock = new UpdateChangedLivesBlockDto
+            {
+                Title = "Lives Title",
+                ChangedLives = 100,
+                ImageId = nonExistentImageId
+            }
+        };
+
+        var serializedDto = JsonSerializer.Serialize(updateDto);
+        var content = new StringContent(serializedDto, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync(_endpointUri, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateReportMediaSettings_WithEmptyTitle_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var image = await Fixture.DbContext.Images.FirstAsync();
+
+        var updateDto = new UpdateReportMediaSettingsDto
+        {
+            CollectedFundsBlock = new UpdateCollectedFundsBlockDto
+            {
+                Title = "",
+                CollectedFunds = 1000,
+                ImageId = image.Id
+            },
+            ChangedLivesBlock = new UpdateChangedLivesBlockDto
+            {
+                Title = "Valid",
+                ChangedLives = 100,
+                ImageId = image.Id
+            }
+        };
+
+        var serializedDto = JsonSerializer.Serialize(updateDto);
+        var content = new StringContent(serializedDto, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync(_endpointUri, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ValidationHelpersTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ValidationHelpersTests.cs
@@ -1,0 +1,106 @@
+using VictoryCenter.BLL.Helpers;
+
+namespace VictoryCenter.UnitTests.HelperTests;
+
+public class ValidationHelpersTests
+{
+    [Fact]
+    public void HaveMaximumDigits_Long_LessThanLimit_ReturnsTrue()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigits(5);
+
+        var result = validator(123);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigits_Long_EqualToLimit_ReturnsTrue()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigits(3);
+
+        var result = validator(123);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigits_Long_GreaterThanLimit_ReturnsFalse()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigits(2);
+
+        var result = validator(123);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigits_Long_Zero_ReturnsTrue()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigits(1);
+
+        var result = validator(0);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigits_Long_NegativeNumber_CountsMinusSign()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigits(3);
+
+        var result = validator(-12); // "-12" length = 3
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigitsInt_LessThanLimit_ReturnsTrue()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigitsInt(4);
+
+        var result = validator(99);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigitsInt_EqualToLimit_ReturnsTrue()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigitsInt(2);
+
+        var result = validator(99);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigitsInt_GreaterThanLimit_ReturnsFalse()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigitsInt(2);
+
+        var result = validator(123);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigitsInt_Zero_ReturnsTrue()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigitsInt(1);
+
+        var result = validator(0);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HaveMaximumDigitsInt_NegativeNumber_CountsMinusSign()
+    {
+        var validator = ValidationHelpers.HaveMaximumDigitsInt(3);
+
+        var result = validator(-12); // "-12" length = 3
+
+        Assert.True(result);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/GetReportMediaSettingsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/GetReportMediaSettingsHandlerTests.cs
@@ -1,0 +1,125 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.BLL.Queries.Admin.ReportMediaSettings.GetAll;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportMediaSettings;
+public class GetReportMediaSettingsHandlerTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+
+    private readonly CollectedFundsBlock _collectedEntity = new()
+    {
+        Id = 1,
+        Title = "Collected",
+        CollectedAmount = 100,
+        ImageId = 10
+    };
+
+    private readonly ChangedLivesBlock _changedEntity = new()
+    {
+        Id = 2,
+        Title = "Lives",
+        ChangedLivesCount = 50,
+        ImageId = 20
+    };
+
+    private readonly ReportMediaSettingsDto _resultDto = new()
+    {
+        CollectedFundsBlock = new(),
+        ChangedLivesBlock = new()
+    };
+
+    public GetReportMediaSettingsHandlerTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+    }
+
+    [Fact]
+    public async Task Handle_BlocksExist_ShouldReturnOk()
+    {
+        // Arrange
+        SetupRepositoryWrapper(_collectedEntity, _changedEntity);
+        SetupMapper(_resultDto);
+
+        var query = new GetReportMediaSettingsQuery();
+        var handler = new GetReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_resultDto, result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_BlocksDoNotExist_ShouldReturnOkWithNullDtos()
+    {
+        // Arrange
+        SetupRepositoryWrapper(null, null);
+
+        _mockMapper
+            .Setup(m => m.Map<CollectedFundsBlockDto>(null))
+            .Returns((CollectedFundsBlockDto?)null);
+
+        _mockMapper
+            .Setup(m => m.Map<ChangedLivesBlockDto>(null))
+            .Returns((ChangedLivesBlockDto?)null);
+
+        var query = new GetReportMediaSettingsQuery();
+        var handler = new GetReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value.CollectedFundsBlock);
+        Assert.Null(result.Value.ChangedLivesBlock);
+    }
+
+    private void SetupMapper(ReportMediaSettingsDto dtoToReturn)
+    {
+        _mockMapper
+            .Setup(m => m.Map<CollectedFundsBlockDto>(It.IsAny<CollectedFundsBlock>()))
+            .Returns(dtoToReturn.CollectedFundsBlock);
+
+        _mockMapper
+            .Setup(m => m.Map<ChangedLivesBlockDto>(It.IsAny<ChangedLivesBlock>()))
+            .Returns(dtoToReturn.ChangedLivesBlock);
+    }
+
+    private void SetupRepositoryWrapper(
+        CollectedFundsBlock? collectedBlock,
+        ChangedLivesBlock? changedBlock)
+    {
+        var collectedRepo = new Mock<IRepositoryBase<CollectedFundsBlock>>();
+        var changedRepo = new Mock<IRepositoryBase<ChangedLivesBlock>>();
+
+        collectedRepo
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CollectedFundsBlock>>()))
+            .ReturnsAsync(collectedBlock);
+
+        changedRepo
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChangedLivesBlock>>()))
+            .ReturnsAsync(changedBlock);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.GetRepository<CollectedFundsBlock>())
+            .Returns(collectedRepo.Object);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.GetRepository<ChangedLivesBlock>())
+            .Returns(changedRepo.Object);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/UpdateReportMediaSettingsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/UpdateReportMediaSettingsHandlerTests.cs
@@ -1,0 +1,273 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportMediaSettings;
+public class UpdateReportMediaSettingsTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IValidator<UpdateReportMediaSettingsCommand>> _mockValidator;
+
+    private readonly UpdateReportMediaSettingsDto _updateDto = new()
+    {
+        CollectedFundsBlock = new()
+        {
+            Title = "Collected",
+            CollectedFunds = 100,
+            ImageId = 1
+        },
+        ChangedLivesBlock = new()
+        {
+            Title = "Lives",
+            ChangedLives = 50,
+            ImageId = 2
+        }
+    };
+
+    private readonly Image _collectedImage = new() { Id = 1 };
+    private readonly Image _changedImage = new() { Id = 2 };
+
+    private readonly CollectedFundsBlock _existingCollected = new()
+    {
+        Id = 1,
+        Title = "Old",
+        CollectedAmount = 10,
+        ImageId = 5
+    };
+
+    private readonly ChangedLivesBlock _existingChanged = new()
+    {
+        Id = 2,
+        Title = "Old",
+        ChangedLivesCount = 5,
+        ImageId = 6
+    };
+
+    private readonly ReportMediaSettingsDto _resultDto = new()
+    {
+        CollectedFundsBlock = new(),
+        ChangedLivesBlock = new()
+    };
+
+    public UpdateReportMediaSettingsTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockValidator = new Mock<IValidator<UpdateReportMediaSettingsCommand>>();
+    }
+
+    [Fact]
+    public async Task Handle_BlocksDoNotExist_ShouldCreateAndReturnOk()
+    {
+        // Arrange
+        var createdCollected = new CollectedFundsBlock { Id = 1 };
+        var createdChanged = new ChangedLivesBlock { Id = 2 };
+
+        SetupRepositoryWrapper(
+            collectedImage: _collectedImage,
+            changedImage: _changedImage,
+            collectedBlock: null,
+            changedBlock: null,
+            finalCollected: createdCollected,
+            finalChanged: createdChanged);
+
+        SetupMapper(_resultDto);
+
+        var command = new UpdateReportMediaSettingsCommand(_updateDto);
+        var handler = new UpdateReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockValidator.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_resultDto, result.Value);
+
+        _mockRepositoryWrapper.Verify(
+            r => r.GetRepository<CollectedFundsBlock>().CreateAsync(It.IsAny<CollectedFundsBlock>()),
+            Times.Once);
+
+        _mockRepositoryWrapper.Verify(
+            r => r.GetRepository<ChangedLivesBlock>().CreateAsync(It.IsAny<ChangedLivesBlock>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_BlocksExist_ShouldUpdateAndReturnOk()
+    {
+        // Arrange
+        SetupRepositoryWrapper(
+            collectedImage: _collectedImage,
+            changedImage: _changedImage,
+            collectedBlock: _existingCollected,
+            changedBlock: _existingChanged,
+            finalCollected: _existingCollected,
+            finalChanged: _existingChanged);
+
+        SetupMapper(_resultDto);
+
+        var command = new UpdateReportMediaSettingsCommand(_updateDto);
+        var handler = new UpdateReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockValidator.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_resultDto, result.Value);
+
+        _mockRepositoryWrapper.Verify(
+            r => r.GetRepository<CollectedFundsBlock>().Update(_existingCollected),
+            Times.Once);
+
+        _mockRepositoryWrapper.Verify(
+            r => r.GetRepository<ChangedLivesBlock>().Update(_existingChanged),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CollectedImageNotFound_ShouldReturnFailure()
+    {
+        // Arrange
+        SetupRepositoryWrapper(
+            collectedImage: null,
+            changedImage: null,
+            collectedBlock: null,
+            changedBlock: null,
+            finalCollected: null,
+            finalChanged: null);
+
+        var command = new UpdateReportMediaSettingsCommand(_updateDto);
+        var handler = new UpdateReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockValidator.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ChangedImageNotFound_ShouldReturnFailure()
+    {
+        // Arrange
+        SetupRepositoryWrapper(
+            collectedImage: _collectedImage,
+            changedImage: null,
+            collectedBlock: null,
+            changedBlock: null,
+            finalCollected: null,
+            finalChanged: null);
+
+        var command = new UpdateReportMediaSettingsCommand(_updateDto);
+        var handler = new UpdateReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockValidator.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_DbUpdateException_ShouldReturnFailure()
+    {
+        // Arrange
+        SetupRepositoryWrapper(
+            collectedImage: _collectedImage,
+            changedImage: _changedImage,
+            collectedBlock: _existingCollected,
+            changedBlock: _existingChanged,
+            finalCollected: _existingCollected,
+            finalChanged: _existingChanged);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var command = new UpdateReportMediaSettingsCommand(_updateDto);
+        var handler = new UpdateReportMediaSettingsHandler(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object,
+            _mockValidator.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(CollectedFundsBlock)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupMapper(ReportMediaSettingsDto dtoToReturn)
+    {
+        _mockMapper
+            .Setup(m => m.Map<CollectedFundsBlockDto>(It.IsAny<CollectedFundsBlock>()))
+            .Returns(dtoToReturn.CollectedFundsBlock);
+
+        _mockMapper
+            .Setup(m => m.Map<ChangedLivesBlockDto>(It.IsAny<ChangedLivesBlock>()))
+            .Returns(dtoToReturn.ChangedLivesBlock);
+    }
+
+    private void SetupRepositoryWrapper(
+        Image? collectedImage,
+        Image? changedImage,
+        CollectedFundsBlock? collectedBlock,
+        ChangedLivesBlock? changedBlock,
+        CollectedFundsBlock? finalCollected,
+        ChangedLivesBlock? finalChanged)
+    {
+        var collectedRepo = new Mock<IRepositoryBase<CollectedFundsBlock>>();
+        var changedRepo = new Mock<IRepositoryBase<ChangedLivesBlock>>();
+
+        collectedRepo
+            .SetupSequence(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CollectedFundsBlock>>()))
+            .ReturnsAsync(collectedBlock)
+            .ReturnsAsync(finalCollected);
+
+        changedRepo
+            .SetupSequence(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChangedLivesBlock>>()))
+            .ReturnsAsync(changedBlock)
+            .ReturnsAsync(finalChanged);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.GetRepository<CollectedFundsBlock>())
+            .Returns(collectedRepo.Object);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.GetRepository<ChangedLivesBlock>())
+            .Returns(changedRepo.Object);
+
+        _mockRepositoryWrapper
+            .SetupSequence(r => r.ImageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Image>>()))
+            .ReturnsAsync(collectedImage)
+            .ReturnsAsync(changedImage);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(1);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/UpdateReportMediaSettingsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/UpdateReportMediaSettingsHandlerTests.cs
@@ -10,7 +10,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportMediaSettings;
-public class UpdateReportMediaSettingsTests
+public class UpdateReportMediaSettingsHandlerTests
 {
     private readonly Mock<IMapper> _mockMapper;
     private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
@@ -57,7 +57,7 @@ public class UpdateReportMediaSettingsTests
         ChangedLivesBlock = new()
     };
 
-    public UpdateReportMediaSettingsTests()
+    public UpdateReportMediaSettingsHandlerTests()
     {
         _mockMapper = new Mock<IMapper>();
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportMediaSettings/UpdateReportMediaSettingsCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportMediaSettings/UpdateReportMediaSettingsCommandValidatorTests.cs
@@ -51,7 +51,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     public void Validate_ChangedLivesBlockTitleTooShort_ShouldHaveValidationError()
     {
         var command = CreateCommand(
-            changedLivesTitle: "Short", // Менше ніж TitleMinLength (10)
+            changedLivesTitle: "Short",
             changedLives: 1000,
             changedLivesImageId: 1,
             collectedFundsTitle: "Valid Title",
@@ -114,7 +114,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     [Fact]
     public void Validate_ChangedLivesBlockTitleValid_ShouldHaveValidationError()
     {
-        var command = CreateValidCommand();
+        var command = CreateNotValidCommand();
 
         var result = _validator.TestValidate(command);
 
@@ -156,7 +156,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     [Fact]
     public void Validate_ChangedLivesIsValid_ShouldNotHaveValidationError()
     {
-        var command = CreateValidCommand();
+        var command = CreateNotValidCommand();
 
         var result = _validator.TestValidate(command);
 
@@ -198,7 +198,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     [Fact]
     public void Validate_ChangedLivesBlockImageIdIsPositive_ShouldNotHaveValidationError()
     {
-        var command = CreateValidCommand();
+        var command = CreateNotValidCommand();
 
         var result = _validator.TestValidate(command);
 
@@ -304,7 +304,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     [Fact]
     public void Validate_CollectedFundsBlockTitleValid_ShouldNotHaveValidationError()
     {
-        var command = CreateValidCommand();
+        var command = CreateNotValidCommand();
 
         var result = _validator.TestValidate(command);
 
@@ -335,7 +335,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
             changedLives: 1000,
             changedLivesImageId: 1,
             collectedFundsTitle: "Valid Title",
-            collectedFunds: 1_000_000_000_000_000, // 16 цифр
+            collectedFunds: 1_000_000_000_000_000,
             collectedFundsImageId: 2);
 
         var result = _validator.TestValidate(command);
@@ -351,7 +351,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
             changedLives: 1000,
             changedLivesImageId: 1,
             collectedFundsTitle: "Valid Title",
-            collectedFunds: 111111111111111, // 15 цифр
+            collectedFunds: 111111111111111,
             collectedFundsImageId: 2);
 
         var result = _validator.TestValidate(command);
@@ -378,7 +378,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     [Fact]
     public void Validate_CollectedFundsIsValid_ShouldNotHaveValidationError()
     {
-        var command = CreateValidCommand();
+        var command = CreateNotValidCommand();
 
         var result = _validator.TestValidate(command);
 
@@ -420,7 +420,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
     [Fact]
     public void Validate_CollectedFundsBlockImageIdIsPositive_ShouldNotHaveValidationError()
     {
-        var command = CreateValidCommand();
+        var command = CreateNotValidCommand();
 
         var result = _validator.TestValidate(command);
 
@@ -448,7 +448,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.ImageId);
     }
 
-    private UpdateReportMediaSettingsCommand CreateValidCommand()
+    private UpdateReportMediaSettingsCommand CreateNotValidCommand()
     {
         return CreateCommand(
             changedLivesTitle: "Valid Title for Changed Lives",
@@ -478,7 +478,7 @@ public class UpdateReportMediaSettingsCommandValidatorTests
             CollectedFundsBlock = new UpdateCollectedFundsBlockDto
             {
                 Title = collectedFundsTitle,
-                CollectedFunds = (int)collectedFunds, // ✅ Виправлено - тепер long
+                CollectedFunds = collectedFunds,
                 ImageId = collectedFundsImageId
             }
         };

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportMediaSettings/UpdateReportMediaSettingsCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportMediaSettings/UpdateReportMediaSettingsCommandValidatorTests.cs
@@ -1,0 +1,488 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.BLL.Validators.ReportMediaSettings.Commands;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.ReportMediaSettings;
+
+public class UpdateReportMediaSettingsCommandValidatorTests
+{
+    private readonly UpdateReportMediaSettingsCommandValidator _validator;
+
+    public UpdateReportMediaSettingsCommandValidatorTests()
+    {
+        _validator = new UpdateReportMediaSettingsCommandValidator();
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleIsEmpty_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: string.Empty,
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleIsNull_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: null!,
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleTooShort_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Short", // Менше ніж TitleMinLength (10)
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleTooLong_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: new string('a', ChangedLivesBlockConstants.TitleMaxLength + 1),
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleAtMinLength_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: new string('a', ChangedLivesBlockConstants.TitleMinLength),
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleAtMaxLength_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: new string('a', ChangedLivesBlockConstants.TitleMaxLength),
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockTitleValid_ShouldHaveValidationError()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesIsNegative_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: -1,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ChangedLives);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesIsZero_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 0,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ChangedLives);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesIsValid_ShouldNotHaveValidationError()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ChangedLives);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockImageIdIsZero_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 0,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ImageId);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockImageIdIsNegative_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: -1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ImageId);
+    }
+
+    [Fact]
+    public void Validate_ChangedLivesBlockImageIdIsPositive_ShouldNotHaveValidationError()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ImageId);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleIsEmpty_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: string.Empty,
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleIsNull_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: null!,
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleTooShort_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Short",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleTooLong_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: new string('a', CollectedFundsBlockConstants.TitleMaxLength + 1),
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleAtMinLength_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: new string('a', CollectedFundsBlockConstants.TitleMinLength),
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleAtMaxLength_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: new string('a', CollectedFundsBlockConstants.TitleMaxLength),
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockTitleValid_ShouldNotHaveValidationError()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsIsNegative_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: -1,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.CollectedFunds);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsExceeds15Digits_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 1_000_000_000_000_000, // 16 цифр
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.CollectedFunds);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsIs15Digits_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 111111111111111, // 15 цифр
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.CollectedFunds);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsIsZero_ShouldNotHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 0,
+            collectedFundsImageId: 2);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.CollectedFunds);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsIsValid_ShouldNotHaveValidationError()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.CollectedFunds);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockImageIdIsZero_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: 0);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.ImageId);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockImageIdIsNegative_ShouldHaveValidationError()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: "Valid Title",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title",
+            collectedFunds: 500000,
+            collectedFundsImageId: -1);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.ImageId);
+    }
+
+    [Fact]
+    public void Validate_CollectedFundsBlockImageIdIsPositive_ShouldNotHaveValidationError()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.ImageId);
+    }
+
+    [Fact]
+    public void Validate_MultiplePropertiesInvalid_ShouldHaveMultipleValidationErrors()
+    {
+        var command = CreateCommand(
+            changedLivesTitle: string.Empty,
+            changedLives: -1,
+            changedLivesImageId: -1,
+            collectedFundsTitle: null!,
+            collectedFunds: -1,
+            collectedFundsImageId: 0);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.Title);
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ChangedLives);
+        result.ShouldHaveValidationErrorFor(x => x.Dto.ChangedLivesBlock.ImageId);
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.Title);
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.CollectedFunds);
+        result.ShouldHaveValidationErrorFor(x => x.Dto.CollectedFundsBlock.ImageId);
+    }
+
+    private UpdateReportMediaSettingsCommand CreateValidCommand()
+    {
+        return CreateCommand(
+            changedLivesTitle: "Valid Title for Changed Lives",
+            changedLives: 1000,
+            changedLivesImageId: 1,
+            collectedFundsTitle: "Valid Title for Collected Funds",
+            collectedFunds: 500000,
+            collectedFundsImageId: 2);
+    }
+
+    private UpdateReportMediaSettingsCommand CreateCommand(
+        string changedLivesTitle,
+        int changedLives,
+        long changedLivesImageId,
+        string collectedFundsTitle,
+        long collectedFunds,
+        long collectedFundsImageId)
+    {
+        var dto = new UpdateReportMediaSettingsDto
+        {
+            ChangedLivesBlock = new UpdateChangedLivesBlockDto
+            {
+                Title = changedLivesTitle,
+                ChangedLives = changedLives,
+                ImageId = changedLivesImageId
+            },
+            CollectedFundsBlock = new UpdateCollectedFundsBlockDto
+            {
+                Title = collectedFundsTitle,
+                CollectedFunds = (int)collectedFunds, // ✅ Виправлено - тепер long
+                ImageId = collectedFundsImageId
+            }
+        };
+
+        return new UpdateReportMediaSettingsCommand(dto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
+using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.BLL.Queries.Admin.ReportMediaSettings.GetAll;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class ReportController : AuthorizedApiController
+{
+    [HttpGet("report")]
+    [ProducesResponseType(typeof(ReportMediaSettingsDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetReportMediaSettings()
+    {
+        return HandleResult(await Mediator.Send(new GetReportMediaSettingsQuery()));
+    }
+
+    [HttpPut("report")]
+    [ProducesResponseType(typeof(ReportMediaSettingsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateReportMediaSettings([FromBody] UpdateReportMediaSettingsDto updateReportMediaSettingsDto)
+    {
+        return HandleResult(await Mediator.Send(new UpdateReportMediaSettingsCommand(updateReportMediaSettingsDto)));
+    }
+}


### PR DESCRIPTION
dev
## JIRA

https://github.com/ita-social-projects/VictoryCenter-Back/issues/1338


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

Implemented Report Management API for admin side:
GET /api/Report/report – retrieve all reports settings
PUT /api/Report/report - update all reports settings

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin endpoints to get and update report media settings (Collected Funds & Changed Lives) with validation, image linking, DTOs, persistence, and DB model support.
  * Added validation helpers, constants, repository support, and AutoMapper mappings for the new blocks.

* **Tests**
  * Comprehensive unit and integration tests covering handlers, validators, helpers, repositories, and controller endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->