### PR TITLE
Feature/issue-1388 [Who we are] Translation indicators for blocks

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/WhoWeAre/Update/UpdateWhoWeAreContentHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/WhoWeAre/Update/UpdateWhoWeAreContentHandler.cs
@@ -109,6 +109,7 @@ public class UpdateWhoWeAreContentHandler : IRequestHandler<UpdateWhoWeAreConten
 
         var entities = await _repository.WhoWeAreContentsRepository.GetAllAsync(new QueryOptions<WhoWeAreContent>
         {
+            AsNoTracking = false,
             Filter = w => contentIds.Contains(w.Id),
             Include = w => w.Include(w => w.Localizations).ThenInclude(l => l.Language)
         });
@@ -189,8 +190,6 @@ public class UpdateWhoWeAreContentHandler : IRequestHandler<UpdateWhoWeAreConten
                 loc.TranslationStatus = TranslationStatus.Outdated;
             }
         }
-
-        _repository.WhoWeAreContentsRepository.Update(entity);
     }
 
     private async Task<long?> GetSectionIdByType(SectionType sectionType)

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/Common/TranslationStatusInfoDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/Common/TranslationStatusInfoDto.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.Common;
+
+public class TranslationStatusInfoDto
+{
+    public long LanguageId { get; set; }
+
+    public TranslationStatus TranslationStatus { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/WhoWeAreSection/WhoWeAreSectionInfoDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/WhoWeAreSection/WhoWeAreSectionInfoDto.cs
@@ -1,9 +1,12 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Common;
+
 namespace VictoryCenter.BLL.DTOs.Admin.WhoWeAreSection;
 
 public class WhoWeAreSectionInfoDto
 {
     public long Id { get; set; }
     public string SectionType { get; set; } = null!;
+    public List<TranslationStatusInfoDto> TranslationStatuses { get; set; } = [];
 
     public required string Title { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/WhoWeAreSections/GetPreviews/GetWhoWeAreSectionPreviewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/WhoWeAreSections/GetPreviews/GetWhoWeAreSectionPreviewsHandler.cs
@@ -1,8 +1,14 @@
 using AutoMapper;
 using FluentResults;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.Localization.Common;
 using VictoryCenter.BLL.DTOs.Admin.WhoWeAreSection;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.WhoWeAreContents;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
 
 namespace VictoryCenter.BLL.Queries.Admin.WhoWeAreSections.GetPreviews;
 
@@ -19,7 +25,47 @@ public class GetWhoWeAreSectionPreviewsHandler : IRequestHandler<GetWhoWeAreSect
 
     public async Task<Result<List<WhoWeAreSectionInfoDto>>> Handle(GetWhoWeAreSectionPreviewsQuery request, CancellationToken cancellationToken)
     {
-        var result = await _repository.WhoWeAreSectionsRepository.GetAllAsync();
-        return Result.Ok(_mapper.Map<List<WhoWeAreSectionInfoDto>>(result));
+        var queryOptions = new QueryOptions<WhoWeAreSection>
+        {
+            Include = s => s
+                   .Include(sec => sec.Contents)
+                   .ThenInclude(c => c.Localizations)
+        };
+
+        var sections = await _repository.WhoWeAreSectionsRepository.GetAllAsync(queryOptions);
+
+        var result = new List<WhoWeAreSectionInfoDto>();
+
+        foreach (var section in sections)
+        {
+            var mappedSection = _mapper.Map<WhoWeAreSectionInfoDto>(section);
+            mappedSection.TranslationStatuses = AggregateLocalizationStatuses(section.Contents);
+            result.Add(mappedSection);
+        }
+
+        return Result.Ok(result);
+    }
+
+    private List<TranslationStatusInfoDto> AggregateLocalizationStatuses(List<WhoWeAreContent> contents)
+    {
+        var textContents = contents.Where(c => c.ContentType != ContentType.Image).ToList();
+
+        if (textContents.Count == 0)
+        {
+            return [];
+        }
+
+        return textContents
+            .SelectMany(c => c.Localizations)
+            .GroupBy(l => l.LanguageId)
+            .Where(g => g.Count() == textContents.Count)
+            .Select(g => new TranslationStatusInfoDto
+            {
+                LanguageId = g.Key,
+                TranslationStatus = g.Any(l => l.TranslationStatus == TranslationStatus.Outdated)
+                    ? TranslationStatus.Outdated
+                    : TranslationStatus.Relevant
+            })
+            .ToList();
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/GetPreviewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/GetPreviewsTests.cs
@@ -3,6 +3,8 @@ using Moq;
 using VictoryCenter.BLL.DTOs.Admin.WhoWeAreSection;
 using VictoryCenter.BLL.Queries.Admin.WhoWeAreSections.GetPreviews;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Entities.WhoWeAreContents;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -50,11 +52,47 @@ public class GetPreviewsTests
         }
     }
 
+    [Fact]
+    public async Task Handle_WithTranslationStatuses_ShouldAggregateCorrectly()
+    {
+        // Arrange
+        var entities = GetEntitiesWithTranslationStatuses();
+        var expectedDtos = GetDtosWithTranslationStatuses();
+
+        SetupRepositoryWrapper(entities);
+        SetupMapper(expectedDtos);
+
+        var handler = new GetWhoWeAreSectionPreviewsHandler(_repositoryWrapper.Object, _mapper.Object);
+        var query = new GetWhoWeAreSectionPreviewsQuery();
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
+
+        var sectionDto = result.Value[0];
+        Assert.Equal(expectedDtos[0].Id, sectionDto.Id);
+        Assert.Equal(expectedDtos[0].Title, sectionDto.Title);
+        Assert.Equal(expectedDtos[0].SectionType, sectionDto.SectionType);
+
+        var statuses = sectionDto.TranslationStatuses;
+        Assert.NotNull(statuses);
+        Assert.Equal(2, statuses.Count);
+        Assert.Contains(statuses, s => s.LanguageId == 1 && s.TranslationStatus == TranslationStatus.Relevant);
+        Assert.Contains(statuses, s => s.LanguageId == 2 && s.TranslationStatus == TranslationStatus.Outdated);
+        Assert.DoesNotContain(statuses, s => s.LanguageId == 3);
+        Assert.DoesNotContain(statuses, s => s.LanguageId == 4);
+    }
+
     private void SetupMapper(List<WhoWeAreSectionInfoDto> dtos)
     {
         _mapper
-            .Setup(m => m.Map<List<WhoWeAreSectionInfoDto>>(It.IsAny<List<WhoWeAreSection>>()))
-            .Returns(dtos);
+            .Setup(m => m.Map<WhoWeAreSectionInfoDto>(It.IsAny<WhoWeAreSection>()))
+            .Returns((WhoWeAreSection source) => dtos.FirstOrDefault(d => d.Id == source.Id)!);
     }
 
     private void SetupRepositoryWrapper(List<WhoWeAreSection> entities)
@@ -72,7 +110,7 @@ public class GetPreviewsTests
             SectionType = SectionType.Main,
             Title = "Основне",
             CreatedAt = DateTime.Now,
-            Contents = null!,
+            Contents = [],
         },
         new WhoWeAreSection
         {
@@ -80,7 +118,7 @@ public class GetPreviewsTests
             SectionType = SectionType.WhatWeDo,
             Title = "Що ми робимо",
             CreatedAt = DateTime.Now,
-            Contents = null!,
+            Contents = [],
         },
         new WhoWeAreSection
         {
@@ -88,7 +126,7 @@ public class GetPreviewsTests
             SectionType = SectionType.WhoWeSupport,
             Title = "Кого ми підтримуємо",
             CreatedAt = DateTime.Now,
-            Contents = null!
+            Contents = []
         },
         new WhoWeAreSection
         {
@@ -96,7 +134,7 @@ public class GetPreviewsTests
             SectionType = SectionType.Team,
             Title = "Команда",
             CreatedAt = DateTime.Now,
-            Contents = null!
+            Contents = []
         },
         new WhoWeAreSection
         {
@@ -104,7 +142,7 @@ public class GetPreviewsTests
             SectionType = SectionType.People,
             Title = "Люди",
             CreatedAt = DateTime.Now,
-            Contents = null!
+            Contents = []
         }
     };
 
@@ -139,6 +177,60 @@ public class GetPreviewsTests
             Id = 5,
             Title = "Люди",
             SectionType = "People"
+        }
+    };
+
+    private static List<WhoWeAreSection> GetEntitiesWithTranslationStatuses() => new()
+    {
+        new WhoWeAreSection
+        {
+            Id = 1,
+            SectionType = SectionType.Main,
+            Title = "Test Support",
+            CreatedAt = DateTime.Now,
+            Contents = new List<WhoWeAreContent>
+            {
+                new TitleContent
+                {
+                    Id = 1,
+                    ContentType = ContentType.Title,
+                    Localizations = new List<WhoWeAreContentLocalization>
+                    {
+                        new() { LanguageId = 1, TranslationStatus = TranslationStatus.Relevant },
+                        new() { LanguageId = 2, TranslationStatus = TranslationStatus.Relevant },
+                        new() { LanguageId = 3, TranslationStatus = TranslationStatus.Outdated }
+                    }
+                },
+                new DescriptionContent
+                {
+                    Id = 2,
+                    ContentType = ContentType.Description,
+                    Localizations = new List<WhoWeAreContentLocalization>
+                    {
+                        new() { LanguageId = 1, TranslationStatus = TranslationStatus.Relevant },
+                        new() { LanguageId = 2, TranslationStatus = TranslationStatus.Outdated }
+                    }
+                },
+                new ImageContent
+                {
+                    Id = 3,
+                    ContentType = ContentType.Image,
+                    Localizations = new List<WhoWeAreContentLocalization>
+                    {
+                        new() { LanguageId = 4, TranslationStatus = TranslationStatus.Relevant }
+                    }
+                }
+            }
+        }
+    };
+
+    private static List<WhoWeAreSectionInfoDto> GetDtosWithTranslationStatuses() => new()
+    {
+        new WhoWeAreSectionInfoDto
+        {
+            Id = 1,
+            Title = "Test Support",
+            SectionType = "Main"
         }
     };
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/GetPreviewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/GetPreviewsTests.cs
@@ -88,6 +88,33 @@ public class GetPreviewsTests
         Assert.DoesNotContain(statuses, s => s.LanguageId == 4);
     }
 
+    [Fact]
+    public async Task Handle_WithImageOnlyContents_ShouldReturnEmptyTranslationStatuses()
+    {
+        // Arrange
+        var entities = GetEntitiesWithImageOnlyContents();
+        var expectedDtos = GetDtosWithTranslationStatuses();
+
+        SetupRepositoryWrapper(entities);
+        SetupMapper(expectedDtos);
+
+        var handler = new GetWhoWeAreSectionPreviewsHandler(_repositoryWrapper.Object, _mapper.Object);
+        var query = new GetWhoWeAreSectionPreviewsQuery();
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
+
+        var statuses = result.Value[0].TranslationStatuses;
+        Assert.NotNull(statuses);
+        Assert.Empty(statuses);
+    }
+
     private void SetupMapper(List<WhoWeAreSectionInfoDto> dtos)
     {
         _mapper
@@ -218,6 +245,30 @@ public class GetPreviewsTests
                     Localizations = new List<WhoWeAreContentLocalization>
                     {
                         new() { LanguageId = 4, TranslationStatus = TranslationStatus.Relevant }
+                    }
+                }
+            }
+        }
+    };
+
+    private static List<WhoWeAreSection> GetEntitiesWithImageOnlyContents() => new()
+    {
+        new WhoWeAreSection
+        {
+            Id = 1,
+            SectionType = SectionType.Main,
+            Title = "Test Support",
+            CreatedAt = DateTime.Now,
+            Contents = new List<WhoWeAreContent>
+            {
+                new ImageContent
+                {
+                    Id = 3,
+                    ContentType = ContentType.Image,
+                    Localizations = new List<WhoWeAreContentLocalization>
+                    {
+                        new() { LanguageId = 1, TranslationStatus = TranslationStatus.Outdated },
+                        new() { LanguageId = 2, TranslationStatus = TranslationStatus.Relevant }
                     }
                 }
             }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/UpdateSectionTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/UpdateSectionTests.cs
@@ -120,7 +120,6 @@ public class UpdateWhoWeAreContentTests
         // Assert
         Assert.True(result.IsSuccess);
         _mockFactory.Verify(f => f.UpdateDescription(It.IsAny<UpdateWhoWeAreContentDto>(), _testDescriptionContent), Times.Once);
-        _mockRepositoryWrapper.Verify(r => r.WhoWeAreContentsRepository.Update(_testDescriptionContent), Times.Once);
         _mockRepositoryWrapper.Verify(r => r.SaveChangesAsync(), Times.Once);
     }
 
@@ -143,7 +142,6 @@ public class UpdateWhoWeAreContentTests
         // Assert
         Assert.True(result.IsSuccess);
         _mockFactory.Verify(f => f.UpdateCard(It.IsAny<UpdateWhoWeAreContentDto>(), _testCardContent), Times.Once);
-        _mockRepositoryWrapper.Verify(r => r.WhoWeAreContentsRepository.Update(_testCardContent), Times.Once);
         _mockRepositoryWrapper.Verify(x => x.ImageRepository.DeleteRange(new List<Image> { _testImage }), Times.Once);
         _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Exactly(2));
     }
@@ -168,7 +166,6 @@ public class UpdateWhoWeAreContentTests
         // Assert
         Assert.True(result.IsSuccess);
         _mockFactory.Verify(f => f.UpdateCard(It.IsAny<UpdateWhoWeAreContentDto>(), _testCardContent), Times.Once);
-        _mockRepositoryWrapper.Verify(r => r.WhoWeAreContentsRepository.Update(_testCardContent), Times.Once);
         _mockRepositoryWrapper.Verify(x => x.ImageRepository.DeleteRange(It.IsAny<IEnumerable<Image>>()), Times.Never);
         _mockRepositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Once);
     }


### PR DESCRIPTION
## GitHub

* #1388 

## Summary of change

This pull request introduces the aggregation and exposure of translation statuses for "Who We Are" sections, refines how content entities are updated, and improves related unit tests. The main focus is to provide a summary of translation status per language for each section, which is now included in the section DTO and tested accordingly. Additionally, redundant repository update calls are removed to streamline the update logic.

**Enhancements to translation status aggregation and exposure:**

* Added a new DTO, `TranslationStatusInfoDto`, to represent translation status per language and included it in `WhoWeAreSectionInfoDto` (`VictoryCenter.BLL.DTOs.Admin.Localization.Common.TranslationStatusInfoDto.cs`, `VictoryCenter.BLL.DTOs.Admin.WhoWeAreSection.WhoWeAreSectionInfoDto.cs`). [[1]](diffhunk://#diff-674eeb9c4d707a0f5e4637ef137bb4fa4b7fe3154f56d41ae8f76509462ac746R1-R10) [[2]](diffhunk://#diff-1b48d28ed816586351dd86c24225c29ca8229b893fd9c5fab51c9aa1a0096397R1-R9)
* Updated the handler `GetWhoWeAreSectionPreviewsHandler` to aggregate translation statuses for each section and include them in the returned DTOs (`VictoryCenter.BLL/Queries/Admin/WhoWeAreSections/GetPreviews/GetWhoWeAreSectionPreviewsHandler.cs`). [[1]](diffhunk://#diff-8fe6cda43b0bc74f708f4ae6b4940ca242a7ace3dbedb15f3f6974fdffca8403R4-R11) [[2]](diffhunk://#diff-8fe6cda43b0bc74f708f4ae6b4940ca242a7ace3dbedb15f3f6974fdffca8403L22-R69)

**Unit test improvements:**

* Added comprehensive tests to verify correct aggregation of translation statuses and adjusted test data to use empty lists instead of null for `Contents` (`VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/GetPreviewsTests.cs`). [[1]](diffhunk://#diff-479b51c3c012f0a38c986523f4d8ae9674fda45b49b0d4b478e37de59a840398R55-R95) [[2]](diffhunk://#diff-479b51c3c012f0a38c986523f4d8ae9674fda45b49b0d4b478e37de59a840398L75-R145) [[3]](diffhunk://#diff-479b51c3c012f0a38c986523f4d8ae9674fda45b49b0d4b478e37de59a840398R182-R235)

**Update logic simplification:**

* Removed redundant calls to `WhoWeAreContentsRepository.Update` in the update handler and corresponding unit tests, relying on the context's tracking for updates (`VictoryCenter.BLL/Commands/Admin/WhoWeAre/Update/UpdateWhoWeAreContentHandler.cs`, `VictoryCenter.UnitTests/MediatRHandlersTests/WhoWeAre/UpdateSectionTests.cs`). [[1]](diffhunk://#diff-ca4216093698d2a0932ad9d36583fdbe0a3eeaeee270577a3bf75ffb5841430eL192-L193) [[2]](diffhunk://#diff-62f9b41191fb6b1f9500ce46954b7c46cd3e16f1c10aca415def8fcb75b77b22L123) [[3]](diffhunk://#diff-62f9b41191fb6b1f9500ce46954b7c46cd3e16f1c10aca415def8fcb75b77b22L146) [[4]](diffhunk://#diff-62f9b41191fb6b1f9500ce46954b7c46cd3e16f1c10aca415def8fcb75b77b22L171)

**Repository query adjustment:**

* Ensured tracked entities by setting `AsNoTracking = false` in content retrieval, supporting the update logic (`VictoryCenter.BLL/Commands/Admin/WhoWeAre/Update/UpdateWhoWeAreContentHandler.cs`).

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation status tracking for Who We Are sections, showing Relevant/Outdated per language; image-only sections now show no translation statuses.

* **Tests**
  * Expanded test coverage to validate translation-status aggregation across languages and the image-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->