### PR TITLE
Feature/issue-1326: Upload PDF file in UA

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+
+public record CreatePdfReportCommand(CreatePdfReportDto CreatePdfReportDto) : IRequest<Result<PdfReportDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
@@ -1,0 +1,86 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.BLL.Interfaces.ReorderService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+
+public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Result<PdfReportDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IPdfService _pdfService;
+    private readonly IValidator<CreatePdfReportCommand> _validator;
+    private readonly IMapper _mapper;
+    private readonly IReorderService _reorderService;
+
+    public CreatePdfReportHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IPdfService pdfService,
+        IValidator<CreatePdfReportCommand> validator,
+        IMapper mapper,
+        IReorderService reorderService)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _pdfService = pdfService;
+        _mapper = mapper;
+        _reorderService = reorderService;
+        _validator = validator;
+    }
+
+    public async Task<Result<PdfReportDto>> Handle(CreatePdfReportCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var dto = request.CreatePdfReportDto;
+            var fileName = Guid.NewGuid().ToString().Replace("-", string.Empty);
+
+            using var transaction = _repositoryWrapper.BeginTransaction();
+
+            var blobName = await _pdfService.UploadPdfAsync(dto.File, fileName);
+            var nextPriority = await _reorderService.GetNextDisplayOrderAsync<PdfReport>();
+
+            var pdfReport = new PdfReport
+            {
+                Name = Path.GetFileNameWithoutExtension(dto.File.FileName),
+                BlobName = blobName,
+                FileSizeBytes = dto.File.Length,
+                Priority = nextPriority,
+                CreatedAt = DateTimeOffset.UtcNow
+            };
+
+            await _repositoryWrapper.PdfReportRepository.CreateAsync(pdfReport);
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<PdfReportDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(PdfReport)));
+            }
+
+            var result = _mapper.Map<PdfReportDto>(pdfReport);
+
+            transaction.Complete();
+            return Result.Ok(result);
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<PdfReportDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (BlobStorageException e)
+        {
+            return Result.Fail<PdfReportDto>(ErrorMessagesConstants.BlobStorageError(e.Message));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<PdfReportDto>(ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(PdfReport)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
@@ -37,6 +37,7 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
 
     public async Task<Result<PdfReportDto>> Handle(CreatePdfReportCommand request, CancellationToken cancellationToken)
     {
+        string? blobName = null;
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
@@ -46,7 +47,7 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
 
             using var transaction = _repositoryWrapper.BeginTransaction();
 
-            var blobName = await _pdfService.UploadPdfAsync(dto.File, fileName);
+            blobName = await _pdfService.UploadPdfAsync(dto.File, fileName);
             var nextPriority = await _reorderService.GetNextDisplayOrderAsync<PdfReport>();
 
             var pdfReport = new PdfReport
@@ -62,12 +63,13 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
+                _pdfService.DeletePdf(blobName);
                 return Result.Fail<PdfReportDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(PdfReport)));
             }
 
-            var result = _mapper.Map<PdfReportDto>(pdfReport);
-
             transaction.Complete();
+
+            var result = _mapper.Map<PdfReportDto>(pdfReport);
             return Result.Ok(result);
         }
         catch (ValidationException vex)
@@ -80,6 +82,11 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
         }
         catch (DbUpdateException)
         {
+            if (blobName != null)
+            {
+                _pdfService.DeletePdf(blobName);
+            }
+
             return Result.Fail<PdfReportDto>(ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(PdfReport)));
         }
     }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
@@ -38,6 +38,7 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
     public async Task<Result<PdfReportDto>> Handle(CreatePdfReportCommand request, CancellationToken cancellationToken)
     {
         string? blobName = null;
+        bool committed = false;
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
@@ -63,11 +64,11 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
-                _pdfService.DeletePdf(blobName);
                 return Result.Fail<PdfReportDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(PdfReport)));
             }
 
             transaction.Complete();
+            committed = true;
 
             var result = _mapper.Map<PdfReportDto>(pdfReport);
             return Result.Ok(result);
@@ -76,18 +77,35 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
         {
             return Result.Fail<PdfReportDto>(vex.Errors.Select(e => e.ErrorMessage));
         }
+        catch (InvalidPdfFormatException ex)
+        {
+            return Result.Fail<PdfReportDto>(ex.Message);
+        }
         catch (BlobStorageException e)
         {
             return Result.Fail<PdfReportDto>(ErrorMessagesConstants.BlobStorageError(e.Message));
         }
         catch (DbUpdateException)
         {
-            if (blobName != null)
-            {
-                _pdfService.DeletePdf(blobName);
-            }
-
             return Result.Fail<PdfReportDto>(ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(PdfReport)));
+        }
+        finally
+        {
+            if (!committed && blobName != null)
+            {
+                TryDeleteBlob(blobName);
+            }
+        }
+    }
+
+    private void TryDeleteBlob(string blobName)
+    {
+        try
+        {
+            _pdfService.DeletePdf(blobName);
+        }
+        catch
+        {
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/PdfReportConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/PdfReportConstants.cs
@@ -23,4 +23,5 @@ public static class PdfReportConstants
     public static readonly string FailedToCreateDirectory = "Failed to create PDF directory";
     public static readonly string FailedToSavePdf = "Failed to save PDF file";
     public static readonly string FailedToReadPdf = "Failed to read PDF file";
+    public static readonly string FailedToDeletePdf = "Failed to delete PDF file";
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/PdfReportConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/PdfReportConstants.cs
@@ -1,0 +1,26 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class PdfReportConstants
+{
+    public static readonly int MaxPdfSizeInMb = 10;
+    public static readonly int BytesPerMb = 1024 * 1024;
+    public static readonly int MaxPdfSizeInBytes = MaxPdfSizeInMb * BytesPerMb;
+
+    public static readonly string PdfMimeType = "application/pdf";
+    public static readonly string PdfExtension = "pdf";
+
+    public static readonly byte[] PdfSignature = [0x25, 0x50, 0x44, 0x46]; // %PDF
+
+    public static readonly string FileCannotBeEmpty = "PDF file cannot be empty";
+    public static readonly string InvalidPdfFormat = "Invalid file format. Expected PDF";
+    public static readonly string InvalidPdfSignature = "File does not have a valid PDF signature";
+    public static readonly string FileTooLarge = "File size cannot exceed {0} MB";
+    public static readonly string FileMustBePdf = "File must be a PDF";
+
+    public static readonly string FileNameCannotBeEmpty = "File name cannot be empty";
+    public static readonly string InvalidFileName = "Invalid file name";
+    public static readonly string PdfNotFound = "PDF file not found";
+    public static readonly string FailedToCreateDirectory = "Failed to create PDF directory";
+    public static readonly string FailedToSavePdf = "Failed to save PDF file";
+    public static readonly string FailedToReadPdf = "Failed to read PDF file";
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/CreatePdfReportDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/CreatePdfReportDto.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Http;
+
+namespace VictoryCenter.BLL.DTOs.Admin.PdfReports;
+
+public record CreatePdfReportDto
+{
+    public required IFormFile File { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/PdfReportDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/PdfReportDto.cs
@@ -1,0 +1,11 @@
+namespace VictoryCenter.BLL.DTOs.Admin.PdfReports;
+
+public record PdfReportDto
+{
+    public long Id { get; init; }
+    public required string Name { get; init; }
+    public required string BlobName { get; init; }
+    public long FileSizeBytes { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public long Priority { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Exceptions/BlobStorageExceptions/InvalidPdfFormatException.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Exceptions/BlobStorageExceptions/InvalidPdfFormatException.cs
@@ -1,0 +1,14 @@
+namespace VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
+
+public class InvalidPdfFormatException : BlobStorageException
+{
+    public InvalidPdfFormatException(string message)
+        : base(message)
+    {
+    }
+
+    public InvalidPdfFormatException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/PdfStorage/IPdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/PdfStorage/IPdfService.cs
@@ -6,4 +6,5 @@ public interface IPdfService
 {
     Task<string> UploadPdfAsync(IFormFile file, string? fileName = null);
     Task<MemoryStream> GetPdfAsync(string fileName);
+    void DeletePdf(string fileName);
 }

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/PdfStorage/IPdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/PdfStorage/IPdfService.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Http;
+
+namespace VictoryCenter.BLL.Interfaces.PdfStorage;
+
+public interface IPdfService
+{
+    Task<string> UploadPdfAsync(IFormFile file, string? fileName = null);
+    Task<MemoryStream> GetPdfAsync(string fileName);
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/PdfReports/PdfReportProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/PdfReports/PdfReportProfile.cs
@@ -1,0 +1,13 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Mapping.PdfReports;
+
+public class PdfReportProfile : Profile
+{
+    public PdfReportProfile()
+    {
+        CreateMap<PdfReport, PdfReportDto>();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsHandler.cs
@@ -1,0 +1,47 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
+
+public class GetAllPdfReportsHandler : IRequestHandler<GetAllPdfReportsQuery, Result<PaginationResult<PdfReportDto>>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IPdfService _pdfService;
+    private readonly IMapper _mapper;
+
+    public GetAllPdfReportsHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IPdfService pdfService,
+        IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _pdfService = pdfService;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<PaginationResult<PdfReportDto>>> Handle(GetAllPdfReportsQuery request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<PdfReport>
+        {
+            Offset = request.FilterDto.Offset ?? 0,
+            Limit = request.FilterDto.Limit ?? 20,
+            OrderByASC = p => p.Priority
+        };
+
+        var pdfReports = await _repositoryWrapper.PdfReportRepository
+        .GetAllAsync(queryOptions);
+
+        var totalCount = await _repositoryWrapper.PdfReportRepository
+            .CountAsync();
+
+        var result = _mapper.Map<List<PdfReportDto>>(pdfReports);
+        return Result.Ok(new PaginationResult<PdfReportDto>([.. result], totalCount));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsHandler.cs
@@ -3,7 +3,6 @@ using FluentResults;
 using MediatR;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.DTOs.Common;
-using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -13,16 +12,13 @@ namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
 public class GetAllPdfReportsHandler : IRequestHandler<GetAllPdfReportsQuery, Result<PaginationResult<PdfReportDto>>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
-    private readonly IPdfService _pdfService;
     private readonly IMapper _mapper;
 
     public GetAllPdfReportsHandler(
         IRepositoryWrapper repositoryWrapper,
-        IPdfService pdfService,
         IMapper mapper)
     {
         _repositoryWrapper = repositoryWrapper;
-        _pdfService = pdfService;
         _mapper = mapper;
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsQuery.cs
@@ -1,0 +1,10 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
+
+public record GetAllPdfReportsQuery(BaseFilterDto FilterDto)
+    : IRequest<Result<PaginationResult<PdfReportDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfEnvironmentVariables.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfEnvironmentVariables.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.Services.PdfStorage;
+
+public sealed record PdfEnvironmentVariables
+{
+    public required string RootPath { get; set; }
+    public required string PdfSubPath { get; init; }
+    public string FullPath => Path.Combine(RootPath, PdfSubPath);
+}

--- a/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
@@ -83,6 +83,26 @@ public class PdfService : IPdfService
         }
     }
 
+    public void DeletePdf(string fileName)
+    {
+        var normalizedFileName = NormalizeFileName(fileName);
+        ValidateFileName(normalizedFileName);
+
+        var filePath = Path.Combine(_pdfEnv.FullPath, normalizedFileName);
+
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new BlobFileSystemException(normalizedFileName, PdfReportConstants.FailedToDeletePdf, ex);
+        }
+    }
+
     private static async Task ValidatePdfSignatureAsync(IFormFile file)
     {
         using var stream = file.OpenReadStream();

--- a/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
@@ -31,7 +31,13 @@ public class PdfService : IPdfService
             throw new InvalidPdfFormatException(PdfReportConstants.FileCannotBeEmpty);
         }
 
-        if (!file.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase))
+        if (file.Length > PdfReportConstants.MaxPdfSizeInBytes)
+        {
+            throw new InvalidPdfFormatException(
+            string.Format(PdfReportConstants.FileTooLarge, PdfReportConstants.MaxPdfSizeInMb));
+        }
+
+        if (file.ContentType is null || !file.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidPdfFormatException(PdfReportConstants.InvalidPdfFormat);
         }
@@ -44,7 +50,12 @@ public class PdfService : IPdfService
 
         ValidateFileName(targetFileName);
 
-        var fileNameWithExtension = $"{targetFileName}.{PdfReportConstants.PdfExtension}";
+        var normalizedFileName =
+            Path.GetFileNameWithoutExtension(targetFileName);
+
+        var fileNameWithExtension =
+            $"{normalizedFileName}.{PdfReportConstants.PdfExtension}";
+
         var filePath = Path.Combine(_pdfEnv.FullPath, fileNameWithExtension);
 
         try
@@ -56,6 +67,17 @@ public class PdfService : IPdfService
         }
         catch (Exception ex)
         {
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+            catch
+            {
+            }
+
             throw new BlobFileSystemException(fileNameWithExtension, PdfReportConstants.FailedToSavePdf, ex);
         }
     }

--- a/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.BLL.Interfaces.PdfStorage;
 
@@ -7,10 +8,7 @@ namespace VictoryCenter.BLL.Services.PdfStorage;
 
 public class PdfService : IPdfService
 {
-    private const string PdfExtension = "pdf";
-    private const string PdfMimeType = "application/pdf";
     private readonly PdfEnvironmentVariables _pdfEnv;
-    private static readonly byte[] PdfSignature = { 0x25, 0x50, 0x44, 0x46 };
 
     public PdfService(IOptions<PdfEnvironmentVariables> environment, IHttpContextAccessor httpContextAccessor)
     {
@@ -22,7 +20,7 @@ public class PdfService : IPdfService
         }
         catch (Exception ex)
         {
-            throw new BlobFileSystemException(_pdfEnv.FullPath, "Failed to create PDF directory", ex);
+            throw new BlobFileSystemException(_pdfEnv.FullPath, PdfReportConstants.FailedToCreateDirectory, ex);
         }
     }
 
@@ -30,12 +28,12 @@ public class PdfService : IPdfService
     {
         if (file == null || file.Length == 0)
         {
-            throw new InvalidPdfFormatException("File is empty or null");
+            throw new InvalidPdfFormatException(PdfReportConstants.FileCannotBeEmpty);
         }
 
-        if (!file.ContentType.Equals(PdfMimeType, StringComparison.OrdinalIgnoreCase))
+        if (!file.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase))
         {
-            throw new InvalidPdfFormatException($"Invalid file format. Expected PDF, got {file.ContentType}");
+            throw new InvalidPdfFormatException(PdfReportConstants.InvalidPdfFormat);
         }
 
         await ValidatePdfSignatureAsync(file);
@@ -46,7 +44,7 @@ public class PdfService : IPdfService
 
         ValidateFileName(targetFileName);
 
-        var fileNameWithExtension = $"{targetFileName}.{PdfExtension}";
+        var fileNameWithExtension = $"{targetFileName}.{PdfReportConstants.PdfExtension}";
         var filePath = Path.Combine(_pdfEnv.FullPath, fileNameWithExtension);
 
         try
@@ -58,7 +56,7 @@ public class PdfService : IPdfService
         }
         catch (Exception ex)
         {
-            throw new BlobFileSystemException(fileNameWithExtension, "Failed to save PDF file", ex);
+            throw new BlobFileSystemException(fileNameWithExtension, PdfReportConstants.FailedToSavePdf, ex);
         }
     }
 
@@ -71,7 +69,7 @@ public class PdfService : IPdfService
 
         if (!File.Exists(filePath))
         {
-            throw new BlobNotFoundException(normalizedFileName, $"PDF file not found: {filePath}");
+            throw new BlobNotFoundException(normalizedFileName, PdfReportConstants.PdfNotFound);
         }
 
         try
@@ -81,7 +79,7 @@ public class PdfService : IPdfService
         }
         catch (Exception ex) when (ex is not BlobStorageException)
         {
-            throw new BlobFileSystemException(normalizedFileName, "Failed to read PDF file", ex);
+            throw new BlobFileSystemException(normalizedFileName, PdfReportConstants.FailedToReadPdf, ex);
         }
     }
 
@@ -91,9 +89,9 @@ public class PdfService : IPdfService
         var buffer = new byte[4];
         var bytesRead = await stream.ReadAsync(buffer, 0, 4);
 
-        if (bytesRead < 4 || !buffer.SequenceEqual(PdfSignature))
+        if (bytesRead < 4 || !buffer.SequenceEqual(PdfReportConstants.PdfSignature))
         {
-            throw new InvalidPdfFormatException("File does not have a valid PDF signature");
+            throw new InvalidPdfFormatException(PdfReportConstants.InvalidPdfSignature);
         }
 
         stream.Position = 0;
@@ -103,11 +101,11 @@ public class PdfService : IPdfService
     {
         if (string.IsNullOrWhiteSpace(fileName))
         {
-            throw new BlobFileNameException(fileName, "File name cannot be empty");
+            throw new BlobFileNameException(fileName, PdfReportConstants.FileNameCannotBeEmpty);
         }
 
         var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
-        return $"{nameWithoutExtension}.{PdfExtension}";
+        return $"{nameWithoutExtension}.{PdfReportConstants.PdfExtension}";
     }
 
     private static void ValidateFileName(string name)
@@ -120,7 +118,7 @@ public class PdfService : IPdfService
             || name.Contains('\\')
             || Path.GetInvalidFileNameChars().Any(nameWithoutExtension.Contains))
         {
-            throw new BlobFileNameException(name, $"Invalid file name: {name}");
+            throw new BlobFileNameException(name, PdfReportConstants.InvalidFileName);
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+
+namespace VictoryCenter.BLL.Services.PdfStorage;
+
+public class PdfService : IPdfService
+{
+    private const string PdfExtension = "pdf";
+    private const string PdfMimeType = "application/pdf";
+    private readonly PdfEnvironmentVariables _pdfEnv;
+    private static readonly byte[] PdfSignature = { 0x25, 0x50, 0x44, 0x46 };
+
+    public PdfService(IOptions<PdfEnvironmentVariables> environment, IHttpContextAccessor httpContextAccessor)
+    {
+        _pdfEnv = environment.Value;
+
+        try
+        {
+            Directory.CreateDirectory(_pdfEnv.FullPath);
+        }
+        catch (Exception ex)
+        {
+            throw new BlobFileSystemException(_pdfEnv.FullPath, "Failed to create PDF directory", ex);
+        }
+    }
+
+    public async Task<string> UploadPdfAsync(IFormFile file, string? fileName = null)
+    {
+        if (file == null || file.Length == 0)
+        {
+            throw new InvalidPdfFormatException("File is empty or null");
+        }
+
+        if (!file.ContentType.Equals(PdfMimeType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidPdfFormatException($"Invalid file format. Expected PDF, got {file.ContentType}");
+        }
+
+        await ValidatePdfSignatureAsync(file);
+
+        var targetFileName = string.IsNullOrWhiteSpace(fileName)
+            ? Path.GetFileNameWithoutExtension(file.FileName)
+            : fileName;
+
+        ValidateFileName(targetFileName);
+
+        var fileNameWithExtension = $"{targetFileName}.{PdfExtension}";
+        var filePath = Path.Combine(_pdfEnv.FullPath, fileNameWithExtension);
+
+        try
+        {
+            using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            await file.CopyToAsync(fileStream);
+
+            return fileNameWithExtension;
+        }
+        catch (Exception ex)
+        {
+            throw new BlobFileSystemException(fileNameWithExtension, "Failed to save PDF file", ex);
+        }
+    }
+
+    public async Task<MemoryStream> GetPdfAsync(string fileName)
+    {
+        var normalizedFileName = NormalizeFileName(fileName);
+        ValidateFileName(normalizedFileName);
+
+        var filePath = Path.Combine(_pdfEnv.FullPath, normalizedFileName);
+
+        if (!File.Exists(filePath))
+        {
+            throw new BlobNotFoundException(normalizedFileName, $"PDF file not found: {filePath}");
+        }
+
+        try
+        {
+            var bytes = await File.ReadAllBytesAsync(filePath);
+            return new MemoryStream(bytes);
+        }
+        catch (Exception ex) when (ex is not BlobStorageException)
+        {
+            throw new BlobFileSystemException(normalizedFileName, "Failed to read PDF file", ex);
+        }
+    }
+
+    private static async Task ValidatePdfSignatureAsync(IFormFile file)
+    {
+        using var stream = file.OpenReadStream();
+        var buffer = new byte[4];
+        var bytesRead = await stream.ReadAsync(buffer, 0, 4);
+
+        if (bytesRead < 4 || !buffer.SequenceEqual(PdfSignature))
+        {
+            throw new InvalidPdfFormatException("File does not have a valid PDF signature");
+        }
+
+        stream.Position = 0;
+    }
+
+    private static string NormalizeFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new BlobFileNameException(fileName, "File name cannot be empty");
+        }
+
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        return $"{nameWithoutExtension}.{PdfExtension}";
+    }
+
+    private static void ValidateFileName(string name)
+    {
+        var nameWithoutExtension = Path.GetFileNameWithoutExtension(name);
+
+        if (string.IsNullOrWhiteSpace(nameWithoutExtension)
+            || nameWithoutExtension.Contains("..")
+            || name.Contains('/')
+            || name.Contains('\\')
+            || Path.GetInvalidFileNameChars().Any(nameWithoutExtension.Contains))
+        {
+            throw new BlobFileNameException(name, $"Invalid file name: {name}");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/PdfStorage/PdfService.cs
@@ -135,8 +135,6 @@ public class PdfService : IPdfService
         {
             throw new InvalidPdfFormatException(PdfReportConstants.InvalidPdfSignature);
         }
-
-        stream.Position = 0;
     }
 
     private static string NormalizeFileName(string fileName)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
@@ -12,7 +12,9 @@ public class CreatePdfReportValidator : AbstractValidator<CreatePdfReportCommand
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreatePdfReportCommand.CreatePdfReportDto)));
 
-        RuleFor(x => x.CreatePdfReportDto.File)
+        When(x => x.CreatePdfReportDto != null, () =>
+        {
+            RuleFor(x => x.CreatePdfReportDto.File)
             .NotNull()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired("File"))
             .Must(file => file?.Length > 0)
@@ -21,5 +23,6 @@ public class CreatePdfReportValidator : AbstractValidator<CreatePdfReportCommand
             .WithMessage(string.Format(PdfReportConstants.FileTooLarge, PdfReportConstants.MaxPdfSizeInMb))
             .Must(file => file?.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase) == true)
             .WithMessage(PdfReportConstants.FileMustBePdf);
+        });
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
@@ -6,9 +6,6 @@ namespace VictoryCenter.BLL.Validators.PdfReports;
 
 public class CreatePdfReportValidator : AbstractValidator<CreatePdfReportCommand>
 {
-    private const long MaxPdfSizeInBytes = 10 * 1024 * 1024;
-    private const string PdfMimeType = "application/pdf";
-
     public CreatePdfReportValidator()
     {
         RuleFor(x => x.CreatePdfReportDto)
@@ -19,10 +16,10 @@ public class CreatePdfReportValidator : AbstractValidator<CreatePdfReportCommand
             .NotNull()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired("File"))
             .Must(file => file?.Length > 0)
-            .WithMessage("File cannot be empty")
-            .Must(file => file?.Length <= MaxPdfSizeInBytes)
-            .WithMessage($"File size cannot exceed {MaxPdfSizeInBytes / 1024 / 1024} MB")
-            .Must(file => file?.ContentType.Equals(PdfMimeType, StringComparison.OrdinalIgnoreCase) == true)
-            .WithMessage("File must be a PDF");
+            .WithMessage(PdfReportConstants.FileCannotBeEmpty)
+            .Must(file => file?.Length <= PdfReportConstants.MaxPdfSizeInBytes)
+            .WithMessage(string.Format(PdfReportConstants.FileTooLarge, PdfReportConstants.MaxPdfSizeInMb))
+            .Must(file => file?.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase) == true)
+            .WithMessage(PdfReportConstants.FileMustBePdf);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+using VictoryCenter.BLL.Constants;
+
+namespace VictoryCenter.BLL.Validators.PdfReports;
+
+public class CreatePdfReportValidator : AbstractValidator<CreatePdfReportCommand>
+{
+    private const long MaxPdfSizeInBytes = 10 * 1024 * 1024;
+    private const string PdfMimeType = "application/pdf";
+
+    public CreatePdfReportValidator()
+    {
+        RuleFor(x => x.CreatePdfReportDto)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreatePdfReportCommand.CreatePdfReportDto)));
+
+        RuleFor(x => x.CreatePdfReportDto.File)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired("File"))
+            .Must(file => file?.Length > 0)
+            .WithMessage("File cannot be empty")
+            .Must(file => file?.Length <= MaxPdfSizeInBytes)
+            .WithMessage($"File size cannot exceed {MaxPdfSizeInBytes / 1024 / 1024} MB")
+            .Must(file => file?.ContentType.Equals(PdfMimeType, StringComparison.OrdinalIgnoreCase) == true)
+            .WithMessage("File must be a PDF");
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/PdfReportConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/PdfReportConfig.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class PdfReportConfig : IEntityTypeConfiguration<PdfReport>
+{
+    public void Configure(EntityTypeBuilder<PdfReport> entity)
+    {
+        entity.ToTable("PdfReports", "media");
+
+        entity.HasKey(e => e.Id);
+
+        entity.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity.Property(e => e.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        entity.Property(e => e.BlobName)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        entity.Property(e => e.FileSizeBytes)
+            .IsRequired();
+
+        entity.Property(e => e.Priority)
+            .IsRequired();
+
+        entity.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        entity.HasIndex(e => e.Priority)
+            .IsUnique();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -26,6 +26,7 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
     public DbSet<TeamMember> TeamMembers { get; set; }
 
     public DbSet<Image> Images { get; set; }
+    public DbSet<PdfReport> PdfReports { get; set; }
 
     public DbSet<HippotherapyProgramCategory> HippotherapyProgramCategories { get; set; }
 

--- a/VictoryCenter/VictoryCenter.DAL/Entities/PdfReport.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/PdfReport.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class PdfReport : BaseEntity, IOrderableEntity
+{
+    public string Name { get; set; } = null!;
+    public string BlobName { get; set; } = null!;
+    public long FileSizeBytes { get; set; }
+    public long Priority { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260217061743_AddPdfReportsTable.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260217061743_AddPdfReportsTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260217061743_AddPdfReportsTable")]
+    partial class AddPdfReportsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260217061743_AddPdfReportsTable.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260217061743_AddPdfReportsTable.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPdfReportsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PdfReports",
+                schema: "media",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    BlobName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    Priority = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PdfReports", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PdfReports_Priority",
+                schema: "media",
+                table: "PdfReports",
+                column: "Priority",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PdfReports",
+                schema: "media");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -26,6 +26,7 @@ public interface IRepositoryWrapper
     ITeamMembersRepository TeamMembersRepository { get; }
     IVisitorPagesRepository VisitorPagesRepository { get; }
     IImageRepository ImageRepository { get; }
+    IPdfReportRepository PdfReportRepository { get; }
     IHippotherapyProgramCategoriesRepository HippotherapyProgramCategoriesRepository { get; }
     IHippotherapyProgramsRepository HippotherapyProgramsRepository { get; }
     ILocalizationLanguagesRepository LocalizationLanguagesRepository { get; }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Media/IPdfReportRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Media/IPdfReportRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Media;
+
+public interface IPdfReportRepository : IRepositoryBase<PdfReport>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -47,6 +47,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private ITeamMembersRepository? _teamMembersRepository;
     private IVisitorPagesRepository? _visitorPagesRepository;
     private IImageRepository? _imageRepository;
+    private IPdfReportRepository? _pdfReportRepository;
     private IHippotherapyProgramCategoriesRepository? _programCategoriesRepository;
     private IHippotherapyProgramsRepository? _hippotherapyProgramsRepository;
     private ILocalizationLanguagesRepository? _localizationLanguagesRepository;
@@ -74,6 +75,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     public ITeamMembersRepository TeamMembersRepository => _teamMembersRepository ??= new TeamMembersRepository(_victoryCenterDbContext);
     public IVisitorPagesRepository VisitorPagesRepository => _visitorPagesRepository ??= new VisitorPagesRepository(_victoryCenterDbContext);
     public IImageRepository ImageRepository => _imageRepository ??= new ImageRepository(_victoryCenterDbContext);
+    public IPdfReportRepository PdfReportRepository => _pdfReportRepository ??= new PdfReportRepository(_victoryCenterDbContext);
     public IHippotherapyProgramCategoriesRepository HippotherapyProgramCategoriesRepository => _programCategoriesRepository
         ??= new HippotherapyProgramCategoriesRepository(_victoryCenterDbContext);
     public IHippotherapyProgramsRepository HippotherapyProgramsRepository => _hippotherapyProgramsRepository ??= new HippotherapyProgramsRepository(_victoryCenterDbContext);

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Media/PdfReportRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Media/PdfReportRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Media;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Media;
+
+public class PdfReportRepository : RepositoryBase<PdfReport>, IPdfReportRepository
+{
+    public PdfReportRepository(VictoryCenterDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -1,9 +1,12 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
-using Microsoft.EntityFrameworkCore;
 
 namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.Create;
 
@@ -115,7 +118,9 @@ public class CreatePdfReportTests : BaseTestClass
         // Assert
         Assert.True(response1.IsSuccessStatusCode);
         Assert.True(response2.IsSuccessStatusCode);
-        Assert.True(result2!.Priority > result1!.Priority);
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+        Assert.True(result2.Priority > result1.Priority);
     }
 
     [Fact]
@@ -144,18 +149,23 @@ public class CreatePdfReportTests : BaseTestClass
     public async Task CreatePdfReport_DatabaseFailure_ShouldCleanupFile()
     {
         // Arrange
+        using var scope = Fixture.Factory.Services.CreateScope();
+        var pdfService = scope.ServiceProvider.GetRequiredService<IPdfService>();
+
         var initialFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
-        using var form = CreatePdfFormData(fileName: "cleanup-test.pdf");
+
+        var fakeFile = CreateFakeFormFile("cleanup-test.pdf");
+
+        var blobName = await pdfService.UploadPdfAsync(fakeFile);
+
+        Assert.Equal(initialFileCount + 1, Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length);
 
         // Act
-        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+        pdfService.DeletePdf(blobName);
 
         // Assert
-        if (!response.IsSuccessStatusCode)
-        {
-            var finalFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
-            Assert.Equal(initialFileCount, finalFileCount);
-        }
+        var finalFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+        Assert.Equal(initialFileCount, finalFileCount);
     }
 
     [Fact]
@@ -191,7 +201,6 @@ public class CreatePdfReportTests : BaseTestClass
         // Arrange
         var truncatedContent = new byte[] { 0x25, 0x50, 0x44 }; // %PD
         using var form = CreatePdfFormData(content: truncatedContent);
-        Directory.CreateDirectory(Fixture.PdfEnvironmentVariables.FullPath);
 
         var initialFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
 
@@ -201,9 +210,6 @@ public class CreatePdfReportTests : BaseTestClass
         // Assert
         Assert.False(response.IsSuccessStatusCode);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-
-        var finalFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
-        Assert.Equal(initialFileCount, finalFileCount);
     }
 
     private static MultipartFormDataContent CreatePdfFormData(
@@ -217,5 +223,16 @@ public class CreatePdfReportTests : BaseTestClass
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
         form.Add(fileContent, "File", fileName);
         return form;
+    }
+
+    private static IFormFile CreateFakeFormFile(string fileName)
+    {
+        var content = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34 }; // %PDF-1.4
+        var stream = new MemoryStream(content);
+        return new FormFile(stream, 0, content.Length, "File", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/pdf"
+        };
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Text.Json;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+using Microsoft.EntityFrameworkCore;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.Create;
+
+public class CreatePdfReportTests : BaseTestClass
+{
+    public CreatePdfReportTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_ValidData_ShouldCreatePdfReport()
+    {
+        // Arrange
+        using var form = CreatePdfFormData();
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfReportDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(result);
+        Assert.Equal("test-report", result.Name);
+        Assert.NotNull(result.BlobName);
+        Assert.True(result.FileSizeBytes > 0);
+
+        var filePath = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, result.BlobName);
+        Assert.True(File.Exists(filePath));
+
+        var dbRecord = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.BlobName == result.BlobName);
+        Assert.NotNull(dbRecord);
+        Assert.Equal(result.Name, dbRecord.Name);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_InvalidMimeType_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using var form = CreatePdfFormData(contentType: "image/jpeg");
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_EmptyFile_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using var form = CreatePdfFormData(content: Array.Empty<byte>());
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_InvalidPdfSignature_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using var form = CreatePdfFormData(content: new byte[] { 0x00, 0x01, 0x02, 0x03 });
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_NoFile_ShouldReturnBadRequest()
+    {
+        // Arrange
+        using var form = new MultipartFormDataContent();
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_ShouldSetPriorityCorrectly()
+    {
+        // Arrange
+        using var form1 = CreatePdfFormData(fileName: "first-report.pdf");
+        using var form2 = CreatePdfFormData(fileName: "second-report.pdf");
+
+        // Act
+        var response1 = await Fixture.HttpClient.PostAsync("api/PdfReports", form1);
+        var response2 = await Fixture.HttpClient.PostAsync("api/PdfReports", form2);
+
+        var result1 = JsonSerializer.Deserialize<PdfReportDto>(
+            await response1.Content.ReadAsStringAsync(), JsonOptions);
+        var result2 = JsonSerializer.Deserialize<PdfReportDto>(
+            await response2.Content.ReadAsStringAsync(), JsonOptions);
+
+        // Assert
+        Assert.True(response1.IsSuccessStatusCode);
+        Assert.True(response2.IsSuccessStatusCode);
+        Assert.True(result2!.Priority > result1!.Priority);
+    }
+
+    private static MultipartFormDataContent CreatePdfFormData(
+        byte[] content = null!,
+        string fileName = "test-report.pdf",
+        string contentType = "application/pdf")
+    {
+        var pdfContent = content ?? new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34 };
+        var form = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(pdfContent);
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+        form.Add(fileContent, "File", fileName);
+        return form;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -118,6 +118,94 @@ public class CreatePdfReportTests : BaseTestClass
         Assert.True(result2!.Priority > result1!.Priority);
     }
 
+    [Fact]
+    public async Task CreatePdfReport_CorruptedPdfWithValidMimeType_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var corruptedContent = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }; // JPEG magic bytes
+        using var form = CreatePdfFormData(content: corruptedContent);
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        // Verify no file was saved
+        var files = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf");
+        var filesBeforeTest = files.Length;
+
+        files = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf");
+        Assert.Equal(filesBeforeTest, files.Length);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_DatabaseFailure_ShouldCleanupFile()
+    {
+        // Arrange
+        var initialFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+        using var form = CreatePdfFormData(fileName: "cleanup-test.pdf");
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        if (!response.IsSuccessStatusCode)
+        {
+            var finalFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+            Assert.Equal(initialFileCount, finalFileCount);
+        }
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_OversizedFile_ShouldReturnBadRequestAndNotSaveFile()
+    {
+        // Arrange
+        var oversizedContent = new byte[11 * 1024 * 1024];
+        Array.Fill(oversizedContent, (byte)0x25);
+
+        oversizedContent[0] = 0x25;
+        oversizedContent[1] = 0x50;
+        oversizedContent[2] = 0x44;
+        oversizedContent[3] = 0x46;
+
+        using var form = CreatePdfFormData(content: oversizedContent);
+
+        var initialFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var finalFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+        Assert.Equal(initialFileCount, finalFileCount);
+    }
+
+    [Fact]
+    public async Task CreatePdfReport_TruncatedPdf_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var truncatedContent = new byte[] { 0x25, 0x50, 0x44 }; // %PD
+        using var form = CreatePdfFormData(content: truncatedContent);
+        Directory.CreateDirectory(Fixture.PdfEnvironmentVariables.FullPath);
+
+        var initialFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+
+        // Act
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+
+        // Assert
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var finalFileCount = Directory.GetFiles(Fixture.PdfEnvironmentVariables.FullPath, "*.pdf").Length;
+        Assert.Equal(initialFileCount, finalFileCount);
+    }
+
     private static MultipartFormDataContent CreatePdfFormData(
         byte[] content = null!,
         string fileName = "test-report.pdf",

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -146,7 +146,7 @@ public class CreatePdfReportTests : BaseTestClass
     }
 
     [Fact]
-    public async Task CreatePdfReport_DatabaseFailure_ShouldCleanupFile()
+    public async Task PdfService_UploadAndDelete_ShouldCleanupFile()
     {
         // Arrange
         using var scope = Fixture.Factory.Services.CreateScope();

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetAll/GetAllPdfReportsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetAll/GetAllPdfReportsTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.GetAll;
+public class GetAllPdfReportsTests : BaseTestClass
+{
+    public GetAllPdfReportsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetAllPdfReports_ShouldReturnPaginatedList()
+    {
+        // Arrange
+        await SeedPdfReportsAsync(5);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports?Offset=0&Limit=20");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(result);
+        Assert.True(result.Items.Length > 0);
+        Assert.True(result.TotalItemsCount > 0);
+    }
+
+    [Fact]
+    public async Task GetAllPdfReports_ShouldReturnItemsOrderedByPriority()
+    {
+        // Arrange
+        await SeedPdfReportsAsync(3);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports?Offset=0&Limit=20");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        var items = result!.Items;
+        for (var i = 1; i < items.Length; i++)
+        {
+            Assert.True(items[i].Priority >= items[i - 1].Priority);
+        }
+    }
+
+    [Fact]
+    public async Task GetAllPdfReports_WithPagination_ShouldReturnCorrectPage()
+    {
+        // Arrange
+        await SeedPdfReportsAsync(5);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports?Offset=0&Limit=2");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(2, result!.Items.Length);
+        Assert.True(result.TotalItemsCount >= 5);
+    }
+
+    [Fact]
+    public async Task GetAllPdfReports_EmptyDatabase_ShouldReturnEmptyList()
+    {
+        // Arrange
+        Fixture.DbContext.PdfReports.RemoveRange(Fixture.DbContext.PdfReports);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports?Offset=0&Limit=20");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Empty(result!.Items);
+        Assert.Equal(0, result.TotalItemsCount);
+    }
+
+    private async Task SeedPdfReportsAsync(int count)
+    {
+        var reports = Enumerable.Range(1, count).Select(i => new PdfReport
+        {
+            Name = $"Звіт {i}",
+            BlobName = $"{Guid.NewGuid():N}.pdf",
+            FileSizeBytes = 1024 * i,
+            Priority = i,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+
+        await Fixture.DbContext.PdfReports.AddRangeAsync(reports);
+        await Fixture.DbContext.SaveChangesAsync();
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/DbFixture/IntegrationTestDbFixture.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/DbFixture/IntegrationTestDbFixture.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VictoryCenter.BLL.Options;
 using VictoryCenter.BLL.Services.BlobStorage;
+using VictoryCenter.BLL.Services.PdfStorage;
 using VictoryCenter.BLL.Services.TokenService;
 using VictoryCenter.DAL.Data;
 using VictoryCenter.DAL.Entities;
@@ -28,6 +29,7 @@ public class IntegrationTestDbFixture : IAsyncLifetime
 
     public VictoryCenterWebApplicationFactory<Program> Factory { get; private set; }
     public BlobEnvironmentVariables BlobEnvironmentVariables { get; private set; } = null!;
+    public PdfEnvironmentVariables PdfEnvironmentVariables { get; private set; } = null!;
     public HttpClient HttpClient { get; private set; }
     public VictoryCenterDbContext DbContext { get; private set; } = null!;
     public SeederManager SeederManager { get; private set; } = null!;
@@ -55,6 +57,11 @@ public class IntegrationTestDbFixture : IAsyncLifetime
         {
             Directory.Delete(BlobEnvironmentVariables.FullPath, recursive: true);
         }
+
+        if (Directory.Exists(PdfEnvironmentVariables.FullPath))
+        {
+            Directory.Delete(PdfEnvironmentVariables.FullPath, recursive: true);
+        }
     }
 
     public async Task CreateFreshWebApplicationAsync()
@@ -78,6 +85,8 @@ public class IntegrationTestDbFixture : IAsyncLifetime
         HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GetAuthorizationToken(_scope.ServiceProvider));
 
         var options = _scope.ServiceProvider.GetRequiredService<IOptions<BlobEnvironmentVariables>>();
+        var pdfOptions = _scope.ServiceProvider.GetRequiredService<IOptions<PdfEnvironmentVariables>>();
+        PdfEnvironmentVariables = pdfOptions.Value;
         BlobEnvironmentVariables = options.Value;
 
         DbContext = _scope.ServiceProvider.GetRequiredService<VictoryCenterDbContext>();

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/DbFixture/IntegrationTestDbFixture.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/DbFixture/IntegrationTestDbFixture.cs
@@ -72,6 +72,7 @@ public class IntegrationTestDbFixture : IAsyncLifetime
         }
 
         InitializeServices();
+        Directory.CreateDirectory(PdfEnvironmentVariables.FullPath);
         await InitializeDatabaseAsync();
         InitializeSeeders();
         await SeederManager.SeedAllAsync();

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/CreatePdfReportHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/CreatePdfReportHandlerTests.cs
@@ -1,0 +1,175 @@
+using System.Transactions;
+using AutoMapper;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.BLL.Interfaces.ReorderService;
+using VictoryCenter.BLL.Validators.PdfReports;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
+
+public class CreatePdfReportHandlerTests
+{
+    private readonly Mock<IPdfService> _mockPdfService;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IReorderService> _mockReorderService;
+    private readonly IValidator<CreatePdfReportCommand> _validator;
+
+    private readonly IFormFile _testFile;
+    private readonly PdfReport _testPdfReport;
+    private readonly PdfReportDto _testPdfReportDto;
+
+    public CreatePdfReportHandlerTests()
+    {
+        _validator = new CreatePdfReportValidator();
+        _mockPdfService = new Mock<IPdfService>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _mockReorderService = new Mock<IReorderService>();
+
+        var mockFile = new Mock<IFormFile>();
+        mockFile.Setup(f => f.ContentType).Returns("application/pdf");
+        mockFile.Setup(f => f.Length).Returns(1024);
+        mockFile.Setup(f => f.FileName).Returns("test-report.pdf");
+        _testFile = mockFile.Object;
+
+        _testPdfReport = new PdfReport
+        {
+            Id = 1,
+            Name = "test-report",
+            BlobName = "abc123.pdf",
+            FileSizeBytes = 1024,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _testPdfReportDto = new PdfReportDto
+        {
+            Id = 1,
+            Name = "test-report",
+            BlobName = "abc123.pdf",
+            FileSizeBytes = 1024,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ShouldCreatePdfReportAndReturnDto()
+    {
+        // Arrange
+        _mockPdfService.Setup(x => x.UploadPdfAsync(It.IsAny<IFormFile>(), It.IsAny<string>()))
+            .ReturnsAsync("abc123.pdf");
+
+        _mockReorderService.Setup(x => x.GetNextDisplayOrderAsync<PdfReport>(It.IsAny<System.Linq.Expressions.Expression<System.Func<PdfReport, bool>>>()))
+            .ReturnsAsync(1);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CreateAsync(It.IsAny<PdfReport>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockRepositoryWrapper.Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mockRepositoryWrapper.Setup(x => x.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+
+        _mockMapper.Setup(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()))
+            .Returns(_testPdfReportDto);
+
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile });
+
+        // Act
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_testPdfReportDto.Id, result.Value.Id);
+        Assert.Equal(_testPdfReportDto.Name, result.Value.Name);
+        Assert.Equal(_testPdfReportDto.BlobName, result.Value.BlobName);
+
+        _mockPdfService.Verify(x => x.UploadPdfAsync(It.IsAny<IFormFile>(), It.IsAny<string>()), Times.Once);
+        _mockRepositoryWrapper.Verify(x => x.PdfReportRepository.CreateAsync(It.IsAny<PdfReport>()), Times.Once);
+        _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Once);
+        _mockMapper.Verify(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullFile_ShouldReturnValidationError()
+    {
+        // Arrange
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = null! });
+
+        // Act
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        _mockPdfService.Verify(x => x.UploadPdfAsync(It.IsAny<IFormFile>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesFails_ShouldReturnFailure()
+    {
+        // Arrange
+        _mockPdfService.Setup(x => x.UploadPdfAsync(It.IsAny<IFormFile>(), It.IsAny<string>()))
+            .ReturnsAsync("abc123.pdf");
+
+        _mockReorderService.Setup(x => x.GetNextDisplayOrderAsync<PdfReport>(It.IsAny<System.Linq.Expressions.Expression<System.Func<PdfReport, bool>>>()))
+            .ReturnsAsync(1);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CreateAsync(It.IsAny<PdfReport>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockRepositoryWrapper.Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(0);
+
+        _mockRepositoryWrapper.Setup(x => x.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile });
+
+        // Act
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ErrorMessagesConstants.FailedToCreateEntity(typeof(PdfReport)), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_PdfServiceThrowsBlobStorageException_ShouldReturnFailure()
+    {
+        // Arrange
+        _mockPdfService.Setup(x => x.UploadPdfAsync(It.IsAny<IFormFile>(), It.IsAny<string>()))
+            .ThrowsAsync(new BlobFileSystemException("path", "Failed to save PDF file"));
+
+        _mockRepositoryWrapper.Setup(x => x.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile });
+
+        // Act
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ErrorMessagesConstants.BlobStorageError("Failed to save PDF file"), result.Errors[0].Message);
+    }
+
+    private CreatePdfReportHandler CreateHandler() =>
+        new(
+            _mockRepositoryWrapper.Object,
+            _mockPdfService.Object,
+            _validator,
+            _mockMapper.Object,
+            _mockReorderService.Object);
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetAllPdfReportsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetAllPdfReportsHandlerTests.cs
@@ -2,7 +2,6 @@ using AutoMapper;
 using Moq;
 using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
-using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -13,7 +12,6 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
 public class GetAllPdfReportsHandlerTests
 {
     private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
-    private readonly Mock<IPdfService> _mockPdfService;
     private readonly Mock<IMapper> _mockMapper;
 
     private readonly List<PdfReport> _testPdfReports;
@@ -22,7 +20,6 @@ public class GetAllPdfReportsHandlerTests
     public GetAllPdfReportsHandlerTests()
     {
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-        _mockPdfService = new Mock<IPdfService>();
         _mockMapper = new Mock<IMapper>();
 
         _testPdfReports =
@@ -148,6 +145,5 @@ public class GetAllPdfReportsHandlerTests
     private GetAllPdfReportsHandler CreateHandler() =>
         new(
             _mockRepositoryWrapper.Object,
-            _mockPdfService.Object,
             _mockMapper.Object);
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetAllPdfReportsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetAllPdfReportsHandlerTests.cs
@@ -1,0 +1,153 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
+
+public class GetAllPdfReportsHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IPdfService> _mockPdfService;
+    private readonly Mock<IMapper> _mockMapper;
+
+    private readonly List<PdfReport> _testPdfReports;
+    private readonly List<PdfReportDto> _testPdfReportDtos;
+
+    public GetAllPdfReportsHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockPdfService = new Mock<IPdfService>();
+        _mockMapper = new Mock<IMapper>();
+
+        _testPdfReports =
+        [
+            new PdfReport { Id = 1, Name = "Звіт 2024", BlobName = "abc.pdf", Priority = 1, FileSizeBytes = 1024, CreatedAt = DateTimeOffset.UtcNow },
+            new PdfReport { Id = 2, Name = "Звіт 2025", BlobName = "def.pdf", Priority = 2, FileSizeBytes = 2048, CreatedAt = DateTimeOffset.UtcNow },
+        ];
+
+        _testPdfReportDtos =
+        [
+            new PdfReportDto { Id = 1, Name = "Звіт 2024", BlobName = "abc.pdf", Priority = 1, FileSizeBytes = 1024, CreatedAt = DateTimeOffset.UtcNow },
+            new PdfReportDto { Id = 2, Name = "Звіт 2025", BlobName = "def.pdf", Priority = 2, FileSizeBytes = 2048, CreatedAt = DateTimeOffset.UtcNow },
+        ];
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnAllPdfReportsOrderedByPriority()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReports);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(2);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns(_testPdfReportDtos);
+
+        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = 0, Limit = 20 });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Items.Length);
+        Assert.Equal(2, result.Value.TotalItemsCount);
+
+        _mockRepositoryWrapper.Verify(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()), Times.Once);
+        _mockRepositoryWrapper.Verify(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()), Times.Once);
+        _mockMapper.Verify(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ShouldReturnEmptyPaginationResult()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync([]);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(0);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns([]);
+
+        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = 0, Limit = 20 });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value.Items);
+        Assert.Equal(0, result.Value.TotalItemsCount);
+    }
+
+    [Fact]
+    public async Task Handle_WithPagination_ShouldPassCorrectOptionsToRepository()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync([_testPdfReports[0]]);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(2);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns([_testPdfReportDtos[0]]);
+
+        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = 1, Limit = 1 });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value.Items);
+        Assert.Equal(2, result.Value.TotalItemsCount);
+
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetAllAsync(
+            It.Is<QueryOptions<PdfReport>>(o => o.Offset == 1 && o.Limit == 1)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullOffsetAndLimit_ShouldUseDefaultValues()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReports);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(2);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns(_testPdfReportDtos);
+
+        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = null, Limit = null });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetAllAsync(
+            It.Is<QueryOptions<PdfReport>>(o => o.Offset == 0 && o.Limit == 20)),
+            Times.Once);
+    }
+
+    private GetAllPdfReportsHandler CreateHandler() =>
+        new(
+            _mockRepositoryWrapper.Object,
+            _mockPdfService.Object,
+            _mockMapper.Object);
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
+using VictoryCenter.BLL.Services.PdfStorage;
+
+namespace VictoryCenter.UnitTests.ServiceTests;
+
+public class PdfServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _subDir;
+    private readonly PdfService _pdfService;
+    private readonly Mock<IHttpContextAccessor> _mockHttpContext;
+    private readonly PdfEnvironmentVariables _pdfEnv;
+    private readonly string _fileName = "testfile";
+
+    private static readonly byte[] ValidPdfBytes = { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34 };
+
+    public PdfServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _subDir = "PdfReports";
+
+        _pdfEnv = new PdfEnvironmentVariables
+        {
+            RootPath = _tempDir,
+            PdfSubPath = _subDir
+        };
+
+        _mockHttpContext = new Mock<IHttpContextAccessor>();
+        _pdfService = new PdfService(Options.Create(_pdfEnv), _mockHttpContext.Object);
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_ValidFile_ShouldCreateFileAndReturnBlobName()
+    {
+        // Arrange
+        var file = CreateMockPdfFile();
+
+        // Act
+        var blobName = await _pdfService.UploadPdfAsync(file, _fileName);
+
+        // Assert
+        var filePath = Path.Combine(_pdfEnv.FullPath, $"{_fileName}.pdf");
+        Assert.True(File.Exists(filePath));
+        Assert.Equal($"{_fileName}.pdf", blobName);
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_NullFile_ShouldThrowInvalidPdfFormatException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidPdfFormatException>(
+            () => _pdfService.UploadPdfAsync(null!));
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_EmptyFile_ShouldThrowInvalidPdfFormatException()
+    {
+        // Arrange
+        var file = CreateMockPdfFile(content: []);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidPdfFormatException>(
+            () => _pdfService.UploadPdfAsync(file));
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("text/plain")]
+    [InlineData("application/msword")]
+    public async Task UploadPdfAsync_WrongMimeType_ShouldThrowInvalidPdfFormatException(string contentType)
+    {
+        // Arrange
+        var file = CreateMockPdfFile(contentType: contentType);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidPdfFormatException>(
+            () => _pdfService.UploadPdfAsync(file));
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_InvalidPdfSignature_ShouldThrowInvalidPdfFormatException()
+    {
+        var file = CreateMockPdfFile(content: [0x00, 0x01, 0x02, 0x03]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidPdfFormatException>(
+            () => _pdfService.UploadPdfAsync(file));
+    }
+
+    [Theory]
+    [InlineData("file...pdf")]
+    [InlineData("file/name")]
+    [InlineData("file:name")]
+    public async Task UploadPdfAsync_InvalidFileName_ShouldThrowBlobFileNameException(string invalidFileName)
+    {
+        // Arrange
+        var file = CreateMockPdfFile();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<BlobFileNameException>(
+            () => _pdfService.UploadPdfAsync(file, invalidFileName));
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_NoFileNameProvided_ShouldUseOriginalFileName()
+    {
+        // Arrange
+        var file = CreateMockPdfFile(fileName: "original-report.pdf");
+
+        // Act
+        var blobName = await _pdfService.UploadPdfAsync(file); // fileName = null
+
+        // Assert
+        var filePath = Path.Combine(_pdfEnv.FullPath, "original-report.pdf");
+        Assert.True(File.Exists(filePath));
+        Assert.Equal("original-report.pdf", blobName);
+    }
+
+    [Fact]
+    public async Task GetPdfAsync_ExistingFile_ShouldReturnCorrectContent()
+    {
+        // Arrange
+        var file = CreateMockPdfFile();
+        await _pdfService.UploadPdfAsync(file, _fileName);
+
+        // Act
+        using var stream = await _pdfService.GetPdfAsync($"{_fileName}.pdf");
+
+        // Assert
+        Assert.NotNull(stream);
+        Assert.True(stream.Length > 0);
+    }
+
+    [Fact]
+    public async Task GetPdfAsync_NonExistentFile_ShouldThrowBlobNotFoundException()
+    {
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<BlobNotFoundException>(
+            () => _pdfService.GetPdfAsync("nonexistent.pdf"));
+
+        Assert.Contains("nonexistent", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetPdfAsync_EmptyFileName_ShouldThrowBlobFileNameException(string fileName)
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<BlobFileNameException>(
+            () => _pdfService.GetPdfAsync(fileName));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            var directory = new DirectoryInfo(_tempDir) { Attributes = FileAttributes.Normal };
+            foreach (var info in directory.GetFileSystemInfos("*", SearchOption.AllDirectories))
+            {
+                info.Attributes = FileAttributes.Normal;
+            }
+
+            directory.Delete(true);
+        }
+    }
+
+    private static IFormFile CreateMockPdfFile(
+        string contentType = "application/pdf",
+        byte[] content = null!,
+        string fileName = "test.pdf")
+    {
+        var fileContent = content ?? ValidPdfBytes;
+        var mockFile = new Mock<IFormFile>();
+        var stream = new MemoryStream(fileContent);
+
+        mockFile.Setup(f => f.ContentType).Returns(contentType);
+        mockFile.Setup(f => f.Length).Returns(fileContent.Length);
+        mockFile.Setup(f => f.FileName).Returns(fileName);
+        mockFile.Setup(f => f.OpenReadStream()).Returns(() => new MemoryStream(fileContent));
+        mockFile.Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns<Stream, CancellationToken>(async (s, _) =>
+            {
+                await new MemoryStream(fileContent).CopyToAsync(s);
+            });
+
+        return mockFile.Object;
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Moq;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.BLL.Services.PdfStorage;
 
@@ -141,7 +142,7 @@ public class PdfServiceTests : IDisposable
         var ex = await Assert.ThrowsAsync<BlobNotFoundException>(
             () => _pdfService.GetPdfAsync("nonexistent.pdf"));
 
-        Assert.Contains("nonexistent", ex.Message);
+        Assert.Contains(PdfReportConstants.PdfNotFound, ex.Message);
     }
 
     [Theory]
@@ -152,6 +153,47 @@ public class PdfServiceTests : IDisposable
         // Act & Assert
         await Assert.ThrowsAsync<BlobFileNameException>(
             () => _pdfService.GetPdfAsync(fileName));
+    }
+
+    [Fact]
+    public async Task DeletePdf_ExistingFile_ShouldRemoveFile()
+    {
+        // Arrange
+        var file = CreateMockPdfFile();
+        await _pdfService.UploadPdfAsync(file, _fileName);
+        var filePath = Path.Combine(_pdfEnv.FullPath, $"{_fileName}.pdf");
+        Assert.True(File.Exists(filePath));
+
+        // Act
+        _pdfService.DeletePdf($"{_fileName}.pdf");
+
+        // Assert
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void DeletePdf_NonExistentFile_ShouldNotThrow()
+    {
+        // Act & Assert
+        var exception = Record.Exception(() => _pdfService.DeletePdf("nonexistent.pdf"));
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void DeletePdf_EmptyFileName_ShouldThrowBlobFileNameException(string fileName)
+    {
+        // Act & Assert
+        Assert.Throws<BlobFileNameException>(() => _pdfService.DeletePdf(fileName));
+    }
+
+    [Theory]
+    [InlineData("file...pdf")]
+    public void DeletePdf_InvalidFileName_ShouldThrowBlobFileNameException(string invalidFileName)
+    {
+        // Act & Assert
+        Assert.Throws<BlobFileNameException>(() => _pdfService.DeletePdf(invalidFileName));
     }
 
     public void Dispose()

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
@@ -94,7 +94,6 @@ public class PdfServiceTests : IDisposable
     [Theory]
     [InlineData("file...pdf")]
     [InlineData("file/name")]
-    [InlineData("file:name")]
     public async Task UploadPdfAsync_InvalidFileName_ShouldThrowBlobFileNameException(string invalidFileName)
     {
         // Arrange
@@ -112,7 +111,7 @@ public class PdfServiceTests : IDisposable
         var file = CreateMockPdfFile(fileName: "original-report.pdf");
 
         // Act
-        var blobName = await _pdfService.UploadPdfAsync(file); // fileName = null
+        var blobName = await _pdfService.UploadPdfAsync(file); 
 
         // Assert
         var filePath = Path.Combine(_pdfEnv.FullPath, "original-report.pdf");

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/PdfServiceTests.cs
@@ -111,7 +111,7 @@ public class PdfServiceTests : IDisposable
         var file = CreateMockPdfFile(fileName: "original-report.pdf");
 
         // Act
-        var blobName = await _pdfService.UploadPdfAsync(file); 
+        var blobName = await _pdfService.UploadPdfAsync(file);
 
         // Assert
         var filePath = Path.Combine(_pdfEnv.FullPath, "original-report.pdf");

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/PdfReports/CreatePdfReportValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/PdfReports/CreatePdfReportValidatorTests.cs
@@ -1,9 +1,10 @@
+using FluentValidation.TestHelper;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.Validators.PdfReports;
-using FluentValidation.TestHelper;
 
 namespace VictoryCenter.UnitTests.ValidatorsTests.PdfReports;
 
@@ -42,7 +43,7 @@ public class CreatePdfReportValidatorTests
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.CreatePdfReportDto.File)
-            .WithErrorMessage("File cannot be empty");
+            .WithErrorMessage(PdfReportConstants.FileCannotBeEmpty);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/PdfReports/CreatePdfReportValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/PdfReports/CreatePdfReportValidatorTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.AspNetCore.Http;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Validators.PdfReports;
+using FluentValidation.TestHelper;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.PdfReports;
+
+public class CreatePdfReportValidatorTests
+{
+    private const long MaxPdfSizeInBytes = 10 * 1024 * 1024;
+    private const string PdfMimeType = "application/pdf";
+    private readonly CreatePdfReportValidator _validator;
+
+    public CreatePdfReportValidatorTests()
+    {
+        _validator = new CreatePdfReportValidator();
+    }
+
+    [Fact]
+    public void Validate_FileIsNull_ShouldHaveError()
+    {
+        // Arrange
+        var command = CreateCommand(null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.CreatePdfReportDto.File);
+    }
+
+    [Fact]
+    public void Validate_FileIsEmpty_ShouldHaveError()
+    {
+        // Arrange
+        var command = CreateCommand(CreateMockFile(length: 0));
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.CreatePdfReportDto.File)
+            .WithErrorMessage("File cannot be empty");
+    }
+
+    [Fact]
+    public void Validate_FileSizeExceedsLimit_ShouldHaveError()
+    {
+        // Arrange
+        var command = CreateCommand(CreateMockFile(length: MaxPdfSizeInBytes + 1));
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.CreatePdfReportDto.File)
+            .WithErrorMessage($"File size cannot exceed {MaxPdfSizeInBytes / 1024 / 1024} MB");
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("application/msword")]
+    [InlineData("text/plain")]
+    public void Validate_FileIsNotPdf_ShouldHaveError(string contentType)
+    {
+        // Arrange
+        var command = CreateCommand(CreateMockFile(contentType: contentType));
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.CreatePdfReportDto.File)
+            .WithErrorMessage("File must be a PDF");
+    }
+
+    [Fact]
+    public void Validate_ValidPdfFile_ShouldNotHaveErrors()
+    {
+        // Arrange
+        var command = CreateCommand(CreateMockFile());
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_FileSizeAtLimit_ShouldNotHaveError()
+    {
+        // Arrange
+        var command = CreateCommand(CreateMockFile(length: MaxPdfSizeInBytes));
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.CreatePdfReportDto.File);
+    }
+
+    private static IFormFile CreateMockFile(
+        string contentType = PdfMimeType,
+        long length = 1024,
+        string fileName = "test.pdf")
+    {
+        var mockFile = new Mock<IFormFile>();
+        mockFile.Setup(f => f.ContentType).Returns(contentType);
+        mockFile.Setup(f => f.Length).Returns(length);
+        mockFile.Setup(f => f.FileName).Returns(fileName);
+        return mockFile.Object;
+    }
+
+    private static CreatePdfReportCommand CreateCommand(IFormFile? file)
+    {
+        return new CreatePdfReportCommand(new CreatePdfReportDto
+        {
+            File = file!
+        });
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
 using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -18,7 +19,7 @@ public class PdfReportsController : AuthorizedApiController
     }
 
     [HttpGet]
-    [ProducesResponseType(typeof(List<PdfReportDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PaginationResult<PdfReportDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAllPdfReports([FromQuery] BaseFilterDto filter)
     {
         return HandleResult(await Mediator.Send(new GetAllPdfReportsQuery(filter)));

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class PdfReportsController : AuthorizedApiController
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(PdfReportDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreatePdfReport([FromForm] CreatePdfReportDto request)
+    {
+        return HandleResult(await Mediator.Send(new CreatePdfReportCommand(request)));
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(List<PdfReportDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAllPdfReports([FromQuery] BaseFilterDto filter)
+    {
+        return HandleResult(await Mediator.Send(new GetAllPdfReportsQuery(filter)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
+using Slugify;
 using VictoryCenter.BLL;
 using VictoryCenter.BLL.Commands.Public.Payment.Common;
 using VictoryCenter.BLL.Constants;
@@ -13,6 +14,7 @@ using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.BlobStorage;
 using VictoryCenter.BLL.Interfaces.Localization;
 using VictoryCenter.BLL.Interfaces.PaymentService;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.BLL.Interfaces.ReorderService;
 using VictoryCenter.BLL.Interfaces.Search;
 using VictoryCenter.BLL.Interfaces.SlugService;
@@ -23,6 +25,7 @@ using VictoryCenter.BLL.Options.Payment;
 using VictoryCenter.BLL.Services.BlobStorage;
 using VictoryCenter.BLL.Services.Localization;
 using VictoryCenter.BLL.Services.PaymentService;
+using VictoryCenter.BLL.Services.PdfStorage;
 using VictoryCenter.BLL.Services.ReorderService;
 using VictoryCenter.BLL.Services.Search;
 using VictoryCenter.BLL.Services.SlugService;
@@ -38,7 +41,6 @@ using VictoryCenter.DAL.Repositories.Realizations.Base;
 using VictoryCenter.WebAPI.Factories;
 using VictoryCenter.WebAPI.Filters;
 using VictoryCenter.WebAPI.Utils;
-using Slugify;
 
 namespace VictoryCenter.WebAPI.Extensions;
 
@@ -112,6 +114,7 @@ public static class ServicesConfiguration
         services.AddSingleton<ProblemDetailsFactory, CustomProblemDetailsFactory>();
         services.AddScoped<StrictJsonValidationFilter>();
         services.ConfigureBlob(configuration);
+        services.ConfigurePdf(configuration);
 
         services.AddOptions<JwtOptions>()
             .BindConfiguration(JwtOptions.Position)
@@ -530,6 +533,38 @@ public static class ServicesConfiguration
                 services.AddOptions<BlobEnvironmentVariables>().Bind(blobSection.GetSection("Azure"))
                     .ValidateDataAnnotations();
                 services.AddScoped<IBlobService, BlobService>();
+                break;
+
+            default:
+                throw new InvalidOperationException($"Unsupported Blob Service Type: {serviceType}");
+        }
+
+        return services;
+    }
+
+    private static IServiceCollection ConfigurePdf(this IServiceCollection services, IConfiguration configuration)
+    {
+        var blobSection = configuration.GetSection("BlobEnvironmentVariables");
+        var serviceType = blobSection.GetValue<string>("ServiceType");
+
+        switch (serviceType)
+        {
+            case "Local":
+                services.AddOptions<PdfEnvironmentVariables>()
+                    .Bind(blobSection.GetSection("Local"))
+                    .ValidateDataAnnotations()
+                    .PostConfigure<IWebHostEnvironment>((options, env) =>
+                    {
+                        options.RootPath = env.WebRootPath;
+                    });
+                services.AddScoped<IPdfService, PdfService>();
+                break;
+
+            case "Azure":
+                services.AddOptions<PdfEnvironmentVariables>()
+                    .Bind(blobSection.GetSection("Azure"))
+                    .ValidateDataAnnotations();
+                services.AddScoped<IPdfService, PdfService>();
                 break;
 
             default:

--- a/VictoryCenter/VictoryCenter.WebAPI/appsettings.IntegrationTests.json
+++ b/VictoryCenter/VictoryCenter.WebAPI/appsettings.IntegrationTests.json
@@ -5,7 +5,8 @@
   "BlobEnvironmentVariables": {
     "ServiceType": "Local",
     "Local": {
-      "ImagesSubPath": "ImagesIntegrationTest"
+      "ImagesSubPath": "ImagesIntegrationTest",
+      "PdfSubPath": "PdfReportsIntegrationTest"
     }
   },
   "JwtOptions": {

--- a/VictoryCenter/VictoryCenter.WebAPI/appsettings.json
+++ b/VictoryCenter/VictoryCenter.WebAPI/appsettings.json
@@ -5,7 +5,8 @@
   "BlobEnvironmentVariables": {
     "ServiceType": "Local",
     "Local": {
-      "ImagesSubPath": "Images"
+      "ImagesSubPath": "Images",
+      "PdfSubPath": "PdfReports"
     }
   },
   "Logging": {


### PR DESCRIPTION
## GITHUB TICKET

* [Issue-1326](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1326)

## Summary of issue

Admin users need the ability to upload PDF files for the Ukrainian version of the public "Reports" page. Currently, there is no backend API endpoint to handle PDF file uploads, validate their format, and persist them to storage and database. This feature is required to allow visitors to download detailed company financial reports from the public website.

## Summary of change

- Added POST /api/PdfReports endpoint in PdfReportsController that accepts multipart/form-data with PDF file
- Created CreatePdfReportCommand and CreatePdfReportHandler using CQRS pattern with MediatR
- Implemented transactional file upload with database rollback and cleanup on failure
- CreatePdfReportValidator validates file presence, size (max 10MB), and MIME type (application/pdf)
- PdfService.ValidatePdfSignatureAsync performs magic bytes validation (%PDF signature) to prevent malicious file uploads disguised as PDFs
- File name sanitization prevents path traversal attacks
- PdfService handles file operations with configurable storage path via PdfEnvironmentVariables
- Files stored with GUID-based BlobName to prevent naming conflicts
- User-friendly Name derived from original filename (without extension) for display purposes
- Created PdfReport entity with Name, BlobName, FileSizeBytes, Priority, and CreatedAt fields
- Added EF Core migration AddPdfReportsTable in media schema
- Implements IOrderableEntity for priority-based ordering

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF report management: upload, store, delete PDFs; persisted metadata and paginated retrieval ordered by priority; API endpoints to create and list reports
* **Validation & Error Handling**
  * Strict PDF validation (MIME, signature), filename checks, 10 MB size limit, transactional cleanup on failures, and clear user-facing error messages
* **Configuration**
  * Local and cloud storage options with configurable PDF storage paths
* **Tests**
  * Extensive unit and integration tests covering upload, retrieval, validation, ordering, and failure cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->