### PR TITLE
Feature/issue [Single program] Update translation for the changed program profile in UA

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -107,9 +107,9 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 return Result.Fail<HippotherapyProgramDto>(assignImagesResult.Errors);
             }
 
-            foreach (var loc in program.Localizations)
+            if (programFieldsChanged)
             {
-                if (programFieldsChanged)
+                foreach (var loc in program.Localizations)
                 {
                     loc.TranslationStatus = TranslationStatus.Outdated;
                 }
@@ -229,14 +229,17 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                     return false;
                 }
 
-                if (!ApplyContentFieldUpdates(oldContent, newContent, imagesById))
+                if (!TryApplyContentFieldUpdates(oldContent, newContent, imagesById, out var contentChanged))
                 {
                     return false;
                 }
 
-                foreach (var loc in oldContent.Localizations)
+                if (contentChanged)
                 {
-                    loc.TranslationStatus = TranslationStatus.Outdated;
+                    foreach (var loc in oldContent.Localizations)
+                    {
+                        loc.TranslationStatus = TranslationStatus.Outdated;
+                    }
                 }
             }
         }
@@ -244,98 +247,133 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         return true;
     }
 
-    private static bool ApplyContentFieldUpdates(
+    private static bool TryApplyContentFieldUpdates(
         ProgramSectionContent oldContent,
         CreateProgramSectionContentDto newContent,
-        IReadOnlyDictionary<long, Image> imagesById)
+        IReadOnlyDictionary<long, Image> imagesById,
+        out bool contentChanged)
     {
+        contentChanged = false;
         oldContent.GroupIndex = newContent.GroupIndex;
 
         return newContent.ContentType switch
         {
-            DAL.Enums.ContentType.Title when oldContent is TitleProgramContent titleContent
-                => UpdateTitleContent(titleContent, newContent),
-            DAL.Enums.ContentType.Description when oldContent is DescriptionProgramContent descriptionContent
-                => UpdateDescriptionContent(descriptionContent, newContent),
-            DAL.Enums.ContentType.Image when oldContent is ImageProgramContent imageContent
-                => UpdateImageContent(imageContent, newContent, imagesById),
-            DAL.Enums.ContentType.Author when oldContent is AuthorProgramContent authorContent
-                => UpdateAuthorContent(authorContent, newContent),
-            DAL.Enums.ContentType.Question when oldContent is QuestionProgramContent questionContent
-                => UpdateQuestionContent(questionContent, newContent),
-            DAL.Enums.ContentType.Answer when oldContent is AnswerProgramContent answerContent
-                => UpdateAnswerContent(answerContent, newContent),
+            ContentType.Title when oldContent is TitleProgramContent titleContent
+                => UpdateTitleContent(titleContent, newContent, out contentChanged),
+            ContentType.Description when oldContent is DescriptionProgramContent descriptionContent
+                => UpdateDescriptionContent(descriptionContent, newContent, out contentChanged),
+            ContentType.Image when oldContent is ImageProgramContent imageContent
+                => UpdateImageContent(imageContent, newContent, imagesById, out contentChanged),
+            ContentType.Author when oldContent is AuthorProgramContent authorContent
+                => UpdateAuthorContent(authorContent, newContent, out contentChanged),
+            ContentType.Question when oldContent is QuestionProgramContent questionContent
+                => UpdateQuestionContent(questionContent, newContent, out contentChanged),
+            ContentType.Answer when oldContent is AnswerProgramContent answerContent
+                => UpdateAnswerContent(answerContent, newContent, out contentChanged),
             _ => false,
         };
     }
 
-    private static bool UpdateTitleContent(TitleProgramContent content, CreateProgramSectionContentDto source)
+    private static bool UpdateTitleContent(
+        TitleProgramContent content,
+        CreateProgramSectionContentDto source,
+        out bool changed)
     {
+        changed = false;
         if (source.Title is null)
         {
             return false;
         }
 
-        content.Title = source.Title.Trim();
+        var newValue = source.Title.Trim();
+        changed = !string.Equals(content.Title, newValue, StringComparison.Ordinal);
+        content.Title = newValue;
         return true;
     }
 
-    private static bool UpdateDescriptionContent(DescriptionProgramContent content, CreateProgramSectionContentDto source)
+    private static bool UpdateDescriptionContent(
+        DescriptionProgramContent content,
+        CreateProgramSectionContentDto source,
+        out bool changed)
     {
+        changed = false;
         if (source.Description is null)
         {
             return false;
         }
 
-        content.Description = source.Description.Trim();
+        var newValue = source.Description.Trim();
+        changed = !string.Equals(content.Description, newValue, StringComparison.Ordinal);
+        content.Description = newValue;
         return true;
     }
 
     private static bool UpdateImageContent(
         ImageProgramContent content,
         CreateProgramSectionContentDto source,
-        IReadOnlyDictionary<long, Image> imagesById)
+        IReadOnlyDictionary<long, Image> imagesById,
+        out bool changed)
     {
+        changed = false;
         if (source.ImageId is null || !imagesById.TryGetValue(source.ImageId.Value, out var image))
         {
             return false;
         }
 
+        changed = false;
         content.ImageId = source.ImageId.Value;
         content.Image = image;
         return true;
     }
 
-    private static bool UpdateAuthorContent(AuthorProgramContent content, CreateProgramSectionContentDto source)
+    private static bool UpdateAuthorContent(
+        AuthorProgramContent content,
+        CreateProgramSectionContentDto source,
+        out bool changed)
     {
+        changed = false;
         if (source.Author is null)
         {
             return false;
         }
 
-        content.Name = source.Author.Trim();
+        var newValue = source.Author.Trim();
+        changed = !string.Equals(content.Name, newValue, StringComparison.Ordinal);
+        content.Name = newValue;
         return true;
     }
 
-    private static bool UpdateQuestionContent(QuestionProgramContent content, CreateProgramSectionContentDto source)
+    private static bool UpdateQuestionContent(
+        QuestionProgramContent content,
+        CreateProgramSectionContentDto source,
+        out bool changed)
     {
+        changed = false;
         if (source.Question is null)
         {
             return false;
         }
 
-        content.Question = source.Question.Trim();
+        var newValue = source.Question.Trim();
+        changed = !string.Equals(content.Question, newValue, StringComparison.Ordinal);
+        content.Question = newValue;
         return true;
     }
 
-    private static bool UpdateAnswerContent(AnswerProgramContent content, CreateProgramSectionContentDto source)
+    private static bool UpdateAnswerContent(
+        AnswerProgramContent content,
+        CreateProgramSectionContentDto source,
+        out bool changed)
     {
+        changed = false;
         if (source.Answer is null)
         {
             return false;
         }
 
-        content.Answer = source.Answer.Trim();
+        var newValue = source.Answer.Trim();
+        changed = !string.Equals(content.Answer, newValue, StringComparison.Ordinal);
+        content.Answer = newValue;
         return true;
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -78,6 +78,11 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             var oldSlug = program.Slug;
             var nameChanged = request.UpdateProgramDto.Name != program.Name;
+            var translatableFieldsChanged = nameChanged
+                || request.UpdateProgramDto.Description != program.Description
+                || request.UpdateProgramDto.Location != program.Location
+                || request.UpdateProgramDto.ParticipantsCount != program.ParticipantsCount
+                || request.UpdateProgramDto.MeetingsCount != program.MeetingsCount;
 
             _mapper.Map(request.UpdateProgramDto, program);
 
@@ -99,13 +104,22 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 return Result.Fail<HippotherapyProgramDto>(assignImagesResult.Errors);
             }
 
-            ReplaceCategories(program, newCategoriesResult.Value);
+            var categoriesChenged = program.Categories.Select(c => c.Id).OrderBy(id => id)
+                .SequenceEqual(request.UpdateProgramDto.CategoryIds.OrderBy(id => id)) == false;
+
+            if (categoriesChenged)
+            {
+                ReplaceCategories(program, newCategoriesResult.Value);
+            }
 
             var now = DateTimeOffset.UtcNow;
 
-            ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
-
-            program.Localizations.Clear();
+            var fieldsChanged = request.UpdateProgramDto.Sections?.Any(s => s.Contents?.Count > 0) ?? false;
+            if (fieldsChanged)
+            {
+                ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
+                program.Localizations.Clear();
+            }
 
             _repositoryWrapper.HippotherapyProgramsRepository.Update(program);
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -9,6 +9,8 @@ using VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -50,6 +52,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                         .Include(x => x.Categories)
                         .Include(x => x.Sections)
                         .ThenInclude(s => s.Contents)
+                        .ThenInclude(c => c.Localizations)
                         .Include(x => x.Localizations)
                 });
 
@@ -78,7 +81,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             var oldSlug = program.Slug;
             var nameChanged = request.UpdateProgramDto.Name != program.Name;
-            var translatableFieldsChanged = nameChanged
+            var programFieldsChanged = nameChanged
                 || request.UpdateProgramDto.Description != program.Description
                 || request.UpdateProgramDto.Location != program.Location
                 || request.UpdateProgramDto.ParticipantsCount != program.ParticipantsCount
@@ -104,6 +107,14 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 return Result.Fail<HippotherapyProgramDto>(assignImagesResult.Errors);
             }
 
+            foreach (var loc in program.Localizations)
+            {
+                if (programFieldsChanged)
+                {
+                    loc.TranslationStatus = TranslationStatus.Outdated;
+                }
+            }
+
             var categoriesChenged = program.Categories.Select(c => c.Id).OrderBy(id => id)
                 .SequenceEqual(request.UpdateProgramDto.CategoryIds.OrderBy(id => id)) == false;
 
@@ -114,8 +125,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             var now = DateTimeOffset.UtcNow;
 
-            var fieldsChanged = request.UpdateProgramDto.Sections?.Any(s => s.Contents?.Count > 0) ?? false;
-            if (fieldsChanged)
+            if (!EnsureReplaceSameSections(program.Sections.ToList(), request.UpdateProgramDto.Sections, imagesByIdResult.Value))
             {
                 ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
                 program.Localizations.Clear();
@@ -144,6 +154,189 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         {
             program.Categories.Add(category);
         }
+    }
+
+    private static bool EnsureReplaceSameSections(
+        List<HippotherapyProgramSection> oldSections,
+        List<CreateHippotherapyProgramSectionDto> newSections,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        if (oldSections.Count != newSections.Count)
+        {
+            return false;
+        }
+
+        Dictionary<int, HippotherapyProgramSection> oldSectionsMap;
+        Dictionary<int, CreateHippotherapyProgramSectionDto> newSectionsMap;
+
+        try
+        {
+            oldSectionsMap = oldSections.ToDictionary(section => section.Order);
+            newSectionsMap = newSections.ToDictionary(section => section.Order);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        if (oldSectionsMap.Count != newSectionsMap.Count)
+        {
+            return false;
+        }
+
+        foreach (var (sectionOrder, newSection) in newSectionsMap)
+        {
+            if (!oldSectionsMap.TryGetValue(sectionOrder, out var oldSection))
+            {
+                return false;
+            }
+
+            if (oldSection.Template != newSection.Template)
+            {
+                return false;
+            }
+
+            var newContents = newSection.Contents ?? [];
+            var oldContents = oldSection.Contents;
+
+            Dictionary<int, CreateProgramSectionContentDto> newContentsMap;
+            Dictionary<int, ProgramSectionContent> oldContentsMap;
+
+            try
+            {
+                newContentsMap = newContents.ToDictionary(content => content.Order);
+                oldContentsMap = oldContents.ToDictionary(content => content.Order);
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            if (newContentsMap.Count != oldContentsMap.Count)
+            {
+                return false;
+            }
+
+            foreach (var (contentOrder, newContent) in newContentsMap)
+            {
+                if (!oldContentsMap.TryGetValue(contentOrder, out var oldContent))
+                {
+                    return false;
+                }
+
+                if (newContent.ContentType != oldContent.ContentType)
+                {
+                    return false;
+                }
+
+                if (!ApplyContentFieldUpdates(oldContent, newContent, imagesById))
+                {
+                    return false;
+                }
+
+                foreach (var loc in oldContent.Localizations)
+                {
+                    loc.TranslationStatus = TranslationStatus.Outdated;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ApplyContentFieldUpdates(
+        ProgramSectionContent oldContent,
+        CreateProgramSectionContentDto newContent,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        oldContent.GroupIndex = newContent.GroupIndex;
+
+        return newContent.ContentType switch
+        {
+            DAL.Enums.ContentType.Title when oldContent is TitleProgramContent titleContent
+                => UpdateTitleContent(titleContent, newContent),
+            DAL.Enums.ContentType.Description when oldContent is DescriptionProgramContent descriptionContent
+                => UpdateDescriptionContent(descriptionContent, newContent),
+            DAL.Enums.ContentType.Image when oldContent is ImageProgramContent imageContent
+                => UpdateImageContent(imageContent, newContent, imagesById),
+            DAL.Enums.ContentType.Author when oldContent is AuthorProgramContent authorContent
+                => UpdateAuthorContent(authorContent, newContent),
+            DAL.Enums.ContentType.Question when oldContent is QuestionProgramContent questionContent
+                => UpdateQuestionContent(questionContent, newContent),
+            DAL.Enums.ContentType.Answer when oldContent is AnswerProgramContent answerContent
+                => UpdateAnswerContent(answerContent, newContent),
+            _ => false,
+        };
+    }
+
+    private static bool UpdateTitleContent(TitleProgramContent content, CreateProgramSectionContentDto source)
+    {
+        if (source.Title is null)
+        {
+            return false;
+        }
+
+        content.Title = source.Title.Trim();
+        return true;
+    }
+
+    private static bool UpdateDescriptionContent(DescriptionProgramContent content, CreateProgramSectionContentDto source)
+    {
+        if (source.Description is null)
+        {
+            return false;
+        }
+
+        content.Description = source.Description.Trim();
+        return true;
+    }
+
+    private static bool UpdateImageContent(
+        ImageProgramContent content,
+        CreateProgramSectionContentDto source,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        if (source.ImageId is null || !imagesById.TryGetValue(source.ImageId.Value, out var image))
+        {
+            return false;
+        }
+
+        content.ImageId = source.ImageId.Value;
+        content.Image = image;
+        return true;
+    }
+
+    private static bool UpdateAuthorContent(AuthorProgramContent content, CreateProgramSectionContentDto source)
+    {
+        if (source.Author is null)
+        {
+            return false;
+        }
+
+        content.Name = source.Author.Trim();
+        return true;
+    }
+
+    private static bool UpdateQuestionContent(QuestionProgramContent content, CreateProgramSectionContentDto source)
+    {
+        if (source.Question is null)
+        {
+            return false;
+        }
+
+        content.Question = source.Question.Trim();
+        return true;
+    }
+
+    private static bool UpdateAnswerContent(AnswerProgramContent content, CreateProgramSectionContentDto source)
+    {
+        if (source.Answer is null)
+        {
+            return false;
+        }
+
+        content.Answer = source.Answer.Trim();
+        return true;
     }
 
     private static void ReplaceSections(

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -50,6 +50,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                         .Include(x => x.Categories)
                         .Include(x => x.Sections)
                         .ThenInclude(s => s.Contents)
+                        .Include(x => x.Localizations)
                 });
 
             if (program is null)
@@ -103,6 +104,8 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
             var now = DateTimeOffset.UtcNow;
 
             ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
+
+            program.Localizations.Clear();
 
             _repositoryWrapper.HippotherapyProgramsRepository.Update(program);
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/HippotherapyProgramLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/HippotherapyProgramLocalizationDto.cs
@@ -1,5 +1,6 @@
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 
@@ -18,6 +19,8 @@ public record HippotherapyProgramLocalizationDto
     public string? ParticipantsCount { get; init; }
 
     public string? MeetingsCount { get; init; }
+
+    public TranslationStatus TranslationStatus { get; init; }
 
     public List<HippotherapyProgramSectionLocalizationDto> Sections { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/HippotherapyProgramSectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/HippotherapyProgramSectionContentLocalizationDto.cs
@@ -1,4 +1,5 @@
 using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 
@@ -17,4 +18,6 @@ public record HippotherapyProgramSectionContentLocalizationDto
     public string? Question { get; init; }
 
     public string? Answer { get; init; }
+
+    public TranslationStatus TranslationStatus { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -64,8 +64,8 @@ public class UpdateHippotherapyProgramTests
         await sut.Handle(
             Command(id: 1, dto: Dto(sections:
             [
-                CreateSection(0),
-                CreateSection(1)
+                CreateSection(0, CreateImageContent(0, 1)),
+                CreateSection(1, CreateImageContent(0, 2))
             ])),
             CancellationToken.None);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -8,6 +8,8 @@ using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -237,6 +239,255 @@ public class UpdateHippotherapyProgramTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task Handle_ProgramFieldsChanged_MarksProgramLocalizationsOutdated()
+    {
+        var program = Program();
+        program.Name = "SameName";
+        program.Description = "SameDescription";
+        program.Location = "Kyiv";
+        program.ParticipantsCount = "10";
+        program.MeetingsCount = "5";
+        program.Localizations =
+        [
+            ProgramLocalization(1, TranslationStatus.Relevant),
+            ProgramLocalization(2, TranslationStatus.Relevant)
+        ];
+
+        var dto = Dto(name: "SameName", description: "SameDescription", sections: []);
+        dto.Location = "Lviv";
+        dto.ParticipantsCount = "10";
+        dto.MeetingsCount = "5";
+
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
+    }
+
+    [Fact]
+    public async Task Handle_ProgramFieldsUnchanged_KeepsProgramLocalizationsRelevant()
+    {
+        var program = Program();
+        program.Name = "SameName";
+        program.Description = "SameDescription";
+        program.Location = "Kyiv";
+        program.ParticipantsCount = "10";
+        program.MeetingsCount = "5";
+        program.Localizations =
+        [
+            ProgramLocalization(1, TranslationStatus.Relevant),
+            ProgramLocalization(2, TranslationStatus.Relevant)
+        ];
+
+        var dto = Dto(name: "SameName", description: "SameDescription", sections: []);
+        dto.Location = "Kyiv";
+        dto.ParticipantsCount = "10";
+        dto.MeetingsCount = "5";
+
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+    }
+
+    [Fact]
+    public async Task Handle_SameSectionStructureAndChangedTitle_MarksContentLocalizationsOutdated()
+    {
+        var content = new TitleProgramContent
+        {
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Old title",
+            Localizations =
+            [
+                ContentLocalization(1, TranslationStatus.Relevant),
+                ContentLocalization(2, TranslationStatus.Relevant)
+            ]
+        };
+
+        var section = new HippotherapyProgramSection
+        {
+            Template = default,
+            Order = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [content]
+        };
+
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        var dto = Dto(sections: [CreateSection(0, CreateTitleContent(0, "New title"))]);
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.Equal("New title", ((TitleProgramContent)program.Sections.Single().Contents.Single()).Title);
+        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
+    }
+
+    [Fact]
+    public async Task Handle_SameSectionStructureAndUnchangedTitle_KeepsContentLocalizationsRelevant()
+    {
+        var content = new TitleProgramContent
+        {
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Same title",
+            Localizations =
+            [
+                ContentLocalization(1, TranslationStatus.Relevant),
+                ContentLocalization(2, TranslationStatus.Relevant)
+            ]
+        };
+
+        var section = new HippotherapyProgramSection
+        {
+            Template = default,
+            Order = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [content]
+        };
+
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        var dto = Dto(sections: [CreateSection(0, CreateTitleContent(0, "Same title"))]);
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+    }
+
+    [Fact]
+    public async Task Handle_DifferentSectionStructure_ClearsProgramLocalizations()
+    {
+        var section = new HippotherapyProgramSection
+        {
+            Template = default,
+            Order = 99,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = []
+        };
+
+        var program = Program(sections: [section]);
+        program.Localizations =
+        [
+            ProgramLocalization(1, TranslationStatus.Relevant),
+            ProgramLocalization(2, TranslationStatus.Relevant)
+        ];
+
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(
+            Command(id: 1, dto: Dto(sections:
+            [
+                CreateSection(0, CreateImageContent(0, 1)),
+                CreateSection(1, CreateImageContent(0, 2))
+            ])),
+            CancellationToken.None);
+
+        Assert.Empty(program.Localizations);
+    }
+
+    [Fact]
+    public async Task Handle_SameStructureAndChangedDescription_MarksContentLocalizationsOutdated()
+    {
+        var content = new DescriptionProgramContent
+        {
+            ContentType = ContentType.Description,
+            Order = 0,
+            Description = "Old description",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateDescriptionContent(0, "New description"))])), CancellationToken.None);
+
+        Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
+    }
+
+    [Fact]
+    public async Task Handle_SameStructureAndChangedAuthor_MarksContentLocalizationsOutdated()
+    {
+        var content = new AuthorProgramContent
+        {
+            ContentType = ContentType.Author,
+            Order = 0,
+            Name = "Old author",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateAuthorContent(0, "New author"))])), CancellationToken.None);
+
+        Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
+    }
+
+    [Fact]
+    public async Task Handle_SameStructureAndChangedQuestion_MarksContentLocalizationsOutdated()
+    {
+        var content = new QuestionProgramContent
+        {
+            ContentType = ContentType.Question,
+            Order = 0,
+            Question = "Old question",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateQuestionContent(0, "New question"))])), CancellationToken.None);
+
+        Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
+    }
+
+    [Fact]
+    public async Task Handle_SameStructureAndChangedAnswer_MarksContentLocalizationsOutdated()
+    {
+        var content = new AnswerProgramContent
+        {
+            ContentType = ContentType.Answer,
+            Order = 0,
+            Answer = "Old answer",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateAnswerContent(0, "New answer"))])), CancellationToken.None);
+
+        Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
+    }
+
+    [Fact]
+    public async Task Handle_SameStructureAndImageChanged_DoesNotMarkContentLocalizationsOutdated()
+    {
+        var content = new ImageProgramContent
+        {
+            ContentType = ContentType.Image,
+            Order = 0,
+            ImageId = 1,
+            Image = Images[0],
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateImageContent(0, 2))])), CancellationToken.None);
+
+        Assert.Equal(2, content.ImageId);
+        Assert.Equal(TranslationStatus.Relevant, content.Localizations.Single().TranslationStatus);
+    }
+
     private UpdateHippotherapyProgramHandler CreateSut(
         HippotherapyProgram? program,
         int saveChanges,
@@ -437,6 +688,79 @@ public class UpdateHippotherapyProgramTests
             ContentType = ContentType.Image,
             Order = order,
             ImageId = imageId
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateTitleContent(int order, string title)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Title,
+            Order = order,
+            Title = title
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateDescriptionContent(int order, string description)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Description,
+            Order = order,
+            Description = description
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateAuthorContent(int order, string author)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Author,
+            Order = order,
+            Author = author
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateQuestionContent(int order, string question)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Question,
+            Order = order,
+            Question = question
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateAnswerContent(int order, string answer)
+    {
+        return new CreateProgramSectionContentDto
+        {
+            ContentType = ContentType.Answer,
+            Order = order,
+            Answer = answer
+        };
+    }
+
+    private static HippotherapyProgramLocalization ProgramLocalization(long languageId, TranslationStatus status)
+    {
+        return new HippotherapyProgramLocalization
+        {
+            EntityId = 1,
+            LanguageId = languageId,
+            Name = "Program",
+            TranslationStatus = status,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ProgramSectionContentLocalization ContentLocalization(long languageId, TranslationStatus status)
+    {
+        return new ProgramSectionContentLocalization
+        {
+            EntityId = 1,
+            LanguageId = languageId,
+            TranslationStatus = status,
+            CreatedAt = DateTimeOffset.UtcNow
         };
     }
 }


### PR DESCRIPTION
dev
## JIRA

* [Main GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1406)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

In this pull request, the update logic for localizations was refactored.

Now the behavior is the following:
	•	If the regular text content is changed (for example, text inside contents or other program text fields) without changing the structure, the translation status will be set to Outdated (orange status).
	•	If the structure changes (for example, sections or contents are added, removed, or reordered), the affected translations will be marked as Missing, and the previous translations related to that structure will be removed.
## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation status is now tracked and shown for hippotherapy program and section content localizations.

* **Improvements**
  * Localization handling tightened: localizations are eagerly loaded and marked outdated when related program or content fields change.
  * Category updates are applied only when selections differ.
  * Section replacement now verifies exact matches before replacing and clears stale localizations when needed.
  * Per-content updates validate and apply field-level changes safely.

* **Tests**
  * Section update tests adjusted to include image contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->