### PR TITLE
Fix/issue [Single program] Update translation for the changed program profile in UA

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -52,7 +52,9 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                         .Include(x => x.Categories)
                         .Include(x => x.Sections)
                         .ThenInclude(s => s.Contents)
-                        .ThenInclude(c => (c as FaqQuestionProgramContent)!.FaqQuestion)
+                        .ThenInclude(c => c.Localizations)
+                        .Include(x => x.Sections)
+                        .ThenInclude(s => s.Contents)
                         .ThenInclude(c => c.Localizations)
                         .Include(x => x.Localizations)
                 });
@@ -108,14 +110,6 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 return Result.Fail<HippotherapyProgramDto>(assignImagesResult.Errors);
             }
 
-            if (programFieldsChanged)
-            {
-                foreach (var loc in program.Localizations)
-                {
-                    loc.TranslationStatus = TranslationStatus.Outdated;
-                }
-            }
-
             var categoriesChenged = program.Categories.Select(c => c.Id).OrderBy(id => id)
                 .SequenceEqual(request.UpdateProgramDto.CategoryIds.OrderBy(id => id)) == false;
 
@@ -132,10 +126,30 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             var oldSections = program.Sections.ToList();
 
-            ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
-            if (!EnsureReplaceSameSections(oldSections, request.UpdateProgramDto.Sections, imagesByIdResult.Value))
+            var sectionsChanged = EnsureReplaceSameSections(oldSections, request.UpdateProgramDto.Sections, imagesByIdResult.Value);
+            if (!sectionsChanged)
             {
+                ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
                 program.Localizations.Clear();
+            }
+
+            if (programFieldsChanged || sectionsChanged)
+            {
+                foreach (var loc in program.Localizations)
+                {
+                    loc.TranslationStatus = TranslationStatus.Outdated;
+                }
+
+                var sections = program.Sections.ToList();
+                var contentsToOutdated = sections
+                    .SelectMany(s => s.Contents
+                        .SelectMany(c => c.Localizations))
+                    .ToList();
+
+                foreach (var content in contentsToOutdated)
+                {
+                    content.TranslationStatus = TranslationStatus.Outdated;
+                }
             }
 
             _repositoryWrapper.HippotherapyProgramsRepository.Update(program);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -135,21 +135,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             if (programFieldsChanged || sectionsChanged)
             {
-                foreach (var loc in program.Localizations)
-                {
-                    loc.TranslationStatus = TranslationStatus.Outdated;
-                }
-
-                var sections = program.Sections.ToList();
-                var contentsToOutdated = sections
-                    .SelectMany(s => s.Contents
-                        .SelectMany(c => c.Localizations))
-                    .ToList();
-
-                foreach (var content in contentsToOutdated)
-                {
-                    content.TranslationStatus = TranslationStatus.Outdated;
-                }
+                SerTranslationsToOutdated(program);
             }
 
             _repositoryWrapper.HippotherapyProgramsRepository.Update(program);
@@ -181,6 +167,25 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         catch (ValidationException vex)
         {
             return Result.Fail<HippotherapyProgramDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+    }
+
+    private static void SerTranslationsToOutdated(HippotherapyProgram program)
+    {
+        foreach (var loc in program.Localizations)
+        {
+            loc.TranslationStatus = TranslationStatus.Outdated;
+        }
+
+        var sections = program.Sections.ToList();
+        var contentsToOutdated = sections
+            .SelectMany(s => s.Contents
+                .SelectMany(c => c.Localizations))
+            .ToList();
+
+        foreach (var content in contentsToOutdated)
+        {
+            content.TranslationStatus = TranslationStatus.Outdated;
         }
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -267,7 +267,7 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
-    public async Task Handle_ProgramFieldsUnchanged_KeepsProgramLocalizationsRelevant()
+    public async Task Handle_ProgramFieldsUnchanged_MarksProgramLocalizationsOutdated()
     {
         var program = Program();
         program.Name = "SameName";
@@ -290,7 +290,7 @@ public class UpdateHippotherapyProgramTests
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
     }
 
     [Fact]
@@ -328,7 +328,7 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
-    public async Task Handle_SameSectionStructureAndUnchangedTitle_KeepsContentLocalizationsRelevant()
+    public async Task Handle_SameSectionStructureAndUnchangedTitle_MarksContentLocalizationsOutdated()
     {
         var content = new TitleProgramContent
         {
@@ -357,7 +357,7 @@ public class UpdateHippotherapyProgramTests
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
     }
 
     [Fact]
@@ -455,7 +455,7 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
-    public async Task Handle_SameStructureAndImageChanged_DoesNotMarkContentLocalizationsOutdated()
+    public async Task Handle_SameStructureAndImageChanged_MarksContentLocalizationsOutdated()
     {
         var content = new ImageProgramContent
         {
@@ -472,7 +472,7 @@ public class UpdateHippotherapyProgramTests
         await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateImageContent(0, 2))])), CancellationToken.None);
 
         Assert.Equal(2, content.ImageId);
-        Assert.Equal(TranslationStatus.Relevant, content.Localizations.Single().TranslationStatus);
+        Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
     }
 
     [Fact]


### PR DESCRIPTION
## GitHub

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1406)

## Summary of change

Several bugs were fixed, including the correct removal of section contents during localization when the main entity changes. Additionally, when any section, content, or the program itself is modified, all related localizations are now marked as outdated.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translation statuses now consistently mark program, section, and content localizations as Outdated when program fields or section structure change.
* **Improvements**
  * Multilingual content reloads more reliably and localizations are cleared/replaced only when structure changes.
* **Tests**
  * Unit tests updated to reflect the new behavior of marking localizations as Outdated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->