### PR TITLE
Feature/issue 1385 - Added abitity to edit HippotherapyProgramLocalization

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
@@ -48,8 +48,6 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
-            var contentTypesById = await _programSectionContentService
-                .GetContentTypesByProgramIdAsync(request.CreateHippotherapyProgramLocalizationDto.EntityId);
             var program = await _repositoryWrapper.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(new QueryOptions<HippotherapyProgramEntity>
             {
                 Filter = c => c.Id == request.CreateHippotherapyProgramLocalizationDto.EntityId,
@@ -61,6 +59,8 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
                 return Result.Fail<HippotherapyProgramLocalizationDto>(ErrorMessagesConstants.NotFound(request.CreateHippotherapyProgramLocalizationDto.EntityId, typeof(HippotherapyProgramEntity)));
             }
 
+            var contentTypesById = await _programSectionContentService
+                .GetContentTypesByProgramIdAsync(request.CreateHippotherapyProgramLocalizationDto.EntityId);
             ProgramSectionContentLocalizationValidationHelper
                 .ValidateSections<CreateHippotherapyProgramSectionLocalizationDto, CreateHippotherapyProgramSectionContentLocalizationDto>(
                     request.CreateHippotherapyProgramLocalizationDto.Sections,

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
@@ -48,8 +48,14 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
-            var contentTypesById = await _programSectionContentService.GetContentTypesByProgramIdAsync(request.CreateHippotherapyProgramLocalizationDto.EntityId);
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(request.CreateHippotherapyProgramLocalizationDto.Sections, contentTypesById);
+            var contentTypesById = await _programSectionContentService
+                .GetContentTypesByProgramIdAsync(request.CreateHippotherapyProgramLocalizationDto.EntityId);
+
+            ProgramSectionContentLocalizationValidationHelper
+                .ValidateSections<CreateHippotherapyProgramSectionLocalizationDto, CreateHippotherapyProgramSectionContentLocalizationDto>(
+                    request.CreateHippotherapyProgramLocalizationDto.Sections,
+                    contentTypesById,
+                    content => content.EntityId);
 
             var hippotherapyProgramLocalizationEntity = _mapper.Map<HippotherapyProgramLocalization>(request.CreateHippotherapyProgramLocalizationDto);
             HippotherapyProgramLocalization createdProgramLocalization = await _programLocalizationService.TrackEntityLocalizationAsync(hippotherapyProgramLocalizationEntity);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
@@ -86,7 +86,8 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
                 {
                     Filter = l => l.Id == request.CreateHippotherapyProgramLocalizationDto.LanguageId
                 }));
-            var sections = await GetProgramSections(createdProgramLocalization.EntityId, createdProgramLocalization.LanguageId);
+            var sections = await _programSectionContentService
+                .GetProgramSectionsAsync(createdProgramLocalization.EntityId, createdProgramLocalization.LanguageId);
             var response = _mapper.Map<HippotherapyProgramLocalizationDto>(createdProgramLocalization);
             response = response with
             {
@@ -117,43 +118,5 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
         {
             return Result.Fail<HippotherapyProgramLocalizationDto>($"Unexpected error: {ex.Message}");
         }
-    }
-
-    private async Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSections(long programId, long languageId)
-    {
-        var program = await _repositoryWrapper.HippotherapyProgramsLocalizationsRepository
-            .GetFirstOrDefaultAsync(
-                new QueryOptions<HippotherapyProgramLocalization>()
-                {
-                    Filter = entity => programId == entity.EntityId
-                                       && languageId == entity.LanguageId,
-                    Include = query => query.Include(entity => entity.Entity)
-                        .ThenInclude(entity => entity.Sections)
-                        .ThenInclude(section => section.Contents)
-                        .ThenInclude(content => content.Localizations)
-                        .ThenInclude(localization => localization.Language),
-                });
-
-        if (program is null)
-        {
-            throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(programId, typeof(HippotherapyProgramEntity)));
-        }
-
-        var sectionLocalizations = program.Entity
-            .Sections
-            .Select(section => new HippotherapyProgramSectionLocalizationDto
-            {
-                EntityId = section.Id,
-                Contents = section.Contents
-                    .SelectMany(content =>
-                        content.Localizations
-                            .Where(localization => localization.LanguageId == languageId)
-                            .Select(localization =>
-                                _mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization)))
-                    .ToList(),
-            })
-            .ToList();
-
-        return sectionLocalizations;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Create/CreateHippotherapyProgramLocalizationHandler.cs
@@ -50,12 +50,23 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
             var contentTypesById = await _programSectionContentService
                 .GetContentTypesByProgramIdAsync(request.CreateHippotherapyProgramLocalizationDto.EntityId);
+            var program = await _repositoryWrapper.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(new QueryOptions<HippotherapyProgramEntity>
+            {
+                Filter = c => c.Id == request.CreateHippotherapyProgramLocalizationDto.EntityId,
+                Include = query => query.Include(p => p.Sections).ThenInclude(p => p.Contents)
+            });
+
+            if(program is null)
+            {
+                return Result.Fail<HippotherapyProgramLocalizationDto>(ErrorMessagesConstants.NotFound(request.CreateHippotherapyProgramLocalizationDto.EntityId, typeof(HippotherapyProgramEntity)));
+            }
 
             ProgramSectionContentLocalizationValidationHelper
                 .ValidateSections<CreateHippotherapyProgramSectionLocalizationDto, CreateHippotherapyProgramSectionContentLocalizationDto>(
                     request.CreateHippotherapyProgramLocalizationDto.Sections,
                     contentTypesById,
-                    content => content.EntityId);
+                    content => content.EntityId,
+                    program);
 
             var hippotherapyProgramLocalizationEntity = _mapper.Map<HippotherapyProgramLocalization>(request.CreateHippotherapyProgramLocalizationDto);
             HippotherapyProgramLocalization createdProgramLocalization = await _programLocalizationService.TrackEntityLocalizationAsync(hippotherapyProgramLocalizationEntity);
@@ -63,7 +74,7 @@ public class CreateHippotherapyProgramLocalizationHandler : IRequestHandler<Crea
                 .SelectMany(section => section.Contents ?? [])
                 .ToList() ?? [];
             var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtos);
-            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations);
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations, false);
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
+public record UpdateHippotherapyProgramLocalizationCommand(UpdateHippotherapyProgramLocalizationDto UpdateHippotherapyProgramLocalizationDto, long EntityId,
+    long LanguageId)
+    : IRequest<Result<HippotherapyProgramLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -49,11 +49,23 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
             var contentTypesById = await _programSectionContentService.GetContentTypesByProgramIdAsync(request.EntityId);
+            var program = await _repositoryWrapper.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(new QueryOptions<HippotherapyProgramEntity>
+            {
+                Filter = c => c.Id == request.EntityId,
+                Include = query => query.Include(p => p.Sections).ThenInclude(p => p.Contents)
+            });
+
+            if (program is null)
+            {
+                return Result.Fail<HippotherapyProgramLocalizationDto>("Not found programEntity");
+            }
+
             ProgramSectionContentLocalizationValidationHelper
                 .ValidateSections<UpdateHippotherapyProgramSectionLocalizationDto, UpdateHippotherapyProgramSectionContentLocalizationDto>(
                     request.UpdateHippotherapyProgramLocalizationDto.Sections,
                     contentTypesById,
-                    content => content.EntityId);
+                    content => content.EntityId,
+                    program);
 
             var dto = request.UpdateHippotherapyProgramLocalizationDto;
             HippotherapyProgramLocalization programLocalizationEntity = _mapper.Map<HippotherapyProgramLocalization>(dto);
@@ -66,7 +78,14 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
                 .ToList();
 
             var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtos);
-            await _contentLocalizationService.TrackEntityLocalizationForUpdateAsync(contentLocalizations);
+
+            for (int i = 0; i < contentLocalizations.Count; i++)
+            {
+                contentLocalizations[i].EntityId = contentDtos[i].EntityId;
+                contentLocalizations[i].LanguageId = request.LanguageId;
+            }
+
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations, true);
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -5,7 +5,6 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
-using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
 using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Helpers;
@@ -102,7 +101,7 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
             var response = _mapper.Map<HippotherapyProgramLocalizationDto>(programLocalizationEntity) with
             {
                 LocalizationInfoDto = _mapper.Map<LocalizationInfoDto>(programLocalizationInfo),
-                Sections = await GetProgramSections(request.EntityId, request.LanguageId)
+                Sections = await _programSectionContentService.GetProgramSectionsAsync(request.EntityId, request.LanguageId)
             };
 
             return Result.Ok(response);
@@ -125,43 +124,5 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
             return Result.Fail<HippotherapyProgramLocalizationDto>(
                 ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)));
         }
-    }
-
-    private async Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSections(long programId, long languageId)
-    {
-        var program = await _repositoryWrapper.HippotherapyProgramsLocalizationsRepository
-            .GetFirstOrDefaultAsync(
-                new QueryOptions<HippotherapyProgramLocalization>()
-                {
-                    Filter = entity => programId == entity.EntityId
-                                       && languageId == entity.LanguageId,
-                    Include = query => query.Include(entity => entity.Entity)
-                        .ThenInclude(entity => entity.Sections)
-                        .ThenInclude(section => section.Contents)
-                        .ThenInclude(content => content.Localizations)
-                        .ThenInclude(localization => localization.Language),
-                });
-
-        if (program is null)
-        {
-            throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(programId, typeof(HippotherapyProgramEntity)));
-        }
-
-        var sectionLocalizations = program.Entity
-            .Sections
-            .Select(section => new HippotherapyProgramSectionLocalizationDto
-            {
-                EntityId = section.Id,
-                Contents = section.Contents
-                    .SelectMany(content =>
-                        content.Localizations
-                            .Where(localization => localization.LanguageId == languageId)
-                            .Select(localization =>
-                                _mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization)))
-                    .ToList(),
-            })
-            .ToList();
-
-        return sectionLocalizations;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -47,7 +47,6 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
-            var contentTypesById = await _programSectionContentService.GetContentTypesByProgramIdAsync(request.EntityId);
             var program = await _repositoryWrapper.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(new QueryOptions<HippotherapyProgramEntity>
             {
                 Filter = c => c.Id == request.EntityId,
@@ -58,6 +57,8 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
             {
                 return Result.Fail<HippotherapyProgramLocalizationDto>("Not found programEntity");
             }
+
+            var contentTypesById = await _programSectionContentService.GetContentTypesByProgramIdAsync(request.EntityId);
 
             ProgramSectionContentLocalizationValidationHelper
                 .ValidateSections<UpdateHippotherapyProgramSectionLocalizationDto, UpdateHippotherapyProgramSectionContentLocalizationDto>(

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -1,0 +1,12 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
+public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<UpdateHippotherapyProgramLocalizationCommand, Result<HippotherapyProgramLocalizationDto>>
+{
+    public Task<Result<HippotherapyProgramLocalizationDto>> Handle(UpdateHippotherapyProgramLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -1,12 +1,148 @@
+using AutoMapper;
 using FluentResults;
+using FluentValidation;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using HippotherapyProgramEntity = VictoryCenter.DAL.Entities.HippotherapyProgram;
 
 namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
 public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<UpdateHippotherapyProgramLocalizationCommand, Result<HippotherapyProgramLocalizationDto>>
 {
-    public Task<Result<HippotherapyProgramLocalizationDto>> Handle(UpdateHippotherapyProgramLocalizationCommand request, CancellationToken cancellationToken)
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<UpdateHippotherapyProgramLocalizationCommand> _validator;
+    private readonly IProgramSectionContentService _programSectionContentService;
+    private readonly ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization> _programLocalizationService;
+    private readonly ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> _contentLocalizationService;
+
+    public UpdateHippotherapyProgramLocalizationHandler(
+        IMapper mapper,
+        IRepositoryWrapper repositoryWrapper,
+        IValidator<UpdateHippotherapyProgramLocalizationCommand> validator,
+        IProgramSectionContentService programSectionContentService,
+        ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization> programLocalizationService,
+        ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> contentLocalizationService)
     {
-        throw new NotImplementedException();
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+        _programSectionContentService = programSectionContentService;
+        _programLocalizationService = programLocalizationService;
+        _contentLocalizationService = contentLocalizationService;
+    }
+
+    public async Task<Result<HippotherapyProgramLocalizationDto>> Handle(UpdateHippotherapyProgramLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var contentTypesById = await _programSectionContentService.GetContentTypesByProgramIdAsync(request.EntityId);
+            ProgramSectionContentLocalizationValidationHelper
+                .ValidateSections<UpdateHippotherapyProgramSectionLocalizationDto, UpdateHippotherapyProgramSectionContentLocalizationDto>(
+                    request.UpdateHippotherapyProgramLocalizationDto.Sections,
+                    contentTypesById,
+                    content => content.EntityId);
+
+            var dto = request.UpdateHippotherapyProgramLocalizationDto;
+            HippotherapyProgramLocalization programLocalizationEntity = _mapper.Map<HippotherapyProgramLocalization>(dto);
+            programLocalizationEntity.EntityId = request.EntityId;
+            programLocalizationEntity.LanguageId = request.LanguageId;
+            await _programLocalizationService.TrackEntityLocalizationForUpdateAsync(programLocalizationEntity);
+
+            var contentDtos = dto.Sections
+                .SelectMany(section => section.Contents ?? [])
+                .ToList();
+
+            var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtos);
+            await _contentLocalizationService.TrackEntityLocalizationForUpdateAsync(contentLocalizations);
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<HippotherapyProgramLocalizationDto>(
+                    ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)));
+            }
+
+            var programLocalizationInfo = await _repositoryWrapper.LocalizationLanguagesRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<LocalizationLanguage>
+                {
+                    Filter = l => l.Id == request.LanguageId
+                });
+
+            var response = _mapper.Map<HippotherapyProgramLocalizationDto>(programLocalizationEntity) with
+            {
+                LocalizationInfoDto = _mapper.Map<LocalizationInfoDto>(programLocalizationInfo),
+                Sections = await GetProgramSections(request.EntityId, request.LanguageId)
+            };
+
+            return Result.Ok(response);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Result.Fail<HippotherapyProgramLocalizationDto>(ex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<HippotherapyProgramLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(HippotherapyProgramLocalization)));
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<HippotherapyProgramLocalizationDto>(ex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<HippotherapyProgramLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)));
+        }
+    }
+
+    private async Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSections(long programId, long languageId)
+    {
+        var program = await _repositoryWrapper.HippotherapyProgramsLocalizationsRepository
+            .GetFirstOrDefaultAsync(
+                new QueryOptions<HippotherapyProgramLocalization>()
+                {
+                    Filter = entity => programId == entity.EntityId
+                                       && languageId == entity.LanguageId,
+                    Include = query => query.Include(entity => entity.Entity)
+                        .ThenInclude(entity => entity.Sections)
+                        .ThenInclude(section => section.Contents)
+                        .ThenInclude(content => content.Localizations)
+                        .ThenInclude(localization => localization.Language),
+                });
+
+        if (program is null)
+        {
+            throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(programId, typeof(HippotherapyProgramEntity)));
+        }
+
+        var sectionLocalizations = program.Entity
+            .Sections
+            .Select(section => new HippotherapyProgramSectionLocalizationDto
+            {
+                EntityId = section.Id,
+                Contents = section.Contents
+                    .SelectMany(content =>
+                        content.Localizations
+                            .Where(localization => localization.LanguageId == languageId)
+                            .Select(localization =>
+                                _mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization)))
+                    .ToList(),
+            })
+            .ToList();
+
+        return sectionLocalizations;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateFaqSectionQuestionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateFaqSectionQuestionDto.cs
@@ -1,6 +1,6 @@
 namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 
-public record CreateFaqQuestionDto
+public record CreateFaqSectionQuestionDto
 {
     public long? Id { get; init; }
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
@@ -18,5 +18,5 @@ public record CreateProgramSectionContentDto
 
     public string? Author { get; init; }
 
-    public CreateFaqQuestionDto? FaqQuestion { get; init; }
+    public CreateFaqSectionQuestionDto? FaqQuestion { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyPrograms/HippotherapyProgramsFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyPrograms/HippotherapyProgramsFilterDto.cs
@@ -1,8 +1,11 @@
 using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+using VictoryCenter.BLL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 
-public record HippotherapyProgramsFilterDto : BaseFilterDto
+public record HippotherapyProgramsFilterDto : BaseFilterDto, ITranslationStatusFilterDto
 {
     public List<long>? CategoryId { get; init; }
+    public TranslationStatusFilter? TranslationStatusFilter { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/BaseHippotherapyProgramLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/BaseHippotherapyProgramLocalizationDto.cs
@@ -1,0 +1,13 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
+public record BaseHippotherapyProgramLocalizationDto
+{
+    public string? Name { get; init; }
+
+    public string? Description { get; init; }
+
+    public string? Location { get; init; }
+
+    public string? ParticipantsCount { get; init; }
+
+    public string? MeetingsCount { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/CreateHippotherapyProgramLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/CreateHippotherapyProgramLocalizationDto.cs
@@ -3,8 +3,7 @@ using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 
-public record CreateHippotherapyProgramLocalizationDto : UpdateHippotherapyProgramLocalizationDto,
-    ILocalizationIdentity
+public record CreateHippotherapyProgramLocalizationDto : BaseHippotherapyProgramLocalizationDto, ILocalizationIdentity
 {
     public long EntityId { get; init; }
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/HippotherapyProgramLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/HippotherapyProgramLocalizationDto.cs
@@ -12,7 +12,5 @@ public record HippotherapyProgramLocalizationDto : BaseHippotherapyProgramLocali
 
     public TranslationStatus TranslationStatus { get; init; }
 
-    public TranslationStatus TranslationStatus { get; init; }
-
     public List<HippotherapyProgramSectionLocalizationDto> Sections { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/HippotherapyProgramLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/HippotherapyProgramLocalizationDto.cs
@@ -1,23 +1,16 @@
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 
-public record HippotherapyProgramLocalizationDto
+public record HippotherapyProgramLocalizationDto : BaseHippotherapyProgramLocalizationDto
 {
     public long EntityId { get; init; }
 
     public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
 
-    public string Name { get; init; } = null!;
-
-    public string? Description { get; init; }
-
-    public string? Location { get; init; }
-
-    public string? ParticipantsCount { get; init; }
-
-    public string? MeetingsCount { get; init; }
+    public TranslationStatus TranslationStatus { get; init; }
 
     public List<HippotherapyProgramSectionLocalizationDto> Sections { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/UpdateHippotherapyProgramLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgram/UpdateHippotherapyProgramLocalizationDto.cs
@@ -1,14 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 
-public record UpdateHippotherapyProgramLocalizationDto
+public record UpdateHippotherapyProgramLocalizationDto : BaseHippotherapyProgramLocalizationDto
 {
-    public string? Name { get; init; }
-
-    public string? Description { get; init; }
-
-    public string? Location { get; init; }
-
-    public string? ParticipantsCount { get; init; }
-
-    public string? MeetingsCount { get; init; }
+    public List<UpdateHippotherapyProgramSectionLocalizationDto> Sections { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Common/BaseHippotherapyProgramSectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Common/BaseHippotherapyProgramSectionContentLocalizationDto.cs
@@ -1,6 +1,5 @@
-namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
-
-public record UpdateHippotherapyProgramSectionContentLocalizationDto
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+public record BaseHippotherapyProgramSectionContentLocalizationDto
 {
     public string? Title { get; init; }
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Common/BaseHippotherapyProgramSectionLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Common/BaseHippotherapyProgramSectionLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+public abstract class BaseHippotherapyProgramSectionLocalizationDto<TContent>
+    where TContent : BaseHippotherapyProgramSectionContentLocalizationDto
+{
+    public long EntityId { get; init; }
+    public List<TContent>? Contents { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/CreateHippotherapyProgramSectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/CreateHippotherapyProgramSectionContentLocalizationDto.cs
@@ -1,8 +1,9 @@
 using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 
-public record CreateHippotherapyProgramSectionContentLocalizationDto : UpdateHippotherapyProgramSectionContentLocalizationDto, ILocalizationIdentity
+public record CreateHippotherapyProgramSectionContentLocalizationDto : BaseHippotherapyProgramSectionContentLocalizationDto, ILocalizationIdentity
 {
     public long EntityId { get; init; }
     public long LanguageId { get; init; }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/CreateHippotherapyProgramSectionLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/CreateHippotherapyProgramSectionLocalizationDto.cs
@@ -1,8 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 
-public class CreateHippotherapyProgramSectionLocalizationDto
+public class CreateHippotherapyProgramSectionLocalizationDto : BaseHippotherapyProgramSectionLocalizationDto<CreateHippotherapyProgramSectionContentLocalizationDto>
 {
-    public long EntityId { get; init; }
-
-    public List<CreateHippotherapyProgramSectionContentLocalizationDto>? Contents { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionContentLocalizationDto.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+public record UpdateHippotherapyProgramSectionContentLocalizationDto : BaseHippotherapyProgramSectionContentLocalizationDto
+{
+    public int EntityId { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionContentLocalizationDto.cs
@@ -1,7 +1,8 @@
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+
 public record UpdateHippotherapyProgramSectionContentLocalizationDto : BaseHippotherapyProgramSectionContentLocalizationDto
 {
-    public int EntityId { get; set; }
+    public long EntityId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+public record UpdateHippotherapyProgramSectionLocalizationDto
+{
+    public long EntityId { get; set; }
+
+    public List<UpdateHippotherapyProgramSectionContentLocalizationDto>? Contents { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramSection/Update/UpdateHippotherapyProgramSectionLocalizationDto.cs
@@ -1,7 +1,6 @@
-namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
-public record UpdateHippotherapyProgramSectionLocalizationDto
-{
-    public long EntityId { get; set; }
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 
-    public List<UpdateHippotherapyProgramSectionContentLocalizationDto>? Contents { get; set; } = [];
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+public class UpdateHippotherapyProgramSectionLocalizationDto : BaseHippotherapyProgramSectionLocalizationDto<UpdateHippotherapyProgramSectionContentLocalizationDto>
+{
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
@@ -4,6 +4,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Enums;
+using HippotherapyProgramEntity = VictoryCenter.DAL.Entities.HippotherapyProgram;
 
 namespace VictoryCenter.BLL.Helpers;
 
@@ -12,78 +13,163 @@ public static class ProgramSectionContentLocalizationValidationHelper
     public static void ValidateSections<TSection, TContent>(
         IReadOnlyCollection<TSection> sections,
         IReadOnlyDictionary<long, ContentType> contentTypesById,
-        Func<TContent, long> getEntityId)
+        Func<TContent, long> getEntityId,
+        HippotherapyProgramEntity programEntity)
         where TSection : BaseHippotherapyProgramSectionLocalizationDto<TContent>
         where TContent : BaseHippotherapyProgramSectionContentLocalizationDto
     {
         ArgumentNullException.ThrowIfNull(getEntityId);
+        ArgumentNullException.ThrowIfNull(programEntity);
 
-        if (sections.Count == 0)
-        {
-            return;
-        }
-
-        var sectionContents = sections
-            .SelectMany(section => section.Contents ?? Enumerable.Empty<TContent>())
-            .ToList();
-
-        var validContents = new HashSet<ContentType>
+        var requiredContentTypes = new HashSet<ContentType>
         {
             ContentType.Title,
             ContentType.Description,
             ContentType.Author,
-            ContentType.Answer,
-            ContentType.Question
+            ContentType.Question,
+            ContentType.Answer
         };
-
-        var filteredContentTypes = contentTypesById
-            .Where(c => validContents.Contains(c.Value))
-            .ToDictionary(c => c.Key, c => c.Value);
-
-        if (sectionContents.Count != filteredContentTypes.Count)
-        {
-            throw new ValidationException(new List<ValidationFailure>
-            {
-                new(nameof(sections),
-                    $"Number of section contents ({sectionContents.Count}) does not match expected program contents ({filteredContentTypes.Count})")
-            });
-        }
 
         var failures = new List<ValidationFailure>();
 
+        var expectedSectionIds = programEntity.Sections
+            .Select(s => s.Id)
+            .ToHashSet();
+
+        var requestSectionIds = sections
+            .Select(s => s.EntityId)
+            .ToHashSet();
+
+        var missingSectionIds = expectedSectionIds.Except(requestSectionIds).ToList();
+        if (missingSectionIds.Count > 0)
+        {
+            throw new ValidationException(
+            [
+                new ValidationFailure(
+                    nameof(sections),
+                    $"Missing sections in localization request: {string.Join(", ", missingSectionIds)}.")
+            ]);
+        }
+
+        var extraSectionIds = requestSectionIds.Except(expectedSectionIds).ToList();
+        if (extraSectionIds.Count > 0)
+        {
+            throw new ValidationException(
+            [
+                new ValidationFailure(
+                    nameof(sections),
+                    $"Unknown sections in localization request: {string.Join(", ", extraSectionIds)}.")
+            ]);
+        }
+
+        var programSectionsById = programEntity.Sections
+            .ToDictionary(s => s.Id);
+
+        var contentSectionIdByContentId = programEntity.Sections
+            .SelectMany(section => section.Contents.Select(content => new
+            {
+                ContentId = content.Id,
+                SectionId = section.Id
+            }))
+            .ToDictionary(x => x.ContentId, x => x.SectionId);
+
         foreach (var section in sections)
         {
-            if (section.Contents is null)
+            if (!programSectionsById.TryGetValue(section.EntityId, out var programSection))
             {
                 continue;
             }
 
-            foreach (var content in section.Contents)
+            var expectedRequiredContents = programSection.Contents
+                .Where(c => requiredContentTypes.Contains(c.ContentType))
+                .ToList();
+
+            var expectedRequiredIds = expectedRequiredContents
+                .Select(c => c.Id)
+                .ToHashSet();
+
+            var expectedTypeByContentId = expectedRequiredContents
+                .ToDictionary(c => c.Id, c => c.ContentType);
+
+            var providedContents = section.Contents ?? [];
+            var providedIds = providedContents
+                .Select(getEntityId)
+                .ToList();
+
+            var duplicateIds = providedIds
+                .GroupBy(id => id)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToList();
+
+            if (duplicateIds.Count > 0)
+            {
+                throw new ValidationException(
+                [
+                    new ValidationFailure(
+                        nameof(sections),
+                        $"Section {section.EntityId} contains duplicate content ids: {string.Join(", ", duplicateIds)}.")
+                ]);
+            }
+
+            var providedIdSet = providedIds.ToHashSet();
+
+            var missingRequiredIds = expectedRequiredIds.Except(providedIdSet).ToList();
+            if (missingRequiredIds.Count > 0)
+            {
+                throw new ValidationException(
+                [
+                    new ValidationFailure(
+                        nameof(sections),
+                        $"Section {section.EntityId} is missing required content ids: {string.Join(", ", missingRequiredIds)}.")
+                ]);
+            }
+
+            if (providedIdSet.Count != expectedRequiredIds.Count)
+            {
+                throw new ValidationException(
+                [
+                    new ValidationFailure(
+                        nameof(sections),
+                        $"Section {section.EntityId} has {providedIdSet.Count} contents, expected {expectedRequiredIds.Count} required contents.")
+                ]);
+            }
+
+            foreach (var content in providedContents)
             {
                 var entityId = getEntityId(content);
 
-                if (!filteredContentTypes.TryGetValue(entityId, out var contentType))
+                if (!contentTypesById.TryGetValue(entityId, out var contentType))
                 {
-                    failures.Add(new ValidationFailure(
-                        "EntityId",
-                        ErrorMessagesConstants.NotFound(entityId, typeof(ProgramSectionContent))));
-                    continue;
+                    throw new ValidationException(
+                    [
+                        new ValidationFailure(
+                            "EntityId",
+                            ErrorMessagesConstants.NotFound(entityId, typeof(ProgramSectionContent)))
+                    ]);
                 }
 
-                ValidateContentLocalizationByType(content, contentType, failures);
-            }
-        }
+                if (!expectedTypeByContentId.TryGetValue(entityId, out var expectedType))
+                {
+                    if (contentType == ContentType.Image)
+                    {
+                        throw new ValidationException(
+                        [
+                            new ValidationFailure(
+                                "EntityId",
+                                $"Section {section.EntityId}: content {entityId} has type {ContentType.Image}, which is not required for localization.")
+                        ]);
+                    }
+                }
 
-        if (failures.Count > 0)
-        {
-            throw new ValidationException(failures);
+                ValidateContentLocalizationByType(content, expectedType);
+            }
         }
     }
 
     private static void ValidateContentLocalizationByType(
         BaseHippotherapyProgramSectionContentLocalizationDto content,
-        ContentType contentType,
-        List<ValidationFailure> failures)
+        ContentType contentType)
     {
         var hasTitle = HasValue(content.Title);
         var hasDescription = HasValue(content.Description);
@@ -94,68 +180,76 @@ public static class ProgramSectionContentLocalizationValidationHelper
         switch (contentType)
         {
             case ContentType.Title:
-                RequireField(failures, nameof(content.Title), hasTitle);
-                ForbidField(failures, nameof(content.Description), hasDescription, contentType);
-                ForbidField(failures, nameof(content.Author), hasAuthor, contentType);
-                ForbidField(failures, nameof(content.Question), hasQuestion, contentType);
-                ForbidField(failures, nameof(content.Answer), hasAnswer, contentType);
+                RequireField(nameof(content.Title), hasTitle);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ForbidField(nameof(content.Author), hasAuthor, contentType);
+                ForbidField(nameof(content.Question), hasQuestion, contentType);
+                ForbidField(nameof(content.Answer), hasAnswer, contentType);
                 break;
             case ContentType.Description:
-                RequireField(failures, nameof(content.Description), hasDescription);
-                ForbidField(failures, nameof(content.Title), hasTitle, contentType);
-                ForbidField(failures, nameof(content.Author), hasAuthor, contentType);
-                ForbidField(failures, nameof(content.Question), hasQuestion, contentType);
-                ForbidField(failures, nameof(content.Answer), hasAnswer, contentType);
+                RequireField(nameof(content.Description), hasDescription);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ForbidField(nameof(content.Author), hasAuthor, contentType);
+                ForbidField(nameof(content.Question), hasQuestion, contentType);
+                ForbidField(nameof(content.Answer), hasAnswer, contentType);
                 break;
             case ContentType.Author:
-                RequireField(failures, nameof(content.Author), hasAuthor);
-                ForbidField(failures, nameof(content.Title), hasTitle, contentType);
-                ForbidField(failures, nameof(content.Description), hasDescription, contentType);
-                ForbidField(failures, nameof(content.Question), hasQuestion, contentType);
-                ForbidField(failures, nameof(content.Answer), hasAnswer, contentType);
+                RequireField(nameof(content.Author), hasAuthor);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ForbidField(nameof(content.Question), hasQuestion, contentType);
+                ForbidField(nameof(content.Answer), hasAnswer, contentType);
                 break;
             case ContentType.Question:
-                RequireField(failures, nameof(content.Question), hasQuestion);
-                ForbidField(failures, nameof(content.Title), hasTitle, contentType);
-                ForbidField(failures, nameof(content.Description), hasDescription, contentType);
-                ForbidField(failures, nameof(content.Author), hasAuthor, contentType);
-                ForbidField(failures, nameof(content.Answer), hasAnswer, contentType);
+                RequireField(nameof(content.Question), hasQuestion);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ForbidField(nameof(content.Author), hasAuthor, contentType);
+                ForbidField(nameof(content.Answer), hasAnswer, contentType);
                 break;
             case ContentType.Answer:
-                RequireField(failures, nameof(content.Answer), hasAnswer);
-                ForbidField(failures, nameof(content.Title), hasTitle, contentType);
-                ForbidField(failures, nameof(content.Description), hasDescription, contentType);
-                ForbidField(failures, nameof(content.Author), hasAuthor, contentType);
-                ForbidField(failures, nameof(content.Question), hasQuestion, contentType);
+                RequireField(nameof(content.Answer), hasAnswer);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ForbidField(nameof(content.Author), hasAuthor, contentType);
+                ForbidField(nameof(content.Question), hasQuestion, contentType);
                 break;
             case ContentType.Image:
-                ForbidField(failures, nameof(content.Title), hasTitle, contentType);
-                ForbidField(failures, nameof(content.Description), hasDescription, contentType);
-                ForbidField(failures, nameof(content.Author), hasAuthor, contentType);
-                ForbidField(failures, nameof(content.Question), hasQuestion, contentType);
-                ForbidField(failures, nameof(content.Answer), hasAnswer, contentType);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ForbidField(nameof(content.Author), hasAuthor, contentType);
+                ForbidField(nameof(content.Question), hasQuestion, contentType);
+                ForbidField(nameof(content.Answer), hasAnswer, contentType);
                 break;
             default:
-                failures.Add(new ValidationFailure(
-                    nameof(contentType),
-                    ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(contentType))));
-                break;
+                throw new ValidationException(
+                [
+                    new ValidationFailure(
+                        nameof(contentType),
+                        ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(contentType)))
+                ]);
         }
     }
 
-    private static void RequireField(List<ValidationFailure> failures, string fieldName, bool hasValue)
+    private static void RequireField(string fieldName, bool hasValue)
     {
         if (!hasValue)
         {
-            failures.Add(new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyIsRequired(fieldName)));
+            throw new ValidationException(
+            [
+                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyIsRequired(fieldName))
+            ]);
         }
     }
 
-    private static void ForbidField(List<ValidationFailure> failures, string fieldName, bool hasValue, ContentType contentType)
+    private static void ForbidField(string fieldName, bool hasValue, ContentType contentType)
     {
         if (hasValue)
         {
-            failures.Add(new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyNotAllowedForContentType(fieldName, contentType)));
+            throw new ValidationException(
+            [
+                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyNotAllowedForContentType(fieldName, contentType))
+            ]);
         }
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using FluentValidation.Results;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Enums;
 
@@ -74,7 +75,7 @@ public static class ProgramSectionContentLocalizationValidationHelper
     }
 
     private static void ValidateContentLocalizationByType(
-        UpdateHippotherapyProgramSectionContentLocalizationDto content,
+        BaseHippotherapyProgramSectionContentLocalizationDto content,
         ContentType contentType,
         List<ValidationFailure> failures)
     {

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
@@ -200,11 +200,11 @@ public static class ProgramSectionContentLocalizationValidationHelper
                 ForbidField(nameof(content.Answer), hasAnswer, contentType);
                 break;
             case ContentType.FaqQuestion:
-                RequireField(failures, nameof(content.Question), hasQuestion);
-                RequireField(failures, nameof(content.Answer), hasAnswer);
-                ForbidField(failures, nameof(content.Title), hasTitle, contentType);
-                ForbidField(failures, nameof(content.Description), hasDescription, contentType);
-                ForbidField(failures, nameof(content.Author), hasAuthor, contentType);
+                RequireField(nameof(content.Question), hasQuestion);
+                RequireField(nameof(content.Answer), hasAnswer);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ForbidField(nameof(content.Author), hasAuthor, contentType);
                 break;
             case ContentType.Image:
                 ForbidField(nameof(content.Title), hasTitle, contentType);

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
@@ -1,7 +1,6 @@
 using FluentValidation;
 using FluentValidation.Results;
 using VictoryCenter.BLL.Constants;
-using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Enums;
@@ -10,17 +9,22 @@ namespace VictoryCenter.BLL.Helpers;
 
 public static class ProgramSectionContentLocalizationValidationHelper
 {
-    public static void ValidateSections(
-        IReadOnlyCollection<CreateHippotherapyProgramSectionLocalizationDto> sections,
-        IReadOnlyDictionary<long, ContentType> contentTypesById)
+    public static void ValidateSections<TSection, TContent>(
+        IReadOnlyCollection<TSection> sections,
+        IReadOnlyDictionary<long, ContentType> contentTypesById,
+        Func<TContent, long> getEntityId)
+        where TSection : BaseHippotherapyProgramSectionLocalizationDto<TContent>
+        where TContent : BaseHippotherapyProgramSectionContentLocalizationDto
     {
+        ArgumentNullException.ThrowIfNull(getEntityId);
+
         if (sections.Count == 0)
         {
             return;
         }
 
         var sectionContents = sections
-            .SelectMany(section => section.Contents ?? Enumerable.Empty<CreateHippotherapyProgramSectionContentLocalizationDto>())
+            .SelectMany(section => section.Contents ?? Enumerable.Empty<TContent>())
             .ToList();
 
         var validContents = new HashSet<ContentType>
@@ -41,7 +45,7 @@ public static class ProgramSectionContentLocalizationValidationHelper
             throw new ValidationException(new List<ValidationFailure>
             {
                 new(nameof(sections),
-                    $"Number of section contents ({sectionContents.Count}) does not match expected program contents ({contentTypesById.Count})")
+                    $"Number of section contents ({sectionContents.Count}) does not match expected program contents ({filteredContentTypes.Count})")
             });
         }
 
@@ -56,11 +60,13 @@ public static class ProgramSectionContentLocalizationValidationHelper
 
             foreach (var content in section.Contents)
             {
-                if (!filteredContentTypes.TryGetValue(content.EntityId, out var contentType))
+                var entityId = getEntityId(content);
+
+                if (!filteredContentTypes.TryGetValue(entityId, out var contentType))
                 {
                     failures.Add(new ValidationFailure(
-                        nameof(content.EntityId),
-                        ErrorMessagesConstants.NotFound(content.EntityId, typeof(ProgramSectionContent))));
+                        "EntityId",
+                        ErrorMessagesConstants.NotFound(entityId, typeof(ProgramSectionContent))));
                     continue;
                 }
 

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/HippotherapyPrograms/IProgramSectionContentService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/HippotherapyPrograms/IProgramSectionContentService.cs
@@ -1,3 +1,4 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
@@ -5,4 +6,6 @@ namespace VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
 public interface IProgramSectionContentService
 {
     Task<Dictionary<long, ContentType>> GetContentTypesByProgramIdAsync(long programId);
+
+    Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSectionsAsync(long programId, long languageId);
 }

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/Localization/ILocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/Localization/ILocalizationService.cs
@@ -12,7 +12,7 @@ public interface ILocalizationService<TEntity, TEntityLocalization>
     Task<TEntityLocalization> UpdateEntityLocalizationAsync(TEntityLocalization entityLocalization);
     Task<(long entityId, long languageId)> DeleteEntityLocalizationAsync(long entityId, long languageId);
     Task<TEntityLocalization> TrackEntityLocalizationAsync(TEntityLocalization entityLocalization);
-    Task TrackEntityLocalizationAsync(IEnumerable<TEntityLocalization> entityLocalization);
+    Task TrackEntityLocalizationAsync(IEnumerable<TEntityLocalization> entityLocalization, bool isUpdate);
 
     Task TrackEntityLocalizationForUpdateAsync(TEntityLocalization entityLocalization);
     Task TrackEntityLocalizationForUpdateAsync(IEnumerable<TEntityLocalization> entityLocalizations);

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/Localization/ILocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/Localization/ILocalizationService.cs
@@ -15,5 +15,4 @@ public interface ILocalizationService<TEntity, TEntityLocalization>
     Task TrackEntityLocalizationAsync(IEnumerable<TEntityLocalization> entityLocalization, bool isUpdate);
 
     Task TrackEntityLocalizationForUpdateAsync(TEntityLocalization entityLocalization);
-    Task TrackEntityLocalizationForUpdateAsync(IEnumerable<TEntityLocalization> entityLocalizations);
 }

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/Localization/ILocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/Localization/ILocalizationService.cs
@@ -13,4 +13,7 @@ public interface ILocalizationService<TEntity, TEntityLocalization>
     Task<(long entityId, long languageId)> DeleteEntityLocalizationAsync(long entityId, long languageId);
     Task<TEntityLocalization> TrackEntityLocalizationAsync(TEntityLocalization entityLocalization);
     Task TrackEntityLocalizationAsync(IEnumerable<TEntityLocalization> entityLocalization);
+
+    Task TrackEntityLocalizationForUpdateAsync(TEntityLocalization entityLocalization);
+    Task TrackEntityLocalizationForUpdateAsync(IEnumerable<TEntityLocalization> entityLocalizations);
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/HippotherapyProgramSections/ProgramSectionContentLocalizationsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/HippotherapyProgramSections/ProgramSectionContentLocalizationsProfile.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 
@@ -13,7 +14,8 @@ public class ProgramSectionContentLocalizationsProfile : Profile
             .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
 
         CreateMap<UpdateHippotherapyProgramSectionContentLocalizationDto, ProgramSectionContentLocalization>()
-            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant))
+            .ForMember(dest => dest.EntityId, opt => opt.Ignore());
 
         CreateMap<ProgramSectionContentLocalization, HippotherapyProgramSectionContentLocalizationDto>()
             .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/HippotherapyPrograms/HippotherapyProgramLocalizationsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/HippotherapyPrograms/HippotherapyProgramLocalizationsProfile.cs
@@ -15,7 +15,7 @@ public class HippotherapyProgramLocalizationsProfile : Profile
             .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
 
         CreateMap<UpdateHippotherapyProgramLocalizationDto, HippotherapyProgramLocalization>()
-            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
 
         CreateMap<HippotherapyProgramLocalization, HippotherapyProgramLocalizationDto>()
             .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyPrograms/GetByFilters/GetHippotherapyProgramsByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyPrograms/GetByFilters/GetHippotherapyProgramsByFiltersHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Enums;
 using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
@@ -27,12 +28,20 @@ public class GetHippotherapyProgramsByFiltersHandler : IRequestHandler<GetHippot
 
     public async Task<Result<PaginationResult<HippotherapyProgramDto>>> Handle(GetHippotherapyProgramsByFiltersQuery request, CancellationToken cancellationToken)
     {
+        var languageCount = await _repositoryWrapper.LocalizationLanguagesRepository.CountAsync();
         Status? status = request.RequestDto?.Status;
         List<long>? programCategories = request.RequestDto?.CategoryId;
+        var translationStatusFilter = request.RequestDto?.TranslationStatusFilter;
         Expression<Func<HippotherapyProgram, bool>> filter =
             t => (status == null || t.Status == status) &&
                  (programCategories == null || programCategories.Count == 0 ||
-                  t.Categories.Any(c => programCategories.Contains(c.Id)));
+                  t.Categories.Any(c => programCategories.Contains(c.Id))) &&
+            (translationStatusFilter == null ||
+            translationStatusFilter == TranslationStatusFilter.All ||
+            (translationStatusFilter == TranslationStatusFilter.Outdated &&
+            t.Localizations.Any(l => l.TranslationStatus == TranslationStatus.Outdated)) ||
+            (translationStatusFilter == TranslationStatusFilter.Missing &&
+            t.Localizations.Count < languageCount));
 
         var queryOptions = new QueryOptions<HippotherapyProgram>
         {

--- a/VictoryCenter/VictoryCenter.BLL/Services/HippotherapyPrograms/ProgramSectionContentService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/HippotherapyPrograms/ProgramSectionContentService.cs
@@ -1,7 +1,10 @@
+using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -11,10 +14,12 @@ namespace VictoryCenter.BLL.Services.HippotherapyPrograms;
 public class ProgramSectionContentService : IProgramSectionContentService
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
 
-    public ProgramSectionContentService(IRepositoryWrapper repositoryWrapper)
+    public ProgramSectionContentService(IRepositoryWrapper repositoryWrapper, IMapper mapper)
     {
         _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
     }
 
     public async Task<Dictionary<long, ContentType>> GetContentTypesByProgramIdAsync(long programId)
@@ -36,5 +41,43 @@ public class ProgramSectionContentService : IProgramSectionContentService
         return program.Sections
             .SelectMany(section => section.Contents)
             .ToDictionary(content => content.Id, content => content.ContentType);
+    }
+
+    public async Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSectionsAsync(long programId, long languageId)
+    {
+        var program = await _repositoryWrapper.HippotherapyProgramsLocalizationsRepository
+            .GetFirstOrDefaultAsync(
+                new QueryOptions<HippotherapyProgramLocalization>
+                {
+                    Filter = entity => programId == entity.EntityId
+                                       && languageId == entity.LanguageId,
+                    Include = query => query.Include(entity => entity.Entity)
+                        .ThenInclude(entity => entity.Sections)
+                        .ThenInclude(section => section.Contents)
+                        .ThenInclude(content => content.Localizations)
+                        .ThenInclude(localization => localization.Language),
+                });
+
+        if (program is null)
+        {
+            throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(programId, typeof(HippotherapyProgram)));
+        }
+
+        var sectionLocalizations = program.Entity
+            .Sections
+            .Select(section => new HippotherapyProgramSectionLocalizationDto
+            {
+                EntityId = section.Id,
+                Contents = section.Contents
+                    .SelectMany(content =>
+                        content.Localizations
+                            .Where(localization => localization.LanguageId == languageId)
+                            .Select(localization =>
+                                _mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization)))
+                    .ToList(),
+            })
+            .ToList();
+
+        return sectionLocalizations;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -164,6 +164,74 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
         throw new InvalidOperationException();
     }
 
+    public async Task TrackEntityLocalizationForUpdateAsync(TEntityLocalization entityLocalization)
+    {
+        var existingLocalization = await _repositoryWrapper.GetRepository<TEntityLocalization>()
+            .GetFirstOrDefaultAsync(new QueryOptions<TEntityLocalization>
+            {
+                Filter = localization => localization.EntityId == entityLocalization.EntityId
+                                     && localization.LanguageId == entityLocalization.LanguageId
+            });
+
+        if (existingLocalization is null)
+        {
+            throw new KeyNotFoundException(
+                ErrorMessagesConstants.NotFound((entityLocalization.EntityId, entityLocalization.LanguageId), typeof(TEntityLocalization)));
+        }
+
+        entityLocalization.TranslationStatus = TranslationStatus.Relevant;
+
+        _repositoryWrapper.GetRepository<TEntityLocalization>().Update(entityLocalization);
+    }
+
+    public async Task TrackEntityLocalizationForUpdateAsync(IEnumerable<TEntityLocalization> entityLocalizations)
+    {
+        var localizations = entityLocalizations.ToList();
+
+        if (localizations.Count == 0)
+        {
+            return;
+        }
+
+        if (localizations.Select(x => x.LanguageId).Distinct().Count() != 1)
+        {
+            throw new ValidationException("Bulk localization update supports only one LanguageId.");
+        }
+
+        var languageId = localizations.First().LanguageId;
+        var entityIds = localizations
+            .Select(x => x.EntityId)
+            .Distinct()
+            .ToList();
+
+        var existingLocalizations = (await _repositoryWrapper.GetRepository<TEntityLocalization>()
+            .GetAllAsync(new QueryOptions<TEntityLocalization>
+            {
+                Filter = localization => localization.LanguageId == languageId
+                                     && entityIds.Contains(localization.EntityId)
+            }))
+            .ToList();
+
+        var existingIds = existingLocalizations
+            .Select(x => x.EntityId)
+            .ToHashSet();
+
+        var missingId = entityIds.FirstOrDefault(id => !existingIds.Contains(id));
+
+        if (missingId != 0)
+        {
+            throw new KeyNotFoundException(
+                ErrorMessagesConstants.NotFound((missingId, languageId), typeof(TEntityLocalization)));
+        }
+
+        foreach (var localization in localizations)
+        {
+            localization.TranslationStatus = TranslationStatus.Relevant;
+        }
+
+        _repositoryWrapper.GetRepository<TEntityLocalization>().UpdateRange(localizations);
+    }
+
     private async Task<TEntityLocalization> ValidateAndTrackAsync(TEntityLocalization entityLocalization)
     {
         var entity = await _repositoryWrapper.GetRepository<TEntity>()

--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -120,14 +120,14 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
             throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(languageId, typeof(LocalizationLanguage)));
         }
 
-        if(isUpdate is false)
+        if(!isUpdate)
         {
             await _repositoryWrapper.GetRepository<TEntityLocalization>()
                 .CreateRangeAsync(entityLocalizations);
         }
         else
         {
-            _repositoryWrapper.GetRepository<TEntityLocalization>().UpdateRange(localizations);
+            _repositoryWrapper.GetRepository<TEntityLocalization>().UpdateRange(entityLocalizations);
         }
     }
 
@@ -189,54 +189,6 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
         entityLocalization.TranslationStatus = TranslationStatus.Relevant;
 
         _repositoryWrapper.GetRepository<TEntityLocalization>().Update(entityLocalization);
-    }
-
-    public async Task TrackEntityLocalizationForUpdateAsync(IEnumerable<TEntityLocalization> entityLocalizations)
-    {
-        var localizations = entityLocalizations.ToList();
-
-        if (localizations.Count == 0)
-        {
-            return;
-        }
-
-        if (localizations.Select(x => x.LanguageId).Distinct().Count() != 1)
-        {
-            throw new ValidationException("Bulk localization update supports only one LanguageId.");
-        }
-
-        var languageId = localizations.First().LanguageId;
-        var entityIds = localizations
-            .Select(x => x.EntityId)
-            .Distinct()
-            .ToList();
-
-        var existingLocalizations = (await _repositoryWrapper.GetRepository<TEntityLocalization>()
-            .GetAllAsync(new QueryOptions<TEntityLocalization>
-            {
-                Filter = localization => localization.LanguageId == languageId
-                                     && entityIds.Contains(localization.EntityId)
-            }))
-            .ToList();
-
-        var existingIds = existingLocalizations
-            .Select(x => x.EntityId)
-            .ToHashSet();
-
-        var missingId = entityIds.FirstOrDefault(id => !existingIds.Contains(id));
-
-        if (missingId != 0)
-        {
-            throw new KeyNotFoundException(
-                ErrorMessagesConstants.NotFound((missingId, languageId), typeof(TEntityLocalization)));
-        }
-
-        foreach (var localization in localizations)
-        {
-            localization.TranslationStatus = TranslationStatus.Relevant;
-        }
-
-        _repositoryWrapper.GetRepository<TEntityLocalization>().UpdateRange(localizations);
     }
 
     private async Task<TEntityLocalization> ValidateAndTrackAsync(TEntityLocalization entityLocalization)

--- a/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/Localization/LocalizationService.cs
@@ -77,7 +77,7 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
         return createdEntity;
     }
 
-    public async Task TrackEntityLocalizationAsync(IEnumerable<TEntityLocalization> localizations)
+    public async Task TrackEntityLocalizationAsync(IEnumerable<TEntityLocalization> localizations, bool isUpdate)
     {
         var entityLocalizations = localizations.ToList();
         var entityIds = entityLocalizations
@@ -120,8 +120,15 @@ public class LocalizationService<TEntity, TEntityLocalization> : ILocalizationSe
             throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(languageId, typeof(LocalizationLanguage)));
         }
 
-        await _repositoryWrapper.GetRepository<TEntityLocalization>()
-            .CreateRangeAsync(entityLocalizations);
+        if(isUpdate is false)
+        {
+            await _repositoryWrapper.GetRepository<TEntityLocalization>()
+                .CreateRangeAsync(entityLocalizations);
+        }
+        else
+        {
+            _repositoryWrapper.GetRepository<TEntityLocalization>().UpdateRange(localizations);
+        }
     }
 
     public async Task<TEntityLocalization> UpdateEntityLocalizationAsync(TEntityLocalization entityLocalization)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidator.cs
@@ -201,7 +201,7 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
 
         if (newFaqQuestions.Any(c => string.IsNullOrWhiteSpace(c.FaqQuestion!.QuestionText)))
         {
-            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqQuestionDto.QuestionText)));
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqSectionQuestionDto.QuestionText)));
         }
 
         if (newFaqQuestions.Any(c => !HasValidLength(c.FaqQuestion!.QuestionText, req.QuestionTextLength)))
@@ -211,7 +211,7 @@ public class BaseHippotherapyProgramSectionValidator : AbstractValidator<CreateH
 
         if (newFaqQuestions.Any(c => string.IsNullOrWhiteSpace(c.FaqQuestion!.AnswerText)))
         {
-            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqQuestionDto.AnswerText)));
+            ctx.AddFailure(prop, ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqSectionQuestionDto.AnswerText)));
         }
 
         if (newFaqQuestions.Any(c => !HasValidLength(c.FaqQuestion!.AnswerText, req.AnswerTextLength)))

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/BaseProgramSectionContentLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/BaseProgramSectionContentLocalizationValidator.cs
@@ -1,66 +1,66 @@
 using FluentValidation;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Constants.Localization;
-using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 
 namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
 
-public class BaseProgramSectionContentLocalizationValidator : AbstractValidator<UpdateHippotherapyProgramSectionContentLocalizationDto>
+public class BaseProgramSectionContentLocalizationValidator : AbstractValidator<BaseHippotherapyProgramSectionContentLocalizationDto>
 {
     public BaseProgramSectionContentLocalizationValidator()
     {
         RuleFor(x => x.Title)
             .MinimumLength(ProgramSectionContentLocalizationConstants.TitleMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Title),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
                 ProgramSectionContentLocalizationConstants.TitleMinLength))
             .MaximumLength(ProgramSectionContentLocalizationConstants.TitleMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Title),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
                 ProgramSectionContentLocalizationConstants.TitleMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Title));
 
         RuleFor(x => x.Description)
             .MinimumLength(ProgramSectionContentLocalizationConstants.DescriptionMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Description),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Description),
                 ProgramSectionContentLocalizationConstants.DescriptionMinLength))
             .MaximumLength(ProgramSectionContentLocalizationConstants.DescriptionMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Description),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Description),
                 ProgramSectionContentLocalizationConstants.DescriptionMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Description));
 
         RuleFor(x => x.Author)
             .MinimumLength(ProgramSectionContentLocalizationConstants.AuthorMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Author),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Author),
                 ProgramSectionContentLocalizationConstants.AuthorMinLength))
             .MaximumLength(ProgramSectionContentLocalizationConstants.AuthorMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Author),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Author),
                 ProgramSectionContentLocalizationConstants.AuthorMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Author));
 
         RuleFor(x => x.Question)
             .MinimumLength(ProgramSectionContentLocalizationConstants.QuestionMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Question),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Question),
                 ProgramSectionContentLocalizationConstants.QuestionMinLength))
             .MaximumLength(ProgramSectionContentLocalizationConstants.QuestionMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Question),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Question),
                 ProgramSectionContentLocalizationConstants.QuestionMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Question));
 
         RuleFor(x => x.Answer)
             .MinimumLength(ProgramSectionContentLocalizationConstants.AnswerMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Answer),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Answer),
                 ProgramSectionContentLocalizationConstants.AnswerMinLength))
             .MaximumLength(ProgramSectionContentLocalizationConstants.AnswerMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateHippotherapyProgramSectionContentLocalizationDto.Answer),
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Answer),
                 ProgramSectionContentLocalizationConstants.AnswerMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Answer));
     }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/CreateHippotherapyProgramSectionContentLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/CreateHippotherapyProgramSectionContentLocalizationValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 
 namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
 
@@ -7,7 +8,7 @@ public class CreateHippotherapyProgramSectionContentLocalizationValidator : Abst
 {
     public CreateHippotherapyProgramSectionContentLocalizationValidator(BaseProgramSectionContentLocalizationValidator baseProgramSectionContentLocalizationValidator)
     {
-        RuleFor(x => (UpdateHippotherapyProgramSectionContentLocalizationDto)x)
+        RuleFor(x => (BaseHippotherapyProgramSectionContentLocalizationDto)x)
             .SetValidator(baseProgramSectionContentLocalizationValidator);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/UpdateHippotherapyProgramSectionContentLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/UpdateHippotherapyProgramSectionContentLocalizationValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
+public class UpdateHippotherapyProgramSectionContentLocalizationValidator : AbstractValidator<UpdateHippotherapyProgramSectionContentLocalizationDto>
+{
+    public UpdateHippotherapyProgramSectionContentLocalizationValidator(BaseProgramSectionContentLocalizationValidator baseProgramSectionContentLocalizationValidator)
+    {
+        RuleFor(x => x.EntityId)
+            .GreaterThan(0).WithMessage("EntityId must be greater than 0.");
+        RuleFor(x => (BaseHippotherapyProgramSectionContentLocalizationDto)x)
+            .SetValidator(baseProgramSectionContentLocalizationValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/UpdateHippotherapyProgramSectionLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramSection/UpdateHippotherapyProgramSectionLocalizationValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
+public class UpdateHippotherapyProgramSectionLocalizationValidator : AbstractValidator<UpdateHippotherapyProgramSectionLocalizationDto>
+{
+    public UpdateHippotherapyProgramSectionLocalizationValidator(
+        UpdateHippotherapyProgramSectionContentLocalizationValidator updateContentValidator)
+    {
+        RuleFor(x => x.EntityId)
+            .GreaterThan(0).WithMessage("EntityId must be greater than 0.");
+        RuleForEach(x => x.Contents)
+            .SetValidator(updateContentValidator)
+            .When(x => x.Contents != null);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyPrograms/BaseHippotherapyProgramLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyPrograms/BaseHippotherapyProgramLocalizationValidator.cs
@@ -5,7 +5,7 @@ using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 
 namespace VictoryCenter.BLL.Validators.Localization.HippotherapyPrograms;
 
-public class BaseHippotherapyProgramLocalizationValidator : AbstractValidator<UpdateHippotherapyProgramLocalizationDto>
+public class BaseHippotherapyProgramLocalizationValidator : AbstractValidator<BaseHippotherapyProgramLocalizationDto>
 {
     public BaseHippotherapyProgramLocalizationValidator()
     {

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
+
+namespace VictoryCenter.BLL.Validators.Localization.HippotherapyPrograms;
+public class UpdateHippotherapyProgramLocalizationValidator : AbstractValidator<UpdateHippotherapyProgramLocalizationCommand>
+{
+    public UpdateHippotherapyProgramLocalizationValidator(
+        BaseHippotherapyProgramLocalizationValidator baseHippotherapyProgramLocalizationValidator,
+        UpdateHippotherapyProgramSectionLocalizationValidator updateHippotherapyProgramSectionLocalizationValidator)
+    {
+        RuleFor(c => c.UpdateHippotherapyProgramLocalizationDto).SetValidator(baseHippotherapyProgramLocalizationValidator);
+
+        RuleForEach(x => x.UpdateHippotherapyProgramLocalizationDto.Sections)
+            .SetValidator(updateHippotherapyProgramSectionLocalizationValidator)
+            .When(x => x.UpdateHippotherapyProgramLocalizationDto.Sections != null);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HippotherapyProgramSectionsBuilderTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HippotherapyProgramSectionsBuilderTests.cs
@@ -268,7 +268,7 @@ public class HippotherapyProgramSectionsBuilderTests
                 ContentType = ContentType.FaqQuestion,
                 Order = 1,
                 GroupIndex = 2,
-                FaqQuestion = new CreateFaqQuestionDto { QuestionText = "Question?", AnswerText = "Answer." }
+                FaqQuestion = new CreateFaqSectionQuestionDto { QuestionText = "Question?", AnswerText = "Answer." }
             });
 
         var result = Build([dto]);
@@ -346,7 +346,7 @@ public class HippotherapyProgramSectionsBuilderTests
         {
             ContentType = ContentType.FaqQuestion,
             Order = order,
-            FaqQuestion = new CreateFaqQuestionDto { QuestionText = questionText, AnswerText = answerText }
+            FaqQuestion = new CreateFaqSectionQuestionDto { QuestionText = questionText, AnswerText = answerText }
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ProgramSectionContentLocalizationValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ProgramSectionContentLocalizationValidationHelperTests.cs
@@ -303,8 +303,7 @@ public class ProgramSectionContentLocalizationValidationHelperTests
                     new() { EntityId = 10, Title = "Title" },
                     new() { EntityId = 11, Description = "Description" },
                     new() { EntityId = 12, Author = "Author" },
-                    new() { EntityId = 13, Question = "Question?" },
-                    new() { EntityId = 14, Answer = "Answer." }
+                    new() { EntityId = 13, Question = "Question?", Answer = "Answer." }
                 ]
             }
         };
@@ -314,9 +313,8 @@ public class ProgramSectionContentLocalizationValidationHelperTests
             { 10, ContentType.Title },
             { 11, ContentType.Description },
             { 12, ContentType.Author },
-            { 13, ContentType.Question },
-            { 14, ContentType.Answer },
-            { 15, ContentType.Image }
+            { 13, ContentType.FaqQuestion },
+            { 14, ContentType.Image }
         };
 
         var program = CreateProgram(
@@ -325,9 +323,8 @@ public class ProgramSectionContentLocalizationValidationHelperTests
                 (10, ContentType.Title),
                 (11, ContentType.Description),
                 (12, ContentType.Author),
-                (13, ContentType.Question),
-                (14, ContentType.Answer),
-                (15, ContentType.Image)));
+                (13, ContentType.FaqQuestion),
+                (14, ContentType.Image)));
 
         ProgramSectionContentLocalizationValidationHelper.ValidateSections<
             CreateHippotherapyProgramSectionLocalizationDto,

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ProgramSectionContentLocalizationValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ProgramSectionContentLocalizationValidationHelperTests.cs
@@ -2,207 +2,371 @@ using FluentValidation;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Enums;
+using HippotherapyProgramEntity = VictoryCenter.DAL.Entities.HippotherapyProgram;
 
 namespace VictoryCenter.UnitTests.HelperTests;
 
 public class ProgramSectionContentLocalizationValidationHelperTests
 {
     [Fact]
-    public void ValidateSections_NoSections_DoesNotThrow()
+    public void ValidateSections_NoSectionsAndNoProgramSections_DoesNotThrow()
     {
-        ProgramSectionContentLocalizationValidationHelper.ValidateSections(
-            new List<CreateHippotherapyProgramSectionLocalizationDto>(),
-            new Dictionary<long, ContentType>());
+        var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>();
+        var contentTypesById = new Dictionary<long, ContentType>();
+        var program = CreateProgram();
+
+        ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+            sections,
+            contentTypesById,
+            content => content.EntityId,
+            program);
     }
 
     [Fact]
-    public void ValidateSections_CountMismatch_ThrowsValidationException()
+    public void ValidateSections_MissingSectionInRequest_ThrowsValidationException()
+    {
+        var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>();
+        var contentTypesById = new Dictionary<long, ContentType>();
+        var program = CreateProgram(CreateSection(1));
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains("Missing sections in localization request", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateSections_UnknownSectionInRequest_ThrowsValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 1, Title = "A" }
-                }
+                EntityId = 99,
+                Contents = []
             }
         };
 
-        var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, new Dictionary<long, ContentType>()));
+        var contentTypesById = new Dictionary<long, ContentType>();
+        var program = CreateProgram(CreateSection(1));
 
-        Assert.Contains("Number of section contents", ex.Message);
+        var ex = Assert.Throws<ValidationException>(() =>
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains("Missing sections in localization request", ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_InvalidContentId_AddsNotFoundFailure()
+    public void ValidateSections_DuplicateContentIds_ThrowsValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 5, Title = "some" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 10, Title = "A" },
+                    new() { EntityId = 10, Title = "B" }
+                ]
             }
         };
 
-        var dict = new Dictionary<long, ContentType>
+        var contentTypesById = new Dictionary<long, ContentType>
         {
-            { 1, ContentType.Title }
+            { 10, ContentType.Title }
         };
 
-        var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
+        var program = CreateProgram(CreateSection(1, (10, ContentType.Title)));
 
-        Assert.Contains(ErrorMessagesConstants.NotFound(5, typeof(object)).Split(' ')[0], ex.Message);
+        var ex = Assert.Throws<ValidationException>(() =>
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains("duplicate content ids", ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_TitleRequired_WhenMissing_ShouldThrow()
+    public void ValidateSections_MissingRequiredContentIds_ThrowsValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 1, Title = "" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 10, Title = "A" }
+                ]
             }
         };
 
-        var dict = new Dictionary<long, ContentType>
+        var contentTypesById = new Dictionary<long, ContentType>
         {
-            { 1, ContentType.Title }
+            { 10, ContentType.Title },
+            { 11, ContentType.Description }
         };
 
-        var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
+        var program = CreateProgram(CreateSection(1, (10, ContentType.Title), (11, ContentType.Description)));
 
-        Assert.Contains("Title is required", ex.Message);
+        var ex = Assert.Throws<ValidationException>(() =>
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains("missing required content ids", ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_ForbiddenField_ThrowsForbidMessage()
+    public void ValidateSections_ContentCountMismatch_ThrowsValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 1, Title = "Good", Description = "oops" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 10, Title = "A" },
+                    new() { EntityId = 12, Description = "img payload" }
+                ]
             }
         };
 
-        var dict = new Dictionary<long, ContentType>
+        var contentTypesById = new Dictionary<long, ContentType>
         {
-            { 1, ContentType.Title }
+            { 10, ContentType.Title },
+            { 12, ContentType.Image }
         };
 
-        var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
+        var program = CreateProgram(CreateSection(1, (10, ContentType.Title), (12, ContentType.Image)));
 
-        Assert.Contains("Description is not allowed for content type Title", ex.Message);
+        var ex = Assert.Throws<ValidationException>(() =>
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains("expected 1 required contents", ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_DescriptionType_RequireDescriptionAndForbidOthers()
+    public void ValidateSections_InvalidContentId_ThrowsNotFoundValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 2, Title = "x" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 10, Title = "A" }
+                ]
             }
         };
-        var dict = new Dictionary<long, ContentType> { { 2, ContentType.Description } };
+
+        var contentTypesById = new Dictionary<long, ContentType>();
+        var program = CreateProgram(CreateSection(1, (10, ContentType.Title)));
+
         var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
-        Assert.Contains("Title is not allowed for content type Description", ex.Message);
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(10, typeof(ProgramSectionContent)).Split(' ')[0],
+            ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_AuthorType_RequireAuthorAndForbidOthers()
+    public void ValidateSections_TitleType_WithoutTitle_ThrowsValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 3, Description = "desc" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 10, Title = "" }
+                ]
             }
         };
-        var dict = new Dictionary<long, ContentType> { { 3, ContentType.Author } };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 10, ContentType.Title }
+        };
+
+        var program = CreateProgram(CreateSection(1, (10, ContentType.Title)));
+
         var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
-        Assert.Contains("Description is not allowed for content type Author", ex.Message);
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains(ErrorMessagesConstants.PropertyIsRequired("Title"), ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_QuestionType_RequireQuestionAndForbidOthers()
+    public void ValidateSections_DescriptionType_WithForbiddenTitle_ThrowsValidationException()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 4, Answer = "ans" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 11, Description = "D", Title = "Forbidden" }
+                ]
             }
         };
-        var dict = new Dictionary<long, ContentType> { { 4, ContentType.Question } };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 11, ContentType.Description }
+        };
+
+        var program = CreateProgram(CreateSection(1, (11, ContentType.Description)));
+
         var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
-        Assert.Contains("Answer is not allowed for content type Question", ex.Message);
+            ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+                sections,
+                contentTypesById,
+                content => content.EntityId,
+                program));
+
+        Assert.Contains(
+            ErrorMessagesConstants.PropertyNotAllowedForContentType("Title", ContentType.Description),
+            ex.Message);
     }
 
     [Fact]
-    public void ValidateSections_AnswerType_RequireAnswerAndForbidOthers()
+    public void ValidateSections_AllRequiredTypesValid_DoesNotThrow()
     {
         var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
         {
             new()
             {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 5, Question = "q" }
-                }
+                EntityId = 1,
+                Contents =
+                [
+                    new() { EntityId = 10, Title = "Title" },
+                    new() { EntityId = 11, Description = "Description" },
+                    new() { EntityId = 12, Author = "Author" },
+                    new() { EntityId = 13, Question = "Question?" },
+                    new() { EntityId = 14, Answer = "Answer." }
+                ]
             }
         };
-        var dict = new Dictionary<long, ContentType> { { 5, ContentType.Answer } };
-        var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
-        Assert.Contains("Question is not allowed for content type Answer", ex.Message);
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 10, ContentType.Title },
+            { 11, ContentType.Description },
+            { 12, ContentType.Author },
+            { 13, ContentType.Question },
+            { 14, ContentType.Answer },
+            { 15, ContentType.Image }
+        };
+
+        var program = CreateProgram(
+            CreateSection(
+                1,
+                (10, ContentType.Title),
+                (11, ContentType.Description),
+                (12, ContentType.Author),
+                (13, ContentType.Question),
+                (14, ContentType.Answer),
+                (15, ContentType.Image)));
+
+        ProgramSectionContentLocalizationValidationHelper.ValidateSections<
+            CreateHippotherapyProgramSectionLocalizationDto,
+            CreateHippotherapyProgramSectionContentLocalizationDto
+        >(
+            sections,
+            contentTypesById,
+            content => content.EntityId,
+            program);
     }
 
-    [Fact]
-    public void ValidateSections_ImageType_FilteredOutFromValidContents()
+    private static HippotherapyProgramEntity CreateProgram(params HippotherapyProgramSection[] sections)
     {
-        var sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
+        return new HippotherapyProgramEntity
         {
-            new()
-            {
-                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
-                {
-                    new() { EntityId = 6, Title = "t" }
-                }
-            }
+            Sections = sections.ToList()
         };
-        var dict = new Dictionary<long, ContentType> { { 6, ContentType.Image } };
-        var ex = Assert.Throws<ValidationException>(() =>
-            ProgramSectionContentLocalizationValidationHelper.ValidateSections(sections, dict));
-        Assert.Contains("Number of section contents", ex.Message);
+    }
+
+    private static HippotherapyProgramSection CreateSection(
+        long sectionId,
+        params (long contentId, ContentType contentType)[] contents)
+    {
+        return new HippotherapyProgramSection
+        {
+            Id = sectionId,
+            Contents = contents
+                .Select(content => new TestProgramSectionContent
+                {
+                    Id = content.contentId,
+                    ContentType = content.contentType,
+                    SectionId = sectionId
+                })
+                .Cast<ProgramSectionContent>()
+                .ToList()
+        };
+    }
+
+    private sealed class TestProgramSectionContent : ProgramSectionContent
+    {
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/GetHippotherapyProgramsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/GetHippotherapyProgramsTests.cs
@@ -4,6 +4,7 @@ using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
 using VictoryCenter.BLL.Queries.Admin.HippotherapyPrograms.GetByFilters;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.Media;
@@ -132,6 +133,10 @@ public class GetHippotherapyProgramsTests
             CategoryId = null
         };
 
+        _repositoryWrapper.Setup(repositoryWrapper => repositoryWrapper.LocalizationLanguagesRepository.CountAsync(
+             It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(2);
+
         var handler = new GetHippotherapyProgramsByFiltersHandler(_mockMapper.Object, _repositoryWrapper.Object);
         var result = await handler.Handle(new GetHippotherapyProgramsByFiltersQuery(requestDto), CancellationToken.None);
 
@@ -161,6 +166,9 @@ public class GetHippotherapyProgramsTests
             Status = Status.Published,
             Sections = new List<HippotherapyProgramSection> { section }
         };
+        _repositoryWrapper.Setup(repositoryWrapper => repositoryWrapper.LocalizationLanguagesRepository.CountAsync(
+             It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(2);
 
         _repositoryWrapper.Setup(r => r.HippotherapyProgramsRepository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgram>>()))
             .ReturnsAsync(new List<HippotherapyProgram> { program });
@@ -192,6 +200,10 @@ public class GetHippotherapyProgramsTests
         };
 
         var program = new HippotherapyProgram { Id = 1, Sections = new List<HippotherapyProgramSection> { section } };
+
+        _repositoryWrapper.Setup(repositoryWrapper => repositoryWrapper.LocalizationLanguagesRepository.CountAsync(
+             It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(2);
 
         _repositoryWrapper.Setup(r => r.HippotherapyProgramsRepository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgram>>()))
             .ReturnsAsync(new List<HippotherapyProgram> { program });

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -735,7 +735,7 @@ public class UpdateHippotherapyProgramTests
         {
             ContentType = ContentType.FaqQuestion,
             Order = order,
-            FaqQuestion = new CreateFaqQuestionDto { Id = id, QuestionText = questionText, AnswerText = answerText }
+            FaqQuestion = new CreateFaqSectionQuestionDto { Id = id, QuestionText = questionText, AnswerText = answerText }
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/CreateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/CreateHippotherapyProgramLocalizationHandlerTests.cs
@@ -73,12 +73,6 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
         LocalizationInfoDto = new() { Id = 2, Code = "en" }
     };
 
-    private readonly HippotherapyProgramEntity _testProgram = new()
-    {
-        Id = 1,
-        Sections = new List<HippotherapyProgramSection>()
-    };
-
     private readonly HippotherapyProgramEntity _testProgramWithContent = new()
     {
         Id = 1,
@@ -188,8 +182,8 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FluentValidation.Results.ValidationResult());
 
-        _mockProgramSectionContentService
-            .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))
+        _mockRepositoryWrapper
+            .Setup(r => r.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramEntity>>()))
             .ThrowsAsync(new KeyNotFoundException(ErrorMessagesConstants.NotFound(_testCreateDto.EntityId, typeof(HippotherapyProgramEntity))));
 
         var command = new CreateHippotherapyProgramLocalizationCommand(_testCreateDto);
@@ -200,9 +194,6 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.NotEmpty(result.Errors);
-        Assert.Contains(
-            ErrorMessagesConstants.NotFound(_testCreateDto.EntityId, typeof(HippotherapyProgramEntity)),
-            result.Errors.Select(e => e.Message));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/CreateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/CreateHippotherapyProgramLocalizationHandlerTests.cs
@@ -38,7 +38,26 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
         Location = "Test Location",
         ParticipantsCount = "20",
         MeetingsCount = "10",
-        Sections = new List<CreateHippotherapyProgramSectionLocalizationDto>()
+        Sections = new List<CreateHippotherapyProgramSectionLocalizationDto>
+        {
+            new()
+            {
+                EntityId = 100,
+                Contents = new List<CreateHippotherapyProgramSectionContentLocalizationDto>
+                {
+                    new()
+                    {
+                        EntityId = 200,
+                        Question = "Localized question"
+                    },
+                    new()
+                    {
+                        EntityId = 201,
+                        Answer = "Localized answer"
+                    }
+                }
+            }
+        }
     };
 
     private readonly HippotherapyProgramLocalization _testEntity = new()
@@ -329,23 +348,7 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
     public async Task Handle_ShouldFail_WhenLanguageNotFound()
     {
         // Arrange
-        _mockValidator
-            .Setup(v => v.ValidateAsync(
-                It.IsAny<FluentValidation.ValidationContext<CreateHippotherapyProgramLocalizationCommand>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
-
-        _mockProgramSectionContentService
-            .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))
-            .ReturnsAsync(new Dictionary<long, ContentType>());
-
-        _mockMapper
-            .Setup(m => m.Map<HippotherapyProgramLocalization>(It.IsAny<CreateHippotherapyProgramLocalizationDto>()))
-            .Returns(_testEntity);
-
-        _mockMapper
-            .Setup(m => m.Map<List<ProgramSectionContentLocalization>>(It.IsAny<List<CreateHippotherapyProgramSectionContentLocalizationDto>>()))
-            .Returns(new List<ProgramSectionContentLocalization>());
+        SetupDependencies();
 
         _mockProgramLocalizationService
             .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<HippotherapyProgramLocalization>()))
@@ -392,16 +395,9 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FluentValidation.Results.ValidationResult());
 
-        var programLocalizationWithSections = new HippotherapyProgramLocalization
-        {
-            EntityId = 1,
-            LanguageId = 2,
-            Entity = _testProgramWithContent
-        };
-
         _mockRepositoryWrapper
-            .Setup(r => r.HippotherapyProgramsLocalizationsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramLocalization>>()))
-            .ReturnsAsync(programLocalizationWithSections);
+            .Setup(r => r.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramEntity>>()))
+            .ReturnsAsync(_testProgramWithContent);
 
         _mockRepositoryWrapper
             .Setup(r => r.LocalizationLanguagesRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<LocalizationLanguage>>()))
@@ -444,7 +440,7 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
             .ReturnsAsync(_testEntity);
 
         _mockContentLocalizationService
-            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<List<ProgramSectionContentLocalization>>()))
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), It.IsAny<bool>()))
             .Returns(Task.CompletedTask);
 
         _mockProgramSectionContentService
@@ -454,5 +450,9 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
                 { 200, ContentType.Question },
                 { 201, ContentType.Answer }
             });
+
+        _mockProgramSectionContentService
+            .Setup(s => s.GetProgramSectionsAsync(It.IsAny<long>(), It.IsAny<long>()))
+            .ReturnsAsync(new List<HippotherapyProgramSectionLocalizationDto>());
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/CreateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/CreateHippotherapyProgramLocalizationHandlerTests.cs
@@ -48,11 +48,7 @@ public class CreateHippotherapyProgramLocalizationHandlerTests
                     new()
                     {
                         EntityId = 200,
-                        Question = "Localized question"
-                    },
-                    new()
-                    {
-                        EntityId = 201,
+                        Question = "Localized question",
                         Answer = "Localized answer"
                     }
                 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
@@ -1,0 +1,351 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using HippotherapyProgramEntity = VictoryCenter.DAL.Entities.HippotherapyProgram;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.HippotherapyPrograms;
+
+public class UpdateHippotherapyProgramLocalizationHandlerTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IValidator<UpdateHippotherapyProgramLocalizationCommand>> _mockValidator;
+    private readonly Mock<ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization>> _mockProgramLocalizationService;
+    private readonly Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>> _mockContentLocalizationService;
+    private readonly Mock<IProgramSectionContentService> _mockProgramSectionContentService;
+    private readonly UpdateHippotherapyProgramLocalizationHandler _handler;
+
+    private readonly UpdateHippotherapyProgramLocalizationDto _testUpdateDto = new()
+    {
+        Name = "Updated Program",
+        Description = "Updated Description",
+        Location = "Updated Location",
+        ParticipantsCount = "25",
+        MeetingsCount = "12",
+        Sections = new List<UpdateHippotherapyProgramSectionLocalizationDto>
+        {
+            new()
+            {
+                EntityId = 100,
+                Contents = new List<UpdateHippotherapyProgramSectionContentLocalizationDto>
+                {
+                    new()
+                    {
+                        EntityId = 200,
+                        Question = "Updated localized question"
+                    },
+                    new()
+                    {
+                        EntityId = 201,
+                        Answer = "Updated localized answer"
+                    }
+                }
+            }
+        }
+    };
+
+    private readonly HippotherapyProgramLocalization _testEntity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Updated Program",
+        Description = "Updated Description",
+        Location = "Updated Location"
+    };
+
+    private readonly HippotherapyProgramLocalizationDto _testDto = new()
+    {
+        Name = "Updated Program",
+        Description = "Updated Description",
+        Location = "Updated Location",
+        LocalizationInfoDto = new() { Id = 2, Code = "en" }
+    };
+
+    private readonly HippotherapyProgramEntity _testProgramWithContent = new()
+    {
+        Id = 1,
+        Sections = new List<HippotherapyProgramSection>
+        {
+            new()
+            {
+                Id = 100,
+                Contents = new List<ProgramSectionContent>
+                {
+                    new QuestionProgramContent
+                    {
+                        Id = 200,
+                        ContentType = ContentType.Question
+                    },
+                    new AnswerProgramContent
+                    {
+                        Id = 201,
+                        ContentType = ContentType.Answer
+                    }
+                }
+            }
+        }
+    };
+
+    public UpdateHippotherapyProgramLocalizationHandlerTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockValidator = new Mock<IValidator<UpdateHippotherapyProgramLocalizationCommand>>();
+        _mockProgramLocalizationService = new Mock<ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization>>();
+        _mockContentLocalizationService = new Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>>();
+        _mockProgramSectionContentService = new Mock<IProgramSectionContentService>();
+
+        _handler = new UpdateHippotherapyProgramLocalizationHandler(
+            _mockMapper.Object,
+            _mockRepositoryWrapper.Object,
+            _mockValidator.Object,
+            _mockProgramSectionContentService.Object,
+            _mockProgramLocalizationService.Object,
+            _mockContentLocalizationService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateHippotherapyProgramLocalization_Successfully()
+    {
+        // Arrange
+        SetupDependencies();
+        var command = new UpdateHippotherapyProgramLocalizationCommand(_testUpdateDto, 1, 2);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_testDto.Name, result.Value.Name);
+        _mockMapper.Verify(m => m.Map<HippotherapyProgramLocalization>(It.IsAny<UpdateHippotherapyProgramLocalizationDto>()), Times.Once);
+        _mockProgramLocalizationService.Verify(s => s.TrackEntityLocalizationForUpdateAsync(It.IsAny<HippotherapyProgramLocalization>()), Times.Once);
+        _mockRepositoryWrapper.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnValidationErrors_WhenValidationFails()
+    {
+        // Arrange
+        var invalidDto = new UpdateHippotherapyProgramLocalizationDto
+        {
+            Name = string.Empty,
+            Description = string.Empty,
+            Location = string.Empty,
+            ParticipantsCount = string.Empty,
+            MeetingsCount = string.Empty,
+            Sections = []
+        };
+        var command = new UpdateHippotherapyProgramLocalizationCommand(invalidDto, 0, 0);
+
+        var validationFailure = new FluentValidation.Results.ValidationFailure("EntityId", "EntityId must be positive");
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<FluentValidation.ValidationContext<UpdateHippotherapyProgramLocalizationCommand>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ValidationException(new[] { validationFailure }));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenProgramNotFound()
+    {
+        // Arrange
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<FluentValidation.ValidationContext<UpdateHippotherapyProgramLocalizationCommand>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockProgramSectionContentService
+            .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))
+            .ReturnsAsync(new Dictionary<long, ContentType>());
+
+        _mockRepositoryWrapper
+            .Setup(r => r.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramEntity>>()))
+            .ReturnsAsync((HippotherapyProgramEntity?)null);
+
+        var command = new UpdateHippotherapyProgramLocalizationCommand(_testUpdateDto, 1, 2);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Not found programEntity", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        // Arrange
+        SetupDependencies();
+        _mockRepositoryWrapper
+            .Setup(r => r.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException("Database error", new InvalidOperationException()));
+
+        var command = new UpdateHippotherapyProgramLocalizationCommand(_testUpdateDto, 1, 2);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)),
+            result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        // Arrange
+        SetupDependencies();
+        _mockProgramLocalizationService
+            .Setup(s => s.TrackEntityLocalizationForUpdateAsync(It.IsAny<HippotherapyProgramLocalization>()))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new UpdateHippotherapyProgramLocalizationCommand(_testUpdateDto, 1, 2);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(HippotherapyProgramLocalization)),
+            result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesReturnsZero()
+    {
+        // Arrange
+        SetupDependencies();
+        _mockRepositoryWrapper
+            .Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(0);
+
+        var command = new UpdateHippotherapyProgramLocalizationCommand(_testUpdateDto, 1, 2);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)),
+            result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenProgramSectionContentServiceThrowsKeyNotFound()
+    {
+        // Arrange
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<FluentValidation.ValidationContext<UpdateHippotherapyProgramLocalizationCommand>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        var expectedError = ErrorMessagesConstants.NotFound(1, typeof(HippotherapyProgramEntity));
+        _mockProgramSectionContentService
+            .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))
+            .ThrowsAsync(new KeyNotFoundException(expectedError));
+
+        var command = new UpdateHippotherapyProgramLocalizationCommand(_testUpdateDto, 1, 2);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(expectedError, result.Errors.Select(e => e.Message));
+    }
+
+    private void SetupDependencies()
+    {
+        _mockValidator
+            .Setup(v => v.ValidateAsync(
+                It.IsAny<FluentValidation.ValidationContext<UpdateHippotherapyProgramLocalizationCommand>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        _mockProgramSectionContentService
+            .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))
+            .ReturnsAsync(new Dictionary<long, ContentType>
+            {
+                { 200, ContentType.Question },
+                { 201, ContentType.Answer }
+            });
+
+        _mockRepositoryWrapper
+            .Setup(r => r.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramEntity>>()))
+            .ReturnsAsync(_testProgramWithContent);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.LocalizationLanguagesRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(new LocalizationLanguage
+            {
+                Id = 2,
+                Code = "en"
+            });
+
+        _mockRepositoryWrapper
+            .Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mockMapper
+            .Setup(m => m.Map<HippotherapyProgramLocalization>(It.IsAny<UpdateHippotherapyProgramLocalizationDto>()))
+            .Returns(_testEntity);
+
+        _mockMapper
+            .Setup(m => m.Map<HippotherapyProgramLocalizationDto>(It.IsAny<HippotherapyProgramLocalization>()))
+            .Returns(_testDto);
+
+        _mockMapper
+            .Setup(m => m.Map<LocalizationInfoDto>(It.IsAny<LocalizationLanguage>()))
+            .Returns(new LocalizationInfoDto { Id = 2, Code = "en" });
+
+        _mockMapper
+            .Setup(m => m.Map<List<ProgramSectionContentLocalization>>(It.IsAny<List<UpdateHippotherapyProgramSectionContentLocalizationDto>>()))
+            .Returns(new List<ProgramSectionContentLocalization>
+            {
+                new(),
+                new()
+            });
+
+        _mockProgramLocalizationService
+            .Setup(s => s.TrackEntityLocalizationForUpdateAsync(It.IsAny<HippotherapyProgramLocalization>()))
+            .Returns(Task.CompletedTask);
+
+        _mockContentLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        _mockProgramSectionContentService
+            .Setup(s => s.GetProgramSectionsAsync(It.IsAny<long>(), It.IsAny<long>()))
+            .ReturnsAsync(new List<HippotherapyProgramSectionLocalizationDto>());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
@@ -47,11 +47,7 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
                     new()
                     {
                         EntityId = 200,
-                        Question = "Updated localized question"
-                    },
-                    new()
-                    {
-                        EntityId = 201,
+                        Question = "Updated localized question",
                         Answer = "Updated localized answer"
                     }
                 }
@@ -86,15 +82,10 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
                 Id = 100,
                 Contents = new List<ProgramSectionContent>
                 {
-                    new QuestionProgramContent
+                    new TestProgramSectionContent
                     {
                         Id = 200,
-                        ContentType = ContentType.Question
-                    },
-                    new AnswerProgramContent
-                    {
-                        Id = 201,
-                        ContentType = ContentType.Answer
+                        ContentType = ContentType.FaqQuestion
                     }
                 }
             }
@@ -296,8 +287,7 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))
             .ReturnsAsync(new Dictionary<long, ContentType>
             {
-                { 200, ContentType.Question },
-                { 201, ContentType.Answer }
+                { 200, ContentType.FaqQuestion }
             });
 
         _mockRepositoryWrapper
@@ -332,7 +322,6 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             .Setup(m => m.Map<List<ProgramSectionContentLocalization>>(It.IsAny<List<UpdateHippotherapyProgramSectionContentLocalizationDto>>()))
             .Returns(new List<ProgramSectionContentLocalization>
             {
-                new(),
                 new()
             });
 
@@ -347,5 +336,9 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
         _mockProgramSectionContentService
             .Setup(s => s.GetProgramSectionsAsync(It.IsAny<long>(), It.IsAny<long>()))
             .ReturnsAsync(new List<HippotherapyProgramSectionLocalizationDto>());
+    }
+
+    private sealed class TestProgramSectionContent : ProgramSectionContent
+    {
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
@@ -260,6 +260,9 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FluentValidation.Results.ValidationResult());
 
+        _mockRepositoryWrapper
+            .Setup(r => r.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramEntity>>()))
+            .ReturnsAsync(_testProgramWithContent);
         var expectedError = ErrorMessagesConstants.NotFound(1, typeof(HippotherapyProgramEntity));
         _mockProgramSectionContentService
             .Setup(s => s.GetContentTypesByProgramIdAsync(It.IsAny<long>()))

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
@@ -565,6 +565,65 @@ public class LocalizationServiceTests
         Assert.Contains(nameof(LocalizationLanguage), ex.Message);
     }
 
+    [Fact]
+    public async Task TrackEntityLocalizationForUpdateAsync_ShouldTrackLocalizationForUpdate_WhenLocalizationExists()
+    {
+        // Arrange
+        var existingLocalization = new TeamMemberLocalization
+        {
+            EntityId = 1,
+            LanguageId = 1,
+            FullName = "Old Name",
+            Description = "Old Description"
+        };
+
+        var localizationToUpdate = new TeamMemberLocalization
+        {
+            EntityId = 1,
+            LanguageId = 1,
+            FullName = "New Name",
+            Description = "New Description"
+        };
+
+        SetupRepositoryWrapper(teamMemberLocalization: existingLocalization);
+
+        // Act
+        await _localizationService.TrackEntityLocalizationForUpdateAsync(localizationToUpdate);
+
+        // Assert
+        Assert.Equal(TranslationStatus.Relevant, localizationToUpdate.TranslationStatus);
+
+        _repositoryWrapper.Verify(
+            x => x.GetRepository<TeamMemberLocalization>()
+                .Update(It.Is<TeamMemberLocalization>(l => l == localizationToUpdate)),
+            Times.Once);
+
+        _repositoryWrapper.Verify(x => x.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task TrackEntityLocalizationForUpdateAsync_ShouldThrowKeyNotFoundException_WhenLocalizationDoesNotExist()
+    {
+        // Arrange
+        var localizationToUpdate = new TeamMemberLocalization
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            FullName = "Name",
+            Description = "Description"
+        };
+
+        SetupRepositoryWrapper(teamMemberLocalization: null);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
+            await _localizationService.TrackEntityLocalizationForUpdateAsync(localizationToUpdate));
+
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound((localizationToUpdate.EntityId, localizationToUpdate.LanguageId), typeof(TeamMemberLocalization)),
+            ex.Message);
+    }
+
     private void SetupRepositoryWrapper(
         TeamMemberLocalization? teamMemberLocalization = null,
         TeamMember? teamMember = null,

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/LocalizationServiceTests.cs
@@ -442,7 +442,7 @@ public class LocalizationServiceTests
             .Returns(Task.CompletedTask);
 
         // Act
-        await _localizationService.TrackEntityLocalizationAsync(localizations);
+        await _localizationService.TrackEntityLocalizationAsync(localizations, false);
 
         // Assert
         _repositoryWrapper.Verify(
@@ -486,7 +486,7 @@ public class LocalizationServiceTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
-            await _localizationService.TrackEntityLocalizationAsync(localizations));
+            await _localizationService.TrackEntityLocalizationAsync(localizations, false));
         Assert.Contains("999", ex.Message);
         Assert.Contains(nameof(TeamMember), ex.Message);
     }
@@ -531,7 +531,7 @@ public class LocalizationServiceTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<ValidationException>(async () =>
-            await _localizationService.TrackEntityLocalizationAsync(localizations));
+            await _localizationService.TrackEntityLocalizationAsync(localizations, false));
         Assert.Contains("Bulk localization supports only one LanguageId", ex.Message);
     }
 
@@ -560,7 +560,7 @@ public class LocalizationServiceTests
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
-            await _localizationService.TrackEntityLocalizationAsync(localizations));
+            await _localizationService.TrackEntityLocalizationAsync(localizations, false));
         Assert.Contains("999", ex.Message);
         Assert.Contains(nameof(LocalizationLanguage), ex.Message);
     }

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using AutoMapper;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Services.HippotherapyPrograms;
 using VictoryCenter.DAL.Entities;
@@ -13,10 +14,11 @@ public class ProgramSectionContentServiceTests
 {
     private readonly ProgramSectionContentService _service;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
 
     public ProgramSectionContentServiceTests()
     {
-        _service = new ProgramSectionContentService(_repositoryWrapperMock.Object);
+        _service = new ProgramSectionContentService(_repositoryWrapperMock.Object, _mapperMock.Object);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
@@ -1,9 +1,11 @@
-using Moq;
 using AutoMapper;
+using Moq;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.Services.HippotherapyPrograms;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -308,6 +310,97 @@ public class ProgramSectionContentServiceTests
         Assert.NotEmpty(result);
         _repositoryWrapperMock.Verify(
             x => x.HippotherapyProgramsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgram>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProgramSectionsAsync_ShouldReturnNotFoundExceptionAsync()
+    {
+        _repositoryWrapperMock
+            .Setup(x => x.HippotherapyProgramsLocalizationsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramLocalization>>()))
+            .ReturnsAsync((HippotherapyProgramLocalization)null);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<KeyNotFoundException>(async () =>
+             await _service.GetProgramSectionsAsync(1, 1));
+
+        Assert.Equal(ErrorMessagesConstants.NotFound(1, typeof(HippotherapyProgram)), ex.Message);
+    }
+
+    [Fact]
+    public async Task GetProgramSectionsAsync_ShouldReturnSectionsSuccessFully()
+    {
+        var content = new TestProgramSectionContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 1,
+            SectionId = 1,
+            Localizations = new List<ProgramSectionContentLocalization>
+            {
+                new()
+                {
+                    EntityId = 1,
+                    LanguageId = 1,
+                    Title = "Test Title",
+                    TranslationStatus = TranslationStatus.Relevant,
+                    Language = new LocalizationLanguage
+                    {
+                        Id = 1,
+                        Code = "en",
+                        Name = "English"
+                    },
+                    CreatedAt = DateTimeOffset.UtcNow
+                }
+            }
+        };
+
+        var section = new HippotherapyProgramSection
+        {
+            Id = 10,
+            ProgramId = 1,
+            Template = ProgramSectionTemplate.TextOnly,
+            Order = 1,
+            Contents = new List<ProgramSectionContent> { content }
+        };
+
+        var programLocalization = new HippotherapyProgramLocalization
+        {
+            EntityId = 1,
+            LanguageId = 1,
+            Entity = new HippotherapyProgram
+            {
+                Id = 1,
+                Name = "Test Program",
+                Slug = "test-program",
+                Status = Status.Published,
+                Sections = new List<HippotherapyProgramSection> { section }
+            }
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.HippotherapyProgramsLocalizationsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramLocalization>>()))
+            .ReturnsAsync(programLocalization);
+
+        _mapperMock
+            .Setup(x => x.Map<HippotherapyProgramSectionContentLocalizationDto>(It.IsAny<ProgramSectionContentLocalization>()))
+            .Returns((ProgramSectionContentLocalization src) => new HippotherapyProgramSectionContentLocalizationDto
+            {
+                EntityId = src.EntityId,
+                Title = src.Title,
+                Description = src.Description,
+                Author = src.Author,
+                Question = src.Question,
+                Answer = src.Answer,
+                TranslationStatus = src.TranslationStatus
+            });
+
+        var result = await _service.GetProgramSectionsAsync(1, 1);
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        _repositoryWrapperMock.Verify(
+            x => x.HippotherapyProgramsLocalizationsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramLocalization>>()),
             Times.Once);
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HippotherapyProgramSections/BaseHippotherapyProgramSectionValidatorTests.cs
@@ -378,7 +378,7 @@ public class BaseHippotherapyProgramSectionValidatorTests
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Contents)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqQuestionDto.QuestionText)));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqSectionQuestionDto.QuestionText)));
     }
 
     [Fact]
@@ -404,7 +404,7 @@ public class BaseHippotherapyProgramSectionValidatorTests
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Contents)
-            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqQuestionDto.AnswerText)));
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateFaqSectionQuestionDto.AnswerText)));
     }
 
     [Fact]
@@ -429,7 +429,7 @@ public class BaseHippotherapyProgramSectionValidatorTests
         {
             ContentType = ContentType.FaqQuestion,
             Order = 1,
-            FaqQuestion = new CreateFaqQuestionDto { Id = 5, QuestionText = "", AnswerText = "" }
+            FaqQuestion = new CreateFaqSectionQuestionDto { Id = 5, QuestionText = "", AnswerText = "" }
         });
 
         var result = _validator.TestValidate(model);
@@ -690,7 +690,7 @@ public class BaseHippotherapyProgramSectionValidatorTests
         {
             ContentType = ContentType.FaqQuestion,
             Order = order,
-            FaqQuestion = new CreateFaqQuestionDto { QuestionText = questionText, AnswerText = answerText }
+            FaqQuestion = new CreateFaqSectionQuestionDto { QuestionText = questionText, AnswerText = answerText }
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyPrograms/Update/UpdateHippotherapyProgramLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyPrograms/Update/UpdateHippotherapyProgramLocalizationValidatorTests.cs
@@ -1,0 +1,126 @@
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyPrograms;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.HippotherapyPrograms.Update;
+
+public class UpdateHippotherapyProgramLocalizationValidatorTests
+{
+    private readonly UpdateHippotherapyProgramLocalizationValidator _validator;
+
+    public UpdateHippotherapyProgramLocalizationValidatorTests()
+    {
+        var baseProgramValidator = new BaseHippotherapyProgramLocalizationValidator();
+        var baseSectionContentValidator = new BaseProgramSectionContentLocalizationValidator();
+        var updateSectionContentValidator = new UpdateHippotherapyProgramSectionContentLocalizationValidator(baseSectionContentValidator);
+        var updateSectionValidator = new UpdateHippotherapyProgramSectionLocalizationValidator(updateSectionContentValidator);
+
+        _validator = new UpdateHippotherapyProgramLocalizationValidator(baseProgramValidator, updateSectionValidator);
+    }
+
+    [Fact]
+    public void Validate_WhenNameIsTooShort_ShouldHaveValidationError()
+    {
+        var command = CreateValidCommand() with
+        {
+            UpdateHippotherapyProgramLocalizationDto = CreateValidDto() with { Name = "A" }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.Contains(
+            result.Errors,
+            x => x.ErrorMessage == ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateHippotherapyProgramLocalizationDto.Name),
+                HippotherapyProgramLocalizationConstants.NameMinLength));
+    }
+
+    [Fact]
+    public void Validate_WhenSectionEntityIdIsInvalid_ShouldHaveValidationError()
+    {
+        var command = CreateValidCommand() with
+        {
+            UpdateHippotherapyProgramLocalizationDto = CreateValidDto() with
+            {
+                Sections =
+                [
+                    new UpdateHippotherapyProgramSectionLocalizationDto
+                    {
+                        EntityId = 0,
+                        Contents = []
+                    }
+
+                ]
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.Contains(result.Errors, x => x.ErrorMessage == "EntityId must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_WhenSectionsIsNull_ShouldNotHaveSectionValidationError()
+    {
+        var command = CreateValidCommand() with
+        {
+            UpdateHippotherapyProgramLocalizationDto = CreateValidDto() with
+            {
+                Sections = null!
+            }
+        };
+
+        var result = _validator.Validate(command);
+
+        Assert.DoesNotContain(result.Errors, x => x.ErrorMessage == "EntityId must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_WhenCommandIsValid_ShouldBeValid()
+    {
+        var command = CreateValidCommand();
+
+        var result = _validator.Validate(command);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    private static UpdateHippotherapyProgramLocalizationCommand CreateValidCommand()
+    {
+        return new UpdateHippotherapyProgramLocalizationCommand(CreateValidDto(), 1, 1);
+    }
+
+    private static UpdateHippotherapyProgramLocalizationDto CreateValidDto()
+    {
+        return new UpdateHippotherapyProgramLocalizationDto
+        {
+            Name = "Valid name",
+            Description = "Valid description",
+            Location = "Kyiv",
+            ParticipantsCount = "12",
+            MeetingsCount = "5",
+            Sections =
+            [
+                new UpdateHippotherapyProgramSectionLocalizationDto
+                {
+                    EntityId = 1,
+                    Contents =
+                    [
+                        new UpdateHippotherapyProgramSectionContentLocalizationDto
+                        {
+                            EntityId = 1,
+                            Title = "Valid title"
+                        }
+
+                    ]
+                }
+
+            ]
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyPrograms/Update/UpdateHippotherapyProgramSectionContentLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyPrograms/Update/UpdateHippotherapyProgramSectionContentLocalizationValidatorTests.cs
@@ -1,0 +1,65 @@
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.HippotherapyPrograms.Update;
+
+public class UpdateHippotherapyProgramSectionContentLocalizationValidatorTests
+{
+    private readonly UpdateHippotherapyProgramSectionContentLocalizationValidator _validator;
+
+    public UpdateHippotherapyProgramSectionContentLocalizationValidatorTests()
+    {
+        var baseValidator = new BaseProgramSectionContentLocalizationValidator();
+        _validator = new UpdateHippotherapyProgramSectionContentLocalizationValidator(baseValidator);
+    }
+
+    [Fact]
+    public void Validate_WhenEntityIdIsNotPositive_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHippotherapyProgramSectionContentLocalizationDto
+        {
+            EntityId = 0,
+            Title = "Valid title"
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.Contains(result.Errors, x => x.ErrorMessage == "EntityId must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_WhenTitleIsTooShort_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHippotherapyProgramSectionContentLocalizationDto
+        {
+            EntityId = 1,
+            Title = "abcd"
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.Contains(
+            result.Errors,
+            x => x.ErrorMessage == ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
+                ProgramSectionContentLocalizationConstants.TitleMinLength));
+    }
+
+    [Fact]
+    public void Validate_WhenDtoIsValid_ShouldBeValid()
+    {
+        var dto = new UpdateHippotherapyProgramSectionContentLocalizationDto
+        {
+            EntityId = 1,
+            Title = "Valid title"
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyPrograms/Update/UpdateHippotherapyProgramSectionLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyPrograms/Update/UpdateHippotherapyProgramSectionLocalizationValidatorTests.cs
@@ -1,0 +1,91 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramSection;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.HippotherapyPrograms.Update;
+
+public class UpdateHippotherapyProgramSectionLocalizationValidatorTests
+{
+    private readonly UpdateHippotherapyProgramSectionLocalizationValidator _validator;
+
+    public UpdateHippotherapyProgramSectionLocalizationValidatorTests()
+    {
+        var baseSectionContentValidator = new BaseProgramSectionContentLocalizationValidator();
+        var updateSectionContentValidator = new UpdateHippotherapyProgramSectionContentLocalizationValidator(baseSectionContentValidator);
+
+        _validator = new UpdateHippotherapyProgramSectionLocalizationValidator(updateSectionContentValidator);
+    }
+
+    [Fact]
+    public void Validate_WhenEntityIdIsNotPositive_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHippotherapyProgramSectionLocalizationDto
+        {
+            EntityId = 0,
+            Contents = []
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.Contains(result.Errors, x => x.ErrorMessage == "EntityId must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_WhenContentHasInvalidEntityId_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHippotherapyProgramSectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents =
+            [
+                new UpdateHippotherapyProgramSectionContentLocalizationDto
+                {
+                    EntityId = 0,
+                    Title = "Valid title"
+                }
+
+            ]
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.Contains(result.Errors, x => x.ErrorMessage == "EntityId must be greater than 0.");
+    }
+
+    [Fact]
+    public void Validate_WhenContentsIsNull_ShouldNotHaveContentValidationErrors()
+    {
+        var dto = new UpdateHippotherapyProgramSectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents = null
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_WhenDtoIsValid_ShouldBeValid()
+    {
+        var dto = new UpdateHippotherapyProgramSectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents =
+            [
+                new UpdateHippotherapyProgramSectionContentLocalizationDto
+                {
+                    EntityId = 1,
+                    Title = "Valid title"
+                }
+
+            ]
+        };
+
+        var result = _validator.Validate(dto);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HippotherapyProgramLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HippotherapyProgramLocalizationsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgram.Update;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -14,5 +15,17 @@ public class HippotherapyProgramLocalizationsController : AuthorizedApiControlle
     public async Task<ActionResult> CreateHippotherapyProgramLocalization([FromBody] CreateHippotherapyProgramLocalizationDto createHippotherapyProgramLocalizationDto)
     {
         return HandleResult(await Mediator.Send(new CreateHippotherapyProgramLocalizationCommand(createHippotherapyProgramLocalizationDto)));
+    }
+
+    [HttpPut("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(HippotherapyProgramLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateHippotherapyProgramLocalization(
+        [FromBody] UpdateHippotherapyProgramLocalizationDto updateHippotherapyProgramLocalizationDto,
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(new UpdateHippotherapyProgramLocalizationCommand(updateHippotherapyProgramLocalizationDto, EntityId, LanguageId)));
     }
 }


### PR DESCRIPTION
## Github Ticket
 * Github Ticket (https://github.com/ita-social-projects/VictoryCenter-Back/issues/1385)
## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an update endpoint for hippotherapy program localizations and a service method to fetch program sections per language.
  * Added translation-status filtering for program listings (All, Outdated, Missing).

* **Refactor**
  * Consolidated localization DTOs and section/content models.
  * Validation reworked to be program-context aware with immediate, specific errors.
  * Localization tracking now supports explicit update mode.

* **Tests**
  * Expanded unit tests for validation, update flows, and new service behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->