### PR TITLE
Feature/issue 1163 Implement edit handler to change existing localization to WhoWeAre admin page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Create/CreateWhoWeAreContentLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Create/CreateWhoWeAreContentLocalizationHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.Localization;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Entities.WhoWeAreContents;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Create/CreateWhoWeAreContentLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Create/CreateWhoWeAreContentLocalizationHandler.cs
@@ -4,15 +4,11 @@ using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
-using VictoryCenter.BLL.Constants.Localization;
 using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
 using VictoryCenter.BLL.Interfaces.Localization;
-using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Entities.WhoWeAreContents;
-using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
-using VictoryCenter.DAL.Repositories.Options;
 
 namespace VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Create;
 
@@ -42,32 +38,20 @@ public class CreateWhoWeAreContentLocalizationHandler : IRequestHandler<CreateWh
             using var transaction = _repository.BeginTransaction();
 
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
-            var dictEntities = await GetContentToLocalizeMappedToDictionary(request.ContentLocalizationDtos);
-            var sectionId = await GetSectionIdByType(request.SectionType) ??
-                            throw new ArgumentException(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(request.SectionType)));
+            var sanitizedDtosResult = await WhoWeAreContentLocalizationHandlerHelper.ValidateAndSanitizeAsync(
+                _repository,
+                request.SectionType,
+                request.ContentLocalizationDtos);
+
+            if (sanitizedDtosResult.IsFailed)
+            {
+                return Result.Fail<List<WhoWeAreContentLocalizationDto>>(sanitizedDtosResult.Errors.Select(e => e.Message));
+            }
 
             var createdLocalizations = new List<WhoWeAreContentLocalizationDto>();
 
-            foreach (var dto in request.ContentLocalizationDtos)
+            foreach (var sanitizedDto in sanitizedDtosResult.Value)
             {
-                if (!dictEntities.TryGetValue(dto.EntityId, out var whoWeAreContent))
-                {
-                    return Result.Fail(ErrorMessagesConstants.NotFound(dto.EntityId, typeof(WhoWeAreContent)));
-                }
-
-                if (whoWeAreContent.SectionId != sectionId)
-                {
-                    return Result.Fail(WhoWeAreConstants.EntityDoesNotBelongToTheSection(typeof(WhoWeAreContent), request.SectionType));
-                }
-
-                var validationError = ValidateDtoFieldsMatchContentType(dto, whoWeAreContent);
-                if (validationError != null)
-                {
-                    return Result.Fail(validationError);
-                }
-
-                var sanitizedDto = SanitizeDtoBasedOnContentType(dto, whoWeAreContent);
-
                 WhoWeAreContentLocalization entity = _mapper.Map<WhoWeAreContentLocalization>(sanitizedDto);
                 var result = await _localizationService.CreateEntityLocalizationAsync(entity);
                 WhoWeAreContentLocalizationDto responseDto = _mapper.Map<WhoWeAreContentLocalizationDto>(result);
@@ -98,54 +82,5 @@ public class CreateWhoWeAreContentLocalizationHandler : IRequestHandler<CreateWh
             return Result.Fail<List<WhoWeAreContentLocalizationDto>>(ErrorMessagesConstants.
                 FailedToCreateEntityInDatabase(typeof(WhoWeAreContentLocalization)));
         }
-    }
-
-    private async Task<Dictionary<long, WhoWeAreContent>> GetContentToLocalizeMappedToDictionary(List<CreateWhoWeAreContentLocalizationDto> content)
-    {
-        var contentIds = content.Select(x => x.EntityId).ToList();
-
-        var entities = await _repository.WhoWeAreContentsRepository.GetAllAsync(new QueryOptions<WhoWeAreContent>
-        {
-            Filter = w => contentIds.Contains(w.Id)
-        });
-
-        return entities.ToDictionary(x => x.Id, x => x);
-    }
-
-    private async Task<long?> GetSectionIdByType(SectionType sectionType)
-    {
-        var section = await _repository.WhoWeAreSectionsRepository.GetFirstOrDefaultAsync(
-            new QueryOptions<WhoWeAreSection>
-            {
-                Filter = x => x.SectionType == sectionType
-            });
-
-        return section?.Id;
-    }
-
-    private static string? ValidateDtoFieldsMatchContentType(CreateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
-    {
-        return content switch
-        {
-            ImageContent => WhoWeAreContentLocalizationConstants.CannotCreateLocalizationForContentType(typeof(ImageContent), dto.EntityId),
-            TitleContent when string.IsNullOrWhiteSpace(dto.Title) =>
-                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Title), typeof(TitleContent), dto.EntityId),
-            DescriptionContent when string.IsNullOrWhiteSpace(dto.Description) =>
-                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(DescriptionContent), dto.EntityId),
-            CardContent when string.IsNullOrWhiteSpace(dto.Description) =>
-                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(CardContent), dto.EntityId),
-            _ => null
-        };
-    }
-
-    private static CreateWhoWeAreContentLocalizationDto SanitizeDtoBasedOnContentType(CreateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
-    {
-        return content switch
-        {
-            TitleContent => dto with { Description = null },
-            DescriptionContent => dto with { Title = null },
-            CardContent => dto with { Title = null },
-            _ => dto
-        };
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationCommand.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Update;
+
+public record UpdateWhoWeAreContentLocalizationCommand(SectionType SectionType, List<UpdateWhoWeAreContentLocalizationDto> ContentLocalizationDtos)
+    : IRequest<Result<List<WhoWeAreContentLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.Localization;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Entities.WhoWeAreContents;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationHandler.cs
@@ -4,13 +4,10 @@ using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
-using VictoryCenter.BLL.Constants.Localization;
 using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
 using VictoryCenter.BLL.Interfaces.Localization;
-using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Entities.WhoWeAreContents;
-using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -42,34 +39,19 @@ public class UpdateWhoWeAreContentLocalizationHandler : IRequestHandler<UpdateWh
             using var transaction = _repository.BeginTransaction();
 
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
-            var dictEntities = await GetContentToLocalizeMappedToDictionary(request.ContentLocalizationDtos);
-            var sectionId = await GetSectionIdByType(request.SectionType) ??
-                            throw new ArgumentException(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(request.SectionType)));
+            var sanitizedDtosResult = await WhoWeAreContentLocalizationHandlerHelper.ValidateAndSanitizeAsync(
+                _repository,
+                request.SectionType,
+                request.ContentLocalizationDtos);
 
-            var localizationsToUpdate = new List<WhoWeAreContentLocalization>();
-
-            foreach (var dto in request.ContentLocalizationDtos)
+            if (sanitizedDtosResult.IsFailed)
             {
-                if (!dictEntities.TryGetValue(dto.EntityId, out var whoWeAreContent))
-                {
-                    return Result.Fail(ErrorMessagesConstants.NotFound(dto.EntityId, typeof(WhoWeAreContent)));
-                }
-
-                if (whoWeAreContent.SectionId != sectionId)
-                {
-                    return Result.Fail(WhoWeAreConstants.EntityDoesNotBelongToTheSection(typeof(WhoWeAreContent), request.SectionType));
-                }
-
-                var validationError = ValidateDtoFieldsMatchContentType(dto, whoWeAreContent);
-                if (validationError != null)
-                {
-                    return Result.Fail(validationError);
-                }
-
-                var sanitizedDto = SanitizeDtoBasedOnContentType(dto, whoWeAreContent);
-
-                localizationsToUpdate.Add(_mapper.Map<WhoWeAreContentLocalization>(sanitizedDto));
+                return Result.Fail<List<WhoWeAreContentLocalizationDto>>(sanitizedDtosResult.Errors.Select(e => e.Message));
             }
+
+            var localizationsToUpdate = sanitizedDtosResult.Value
+                .Select(sanitizedDto => _mapper.Map<WhoWeAreContentLocalization>(sanitizedDto))
+                .ToList();
 
             await _localizationService.TrackEntityLocalizationAsync(localizationsToUpdate, true);
 
@@ -115,54 +97,5 @@ public class UpdateWhoWeAreContentLocalizationHandler : IRequestHandler<UpdateWh
             return Result.Fail<List<WhoWeAreContentLocalizationDto>>(ErrorMessagesConstants.
                 FailedToUpdateEntityInDatabase(typeof(WhoWeAreContentLocalization)));
         }
-    }
-
-    private async Task<Dictionary<long, WhoWeAreContent>> GetContentToLocalizeMappedToDictionary(List<UpdateWhoWeAreContentLocalizationDto> content)
-    {
-        var contentIds = content.Select(x => x.EntityId).ToList();
-
-        var entities = await _repository.WhoWeAreContentsRepository.GetAllAsync(new QueryOptions<WhoWeAreContent>
-        {
-            Filter = w => contentIds.Contains(w.Id)
-        });
-
-        return entities.ToDictionary(x => x.Id, x => x);
-    }
-
-    private async Task<long?> GetSectionIdByType(SectionType sectionType)
-    {
-        var section = await _repository.WhoWeAreSectionsRepository.GetFirstOrDefaultAsync(
-            new QueryOptions<WhoWeAreSection>
-            {
-                Filter = x => x.SectionType == sectionType
-            });
-
-        return section?.Id;
-    }
-
-    private static string? ValidateDtoFieldsMatchContentType(UpdateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
-    {
-        return content switch
-        {
-            ImageContent => WhoWeAreContentLocalizationConstants.CannotCreateLocalizationForContentType(typeof(ImageContent), dto.EntityId),
-            TitleContent when string.IsNullOrWhiteSpace(dto.Title) =>
-                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Title), typeof(TitleContent), dto.EntityId),
-            DescriptionContent when string.IsNullOrWhiteSpace(dto.Description) =>
-                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(DescriptionContent), dto.EntityId),
-            CardContent when string.IsNullOrWhiteSpace(dto.Description) =>
-                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(CardContent), dto.EntityId),
-            _ => null
-        };
-    }
-
-    private static UpdateWhoWeAreContentLocalizationDto SanitizeDtoBasedOnContentType(UpdateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
-    {
-        return content switch
-        {
-            TitleContent => dto with { Description = null },
-            DescriptionContent => dto with { Title = null },
-            CardContent => dto with { Title = null },
-            _ => dto
-        };
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/Update/UpdateWhoWeAreContentLocalizationHandler.cs
@@ -1,0 +1,168 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Entities.WhoWeAreContents;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Update;
+
+public class UpdateWhoWeAreContentLocalizationHandler : IRequestHandler<UpdateWhoWeAreContentLocalizationCommand, Result<List<WhoWeAreContentLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IValidator<UpdateWhoWeAreContentLocalizationCommand> _validator;
+    private readonly ILocalizationService<WhoWeAreContent, WhoWeAreContentLocalization> _localizationService;
+    private readonly IRepositoryWrapper _repository;
+
+    public UpdateWhoWeAreContentLocalizationHandler(
+        IMapper mapper,
+        IValidator<UpdateWhoWeAreContentLocalizationCommand> validator,
+        ILocalizationService<WhoWeAreContent, WhoWeAreContentLocalization> localizationService,
+        IRepositoryWrapper repository)
+    {
+        _mapper = mapper;
+        _validator = validator;
+        _localizationService = localizationService;
+        _repository = repository;
+    }
+
+    public async Task<Result<List<WhoWeAreContentLocalizationDto>>> Handle(UpdateWhoWeAreContentLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var transaction = _repository.BeginTransaction();
+
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var dictEntities = await GetContentToLocalizeMappedToDictionary(request.ContentLocalizationDtos);
+            var sectionId = await GetSectionIdByType(request.SectionType) ??
+                            throw new ArgumentException(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(request.SectionType)));
+
+            var localizationsToUpdate = new List<WhoWeAreContentLocalization>();
+
+            foreach (var dto in request.ContentLocalizationDtos)
+            {
+                if (!dictEntities.TryGetValue(dto.EntityId, out var whoWeAreContent))
+                {
+                    return Result.Fail(ErrorMessagesConstants.NotFound(dto.EntityId, typeof(WhoWeAreContent)));
+                }
+
+                if (whoWeAreContent.SectionId != sectionId)
+                {
+                    return Result.Fail(WhoWeAreConstants.EntityDoesNotBelongToTheSection(typeof(WhoWeAreContent), request.SectionType));
+                }
+
+                var validationError = ValidateDtoFieldsMatchContentType(dto, whoWeAreContent);
+                if (validationError != null)
+                {
+                    return Result.Fail(validationError);
+                }
+
+                var sanitizedDto = SanitizeDtoBasedOnContentType(dto, whoWeAreContent);
+
+                localizationsToUpdate.Add(_mapper.Map<WhoWeAreContentLocalization>(sanitizedDto));
+            }
+
+            await _localizationService.TrackEntityLocalizationAsync(localizationsToUpdate, true);
+
+            if (await _repository.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<List<WhoWeAreContentLocalizationDto>>(
+                    ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(WhoWeAreContentLocalization)));
+            }
+
+            var languageId = request.ContentLocalizationDtos.First().LanguageId;
+            var entityIds = request.ContentLocalizationDtos.Select(x => x.EntityId).ToList();
+
+            var updatedLocalizations = await _repository.GetRepository<WhoWeAreContentLocalization>()
+                .GetAllAsync(new QueryOptions<WhoWeAreContentLocalization>
+                {
+                    Filter = l => entityIds.Contains(l.EntityId) && l.LanguageId == languageId,
+                    Include = l => l.Include(x => x.Language)
+                });
+
+            var response = _mapper.Map<List<WhoWeAreContentLocalizationDto>>(updatedLocalizations);
+
+            transaction.Complete();
+            return Result.Ok(response);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<List<WhoWeAreContentLocalizationDto>>(knfex.Message);
+        }
+        catch (ArgumentException aex)
+        {
+            return Result.Fail<List<WhoWeAreContentLocalizationDto>>(aex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<List<WhoWeAreContentLocalizationDto>>(ErrorMessagesConstants.FailedToUpdateEntity(typeof(WhoWeAreContentLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<List<WhoWeAreContentLocalizationDto>>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<List<WhoWeAreContentLocalizationDto>>(ErrorMessagesConstants.
+                FailedToUpdateEntityInDatabase(typeof(WhoWeAreContentLocalization)));
+        }
+    }
+
+    private async Task<Dictionary<long, WhoWeAreContent>> GetContentToLocalizeMappedToDictionary(List<UpdateWhoWeAreContentLocalizationDto> content)
+    {
+        var contentIds = content.Select(x => x.EntityId).ToList();
+
+        var entities = await _repository.WhoWeAreContentsRepository.GetAllAsync(new QueryOptions<WhoWeAreContent>
+        {
+            Filter = w => contentIds.Contains(w.Id)
+        });
+
+        return entities.ToDictionary(x => x.Id, x => x);
+    }
+
+    private async Task<long?> GetSectionIdByType(SectionType sectionType)
+    {
+        var section = await _repository.WhoWeAreSectionsRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<WhoWeAreSection>
+            {
+                Filter = x => x.SectionType == sectionType
+            });
+
+        return section?.Id;
+    }
+
+    private static string? ValidateDtoFieldsMatchContentType(UpdateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
+    {
+        return content switch
+        {
+            ImageContent => WhoWeAreContentLocalizationConstants.CannotCreateLocalizationForContentType(typeof(ImageContent), dto.EntityId),
+            TitleContent when string.IsNullOrWhiteSpace(dto.Title) =>
+                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Title), typeof(TitleContent), dto.EntityId),
+            DescriptionContent when string.IsNullOrWhiteSpace(dto.Description) =>
+                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(DescriptionContent), dto.EntityId),
+            CardContent when string.IsNullOrWhiteSpace(dto.Description) =>
+                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(CardContent), dto.EntityId),
+            _ => null
+        };
+    }
+
+    private static UpdateWhoWeAreContentLocalizationDto SanitizeDtoBasedOnContentType(UpdateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
+    {
+        return content switch
+        {
+            TitleContent => dto with { Description = null },
+            DescriptionContent => dto with { Title = null },
+            CardContent => dto with { Title = null },
+            _ => dto
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/WhoWeAreContentLocalizationHandlerHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/WhoWeAreContents/WhoWeAreContentLocalizationHandlerHelper.cs
@@ -1,0 +1,101 @@
+using FluentResults;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.WhoWeAreContents;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents;
+
+internal static class WhoWeAreContentLocalizationHandlerHelper
+{
+    internal static async Task<Result<List<UpdateWhoWeAreContentLocalizationDto>>> ValidateAndSanitizeAsync(
+        IRepositoryWrapper repository,
+        SectionType sectionType,
+        IEnumerable<UpdateWhoWeAreContentLocalizationDto> contentLocalizationDtos)
+    {
+        var contentLocalizationDtosList = contentLocalizationDtos.ToList();
+        var dictEntities = await GetContentToLocalizeMappedToDictionary(repository, contentLocalizationDtosList);
+        var sectionId = await GetSectionIdByType(repository, sectionType) ??
+                        throw new ArgumentException(ErrorMessagesConstants.PropertyMustBeValidEnum("SectionType"));
+
+        var sanitizedDtos = new List<UpdateWhoWeAreContentLocalizationDto>(contentLocalizationDtosList.Count);
+
+        foreach (var dto in contentLocalizationDtosList)
+        {
+            if (!dictEntities.TryGetValue(dto.EntityId, out var whoWeAreContent))
+            {
+                return Result.Fail(ErrorMessagesConstants.NotFound(dto.EntityId, typeof(WhoWeAreContent)));
+            }
+
+            if (whoWeAreContent.SectionId != sectionId)
+            {
+                return Result.Fail(WhoWeAreConstants.EntityDoesNotBelongToTheSection(typeof(WhoWeAreContent), sectionType));
+            }
+
+            var validationError = ValidateDtoFieldsMatchContentType(dto, whoWeAreContent);
+            if (validationError != null)
+            {
+                return Result.Fail(validationError);
+            }
+
+            sanitizedDtos.Add(SanitizeDtoBasedOnContentType(dto, whoWeAreContent));
+        }
+
+        return Result.Ok(sanitizedDtos);
+    }
+
+    private static async Task<Dictionary<long, WhoWeAreContent>> GetContentToLocalizeMappedToDictionary(
+        IRepositoryWrapper repository,
+        List<UpdateWhoWeAreContentLocalizationDto> content)
+    {
+        var contentIds = content.Select(x => x.EntityId).ToList();
+
+        var entities = await repository.WhoWeAreContentsRepository.GetAllAsync(new QueryOptions<WhoWeAreContent>
+        {
+            Filter = w => contentIds.Contains(w.Id)
+        });
+
+        return entities.ToDictionary(x => x.Id, x => x);
+    }
+
+    private static async Task<long?> GetSectionIdByType(IRepositoryWrapper repository, SectionType sectionType)
+    {
+        var section = await repository.WhoWeAreSectionsRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<WhoWeAreSection>
+            {
+                Filter = x => x.SectionType == sectionType
+            });
+
+        return section?.Id;
+    }
+
+    private static string? ValidateDtoFieldsMatchContentType(UpdateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
+    {
+        return content switch
+        {
+            ImageContent => WhoWeAreContentLocalizationConstants.CannotCreateLocalizationForContentType(typeof(ImageContent), dto.EntityId),
+            TitleContent when string.IsNullOrWhiteSpace(dto.Title) =>
+                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Title), typeof(TitleContent), dto.EntityId),
+            DescriptionContent when string.IsNullOrWhiteSpace(dto.Description) =>
+                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(DescriptionContent), dto.EntityId),
+            CardContent when string.IsNullOrWhiteSpace(dto.Description) =>
+                WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Description), typeof(CardContent), dto.EntityId),
+            _ => null
+        };
+    }
+
+    private static UpdateWhoWeAreContentLocalizationDto SanitizeDtoBasedOnContentType(UpdateWhoWeAreContentLocalizationDto dto, WhoWeAreContent content)
+    {
+        return content switch
+        {
+            TitleContent => dto with { Description = null },
+            DescriptionContent => dto with { Title = null },
+            CardContent => dto with { Title = null },
+            _ => dto
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/WhoWeAreContents/CreateWhoWeAreContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/WhoWeAreContents/CreateWhoWeAreContentLocalizationDto.cs
@@ -1,8 +1,3 @@
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
 
-public record CreateWhoWeAreContentLocalizationDto : UpdateWhoWeAreContentLocalizationDto
-{
-    public long EntityId { get; init; }
-
-    public long LanguageId { get; init; }
-}
+public record CreateWhoWeAreContentLocalizationDto : UpdateWhoWeAreContentLocalizationDto { }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/WhoWeAreContents/CreateWhoWeAreContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/WhoWeAreContents/CreateWhoWeAreContentLocalizationDto.cs
@@ -1,8 +1,6 @@
-using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
-
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
 
-public record CreateWhoWeAreContentLocalizationDto : UpdateWhoWeAreContentLocalizationDto, ILocalizationIdentity
+public record CreateWhoWeAreContentLocalizationDto : UpdateWhoWeAreContentLocalizationDto
 {
     public long EntityId { get; init; }
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationDto.cs
@@ -1,7 +1,12 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
 
-public record UpdateWhoWeAreContentLocalizationDto
+public record UpdateWhoWeAreContentLocalizationDto : ILocalizationIdentity
 {
+    public long EntityId { get; init; }
+
+    public long LanguageId { get; init; }
 
     public string? Title { get; init; }
 

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/WhoWeAreContentLocalizationHandlerHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/WhoWeAreContentLocalizationHandlerHelper.cs
@@ -8,7 +8,7 @@ using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
-namespace VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents;
+namespace VictoryCenter.BLL.Helpers;
 
 internal static class WhoWeAreContentLocalizationHandlerHelper
 {

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/WhoWeAreContents/WhoWeAreContentLocalizationsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/WhoWeAreContents/WhoWeAreContentLocalizationsProfile.cs
@@ -12,6 +12,9 @@ public class WhoWeAreContentLocalizationsProfile : Profile
         CreateMap<CreateWhoWeAreContentLocalizationDto, WhoWeAreContentLocalization>()
             .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
 
+        CreateMap<UpdateWhoWeAreContentLocalizationDto, WhoWeAreContentLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+
         CreateMap<WhoWeAreContentLocalization, WhoWeAreContentLocalizationDto>()
             .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
     }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Update;
+using VictoryCenter.BLL.Constants;
+
+namespace VictoryCenter.BLL.Validators.Localization.WhoWeAreContents;
+
+public class UpdateWhoWeAreContentLocalizationValidator : AbstractValidator<UpdateWhoWeAreContentLocalizationCommand>
+{
+    public UpdateWhoWeAreContentLocalizationValidator()
+    {
+        RuleFor(x => x.ContentLocalizationDtos)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateWhoWeAreContentLocalizationCommand.ContentLocalizationDtos)));
+
+        RuleForEach(x => x.ContentLocalizationDtos)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainNullElements(nameof(UpdateWhoWeAreContentLocalizationCommand.ContentLocalizationDtos)));
+
+        RuleForEach(x => x.ContentLocalizationDtos)
+            .SetValidator(command => new WhoWeAreSectionLocalizationValidator(command.SectionType));
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/WhoWeAreContentLocalizations/Update/UpdateWhoWeAreContentLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/WhoWeAreContentLocalizations/Update/UpdateWhoWeAreContentLocalizationTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.WhoWeAreContentLocalizations.Update;
+
+public class UpdateWhoWeAreContentLocalizationTests : BaseTestClass
+{
+    public UpdateWhoWeAreContentLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateWhoWeAreContentLocalization_ShouldReturnOk()
+    {
+        var titleContent = await Fixture.DbContext.WhoWeAreContents
+            .Include(c => c.Section)
+            .FirstOrDefaultAsync(c => c.ContentType == ContentType.Title)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var language = await Fixture.DbContext.LocalizationLanguages
+            .FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var existingLocalization = await EnsureLocalizationExists(titleContent.Id, language.Id);
+
+        var dtos = new List<UpdateWhoWeAreContentLocalizationDto>
+        {
+            new()
+            {
+                EntityId = existingLocalization.EntityId,
+                LanguageId = existingLocalization.LanguageId,
+                Title = "Updated localized title"
+            }
+        };
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/WhoWeAreContentLocalizations/{(int)titleContent.Section.SectionType}",
+            Serialize(dtos));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateWhoWeAreContentLocalization_ShouldReturnNotFound_WhenEntityIdDoesNotExist()
+    {
+        var section = await Fixture.DbContext.WhoWeAreSections
+            .FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var language = await Fixture.DbContext.LocalizationLanguages
+            .FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var dtos = new List<UpdateWhoWeAreContentLocalizationDto>
+        {
+            new()
+            {
+                EntityId = 99999,
+                LanguageId = language.Id,
+                Title = "Updated localized title"
+            }
+        };
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/WhoWeAreContentLocalizations/{(int)section.SectionType}",
+            Serialize(dtos));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateWhoWeAreContentLocalization_ShouldReturnBadRequest_WhenImageContentProvided()
+    {
+        var imageContent = await Fixture.DbContext.WhoWeAreContents
+            .Include(c => c.Section)
+            .FirstOrDefaultAsync(c => c.ContentType == ContentType.Image)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var language = await Fixture.DbContext.LocalizationLanguages
+            .FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var dtos = new List<UpdateWhoWeAreContentLocalizationDto>
+        {
+            new()
+            {
+                EntityId = imageContent.Id,
+                LanguageId = language.Id
+            }
+        };
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/WhoWeAreContentLocalizations/{(int)imageContent.Section.SectionType}",
+            Serialize(dtos));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateWhoWeAreContentLocalization_InvalidData_ShouldReturnBadRequest()
+    {
+        var dtos = new List<UpdateWhoWeAreContentLocalizationDto>
+        {
+            new()
+            {
+                EntityId = 0,
+                LanguageId = 0,
+                Title = "t"
+            }
+        };
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/WhoWeAreContentLocalizations/{(int)SectionType.Main}",
+            Serialize(dtos));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static StringContent Serialize(object obj) =>
+        new(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json");
+
+    private async Task<WhoWeAreContentLocalization> EnsureLocalizationExists(long entityId, long languageId)
+    {
+        var existingLocalization = await Fixture.DbContext.WhoWeAreContentLocalizations
+            .FirstOrDefaultAsync(l => l.EntityId == entityId && l.LanguageId == languageId);
+
+        if (existingLocalization != null)
+        {
+            return existingLocalization;
+        }
+
+        var localization = new WhoWeAreContentLocalization
+        {
+            EntityId = entityId,
+            LanguageId = languageId,
+            Title = "Initial localized title"
+        };
+
+        Fixture.DbContext.WhoWeAreContentLocalizations.Add(localization);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        return localization;
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationTests.cs
@@ -1,0 +1,405 @@
+using System.Transactions;
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.WhoWeAreContents;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Entities.WhoWeAreContents;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreContents;
+using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreSections;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.WhoWeAreContents;
+
+public class UpdateWhoWeAreContentLocalizationTests
+{
+    private readonly Mock<ILocalizationService<WhoWeAreContent, WhoWeAreContentLocalization>> _mockLocalizationService;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IWhoWeAreContentsRepository> _mockContentsRepository;
+    private readonly Mock<IWhoWeAreSectionsRepository> _mockSectionsRepository;
+    private readonly Mock<IRepositoryBase<WhoWeAreContentLocalization>> _mockGenericLocalizationRepository;
+    private readonly IValidator<UpdateWhoWeAreContentLocalizationCommand> _validator;
+
+    private readonly WhoWeAreSection _testSection = new()
+    {
+        Id = 10,
+        SectionType = SectionType.Main,
+        Title = "Main Section",
+        Contents = null!
+    };
+
+    private readonly WhoWeAreContentLocalization _testEntity = new()
+    {
+        EntityId = 1,
+        LanguageId = 1,
+        Title = "Updated title"
+    };
+
+    private readonly WhoWeAreContentLocalizationDto _testDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 1, Code = "en" },
+        Title = "Updated title"
+    };
+
+    private readonly UpdateWhoWeAreContentLocalizationDto _testUpdateDto = new()
+    {
+        EntityId = 1,
+        LanguageId = 1,
+        Title = "Updated title",
+        Description = "This value should be ignored for title content"
+    };
+
+    public UpdateWhoWeAreContentLocalizationTests()
+    {
+        _mockLocalizationService = new Mock<ILocalizationService<WhoWeAreContent, WhoWeAreContentLocalization>>();
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockContentsRepository = new Mock<IWhoWeAreContentsRepository>();
+        _mockSectionsRepository = new Mock<IWhoWeAreSectionsRepository>();
+        _mockGenericLocalizationRepository = new Mock<IRepositoryBase<WhoWeAreContentLocalization>>();
+        _validator = new UpdateWhoWeAreContentLocalizationValidator();
+
+        _mockRepositoryWrapper.Setup(x => x.WhoWeAreContentsRepository).Returns(_mockContentsRepository.Object);
+        _mockRepositoryWrapper.Setup(x => x.WhoWeAreSectionsRepository).Returns(_mockSectionsRepository.Object);
+        _mockRepositoryWrapper.Setup(x => x.GetRepository<WhoWeAreContentLocalization>()).Returns(_mockGenericLocalizationRepository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateWhoWeAreContentLocalization_Successfully()
+    {
+        // Arrange
+        var titleContent = CreateContentByType(ContentType.Title, id: 1, sectionId: _testSection.Id);
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { titleContent });
+        SetupMapperAndService();
+
+        UpdateWhoWeAreContentLocalizationDto? mappedDto = null;
+        _mockMapper
+            .Setup(m => m.Map<WhoWeAreContentLocalization>(It.IsAny<UpdateWhoWeAreContentLocalizationDto>()))
+            .Callback<object>(dto => mappedDto = dto as UpdateWhoWeAreContentLocalizationDto)
+            .Returns(_testEntity);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
+        Assert.NotNull(mappedDto);
+        Assert.Null(mappedDto!.Description);
+        _mockLocalizationService.Verify(
+            s => s.TrackEntityLocalizationAsync(It.Is<IEnumerable<WhoWeAreContentLocalization>>(l => l.Count() == 1), true),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSectionNotFound()
+    {
+        // Arrange
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(sectionToReturn: null, new List<WhoWeAreContent>());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(command.SectionType)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenContentNotFound()
+    {
+        // Arrange
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent>());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(_testUpdateDto.EntityId, typeof(WhoWeAreContent)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenContentDoesNotBelongToSection()
+    {
+        // Arrange
+        var foreignContent = CreateContentByType(ContentType.Title, id: 1, sectionId: 999);
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { foreignContent });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            WhoWeAreConstants.EntityDoesNotBelongToTheSection(typeof(WhoWeAreContent), SectionType.Main),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenImageContentLocalizationRequested()
+    {
+        // Arrange
+        var imageContent = CreateContentByType(ContentType.Image, id: 1, sectionId: _testSection.Id);
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { imageContent });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            WhoWeAreContentLocalizationConstants.CannotCreateLocalizationForContentType(typeof(ImageContent), _testUpdateDto.EntityId),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenRequiredContentFieldIsMissing()
+    {
+        // Arrange
+        var titleContent = CreateContentByType(ContentType.Title, id: 1, sectionId: _testSection.Id);
+        var dto = new UpdateWhoWeAreContentLocalizationDto
+        {
+            EntityId = 1,
+            LanguageId = 1,
+            Title = null
+        };
+
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { dto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { titleContent });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            WhoWeAreContentLocalizationConstants.FieldIsRequiredForContentType(nameof(dto.Title), typeof(TitleContent), dto.EntityId),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesReturnsZero()
+    {
+        // Arrange
+        var titleContent = CreateContentByType(ContentType.Title, id: 1, sectionId: _testSection.Id);
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { titleContent });
+        SetupMapperAndService(saveChangesResult: 0);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(WhoWeAreContentLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        // Arrange
+        var titleContent = CreateContentByType(ContentType.Title, id: 1, sectionId: _testSection.Id);
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { titleContent });
+        SetupMapperAndService();
+        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync()).ThrowsAsync(new DbUpdateException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(WhoWeAreContentLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        // Arrange
+        var titleContent = CreateContentByType(ContentType.Title, id: 1, sectionId: _testSection.Id);
+        var notFoundMessage = "Language or entity not found";
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { titleContent });
+        SetupMapperAndService();
+        _mockLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<WhoWeAreContentLocalization>>(), true))
+            .ThrowsAsync(new KeyNotFoundException(notFoundMessage));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Single(result.Errors);
+        Assert.Equal(notFoundMessage, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        // Arrange
+        var titleContent = CreateContentByType(ContentType.Title, id: 1, sectionId: _testSection.Id);
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { _testUpdateDto });
+
+        SetupRepositoryWrapper(_testSection, new List<WhoWeAreContent> { titleContent });
+        SetupMapperAndService();
+        _mockLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<WhoWeAreContentLocalization>>(), true))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(WhoWeAreContentLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        // Arrange
+        var command = new UpdateWhoWeAreContentLocalizationCommand(SectionType.Main, null!);
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateWhoWeAreContentLocalizationCommand.ContentLocalizationDtos)),
+            result.Errors[0].Message);
+    }
+
+    private UpdateWhoWeAreContentLocalizationHandler CreateHandler() =>
+        new(_mockMapper.Object, _validator, _mockLocalizationService.Object, _mockRepositoryWrapper.Object);
+
+    private void SetupMapperAndService(int saveChangesResult = 1)
+    {
+        _mockMapper
+            .Setup(m => m.Map<WhoWeAreContentLocalization>(It.IsAny<UpdateWhoWeAreContentLocalizationDto>()))
+            .Returns(_testEntity);
+
+        _mockLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<WhoWeAreContentLocalization>>(), true))
+            .Returns(Task.CompletedTask);
+
+        _mockRepositoryWrapper
+            .Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(saveChangesResult);
+
+        _mockGenericLocalizationRepository
+            .Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<WhoWeAreContentLocalization>>()))
+            .ReturnsAsync(new List<WhoWeAreContentLocalization> { _testEntity });
+
+        _mockMapper
+            .Setup(m => m.Map<List<WhoWeAreContentLocalizationDto>>(It.IsAny<IEnumerable<WhoWeAreContentLocalization>>()))
+            .Returns(new List<WhoWeAreContentLocalizationDto> { _testDto });
+    }
+
+    private void SetupRepositoryWrapper(
+        WhoWeAreSection? sectionToReturn = null,
+        List<WhoWeAreContent>? contentsToReturn = null)
+    {
+        _mockSectionsRepository
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<WhoWeAreSection>>()))
+            .ReturnsAsync(sectionToReturn);
+
+        _mockContentsRepository
+            .Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<WhoWeAreContent>>()))
+            .ReturnsAsync(contentsToReturn ?? new List<WhoWeAreContent>());
+
+        _mockRepositoryWrapper
+            .Setup(r => r.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+    }
+
+    private static WhoWeAreContent CreateContentByType(ContentType contentType, long id, long sectionId) =>
+        contentType switch
+        {
+            ContentType.Title => new TitleContent { Id = id, ContentType = ContentType.Title, SectionId = sectionId, Title = "Default Title" },
+            ContentType.Description => new DescriptionContent { Id = id, ContentType = ContentType.Description, SectionId = sectionId, Description = "Default Description" },
+            ContentType.Card => new CardContent { Id = id, ContentType = ContentType.Card, SectionId = sectionId, Description = "Default Card Description" },
+            ContentType.Image => new ImageContent { Id = id, ContentType = ContentType.Image, SectionId = sectionId },
+            _ => throw new ArgumentException($"Unsupported content type: {contentType}")
+        };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/WhoWeAreContents/UpdateWhoWeAreContentLocalizationValidatorTests.cs
@@ -1,0 +1,156 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
+using VictoryCenter.BLL.Validators.Localization.WhoWeAreContents;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.WhoWeAreContents;
+
+public class UpdateWhoWeAreContentLocalizationValidatorTests
+{
+    private readonly UpdateWhoWeAreContentLocalizationValidator _validator;
+
+    public UpdateWhoWeAreContentLocalizationValidatorTests()
+    {
+        _validator = new UpdateWhoWeAreContentLocalizationValidator();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenContentLocalizationDtosIsNull()
+    {
+        var command = new UpdateWhoWeAreContentLocalizationCommand(SectionType.Main, null!);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.ContentLocalizationDtos)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(UpdateWhoWeAreContentLocalizationCommand.ContentLocalizationDtos)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenContentLocalizationDtosContainsNull()
+    {
+        var command = new UpdateWhoWeAreContentLocalizationCommand(
+            SectionType.Main,
+            new List<UpdateWhoWeAreContentLocalizationDto> { null! });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("ContentLocalizationDtos[0]")
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotContainNullElements(
+                nameof(UpdateWhoWeAreContentLocalizationCommand.ContentLocalizationDtos)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var shortTitle = new string('A', WhoWeAreContentLocalizationConstants.ValidationTitleRules.MinLen - 1);
+        var minDescLen = WhoWeAreContentLocalizationConstants.ValidationDescriptionRules[SectionType.Main].MinLen;
+        var command = BuildCommand(
+            SectionType.Main,
+            title: shortTitle,
+            description: new string('A', minDescLen));
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("ContentLocalizationDtos[0].Title")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateWhoWeAreContentLocalizationDto.Title),
+                WhoWeAreContentLocalizationConstants.ValidationTitleRules.MinLen));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var longTitle = new string('A', WhoWeAreContentLocalizationConstants.ValidationTitleRules.MaxLen + 1);
+        var minDescLen = WhoWeAreContentLocalizationConstants.ValidationDescriptionRules[SectionType.Main].MinLen;
+        var command = BuildCommand(
+            SectionType.Main,
+            title: longTitle,
+            description: new string('A', minDescLen));
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("ContentLocalizationDtos[0].Title")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateWhoWeAreContentLocalizationDto.Title),
+                WhoWeAreContentLocalizationConstants.ValidationTitleRules.MaxLen));
+    }
+
+    [Theory]
+    [InlineData(SectionType.Main)]
+    [InlineData(SectionType.WhatWeDo)]
+    [InlineData(SectionType.People)]
+    [InlineData(SectionType.Team)]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort(SectionType sectionType)
+    {
+        var minLen = WhoWeAreContentLocalizationConstants.ValidationDescriptionRules[sectionType].MinLen;
+        var shortDescription = new string('A', minLen - 1);
+        var command = BuildCommand(sectionType, description: shortDescription);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("ContentLocalizationDtos[0].Description")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateWhoWeAreContentLocalizationDto.Description),
+                minLen));
+    }
+
+    [Theory]
+    [InlineData(SectionType.Main)]
+    [InlineData(SectionType.WhatWeDo)]
+    [InlineData(SectionType.People)]
+    [InlineData(SectionType.Team)]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong(SectionType sectionType)
+    {
+        var maxLen = WhoWeAreContentLocalizationConstants.ValidationDescriptionRules[sectionType].MaxLen;
+        var longDescription = new string('A', maxLen + 1);
+        var command = BuildCommand(sectionType, description: longDescription);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("ContentLocalizationDtos[0].Description")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateWhoWeAreContentLocalizationDto.Description),
+                maxLen));
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenCommandIsValid()
+    {
+        var minDescLen = WhoWeAreContentLocalizationConstants.ValidationDescriptionRules[SectionType.Main].MinLen;
+        var minTitleLen = WhoWeAreContentLocalizationConstants.ValidationTitleRules.MinLen;
+
+        var command = BuildCommand(
+            SectionType.Main,
+            title: new string('A', minTitleLen),
+            description: new string('A', minDescLen));
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static UpdateWhoWeAreContentLocalizationCommand BuildCommand(
+        SectionType sectionType,
+        long entityId = 1,
+        long languageId = 1,
+        string? title = null,
+        string? description = null)
+    {
+        return new UpdateWhoWeAreContentLocalizationCommand(
+            sectionType,
+            new List<UpdateWhoWeAreContentLocalizationDto>
+            {
+                new()
+                {
+                    EntityId = entityId,
+                    LanguageId = languageId,
+                    Title = title,
+                    Description = description
+                }
+            });
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/WhoWeAreContentLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/WhoWeAreContentLocalizationsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.WhoWeAreContents.Update;
 using VictoryCenter.BLL.DTOs.Admin.Localization.WhoWeAreContents;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.WebAPI.Controllers.Common;
@@ -15,5 +16,14 @@ public class WhoWeAreContentLocalizationsController : AuthorizedApiController
     public async Task<IActionResult> CreateWhoWeAreContentLocalization([FromBody] List<CreateWhoWeAreContentLocalizationDto> dtos, SectionType sectionType)
     {
         return HandleResult(await Mediator.Send(new CreateWhoWeAreContentLocalizationCommand(sectionType, dtos)));
+    }
+
+    [HttpPut("{sectionType}")]
+    [ProducesResponseType(typeof(List<WhoWeAreContentLocalizationDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateWhoWeAreContentLocalization([FromBody] List<UpdateWhoWeAreContentLocalizationDto> dtos, SectionType sectionType)
+    {
+        return HandleResult(await Mediator.Send(new UpdateWhoWeAreContentLocalizationCommand(sectionType, dtos)));
     }
 }


### PR DESCRIPTION
dev
## GitHub

* [GitHub #1393](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1393)

## Summary of issue

This pull request introduces a new update flow for localizing "Who We Are" content, refactors validation and sanitization logic for localization DTOs, and improves type consistency across DTOs. The main changes include the addition of update command/handler/validator, extraction of shared validation logic, and cleanup of DTO inheritance. These changes make the codebase more maintainable and consistent, and enable both creation and updating of localizations with unified validation.

**New Update Flow for Localizations:**

* Added `UpdateWhoWeAreContentLocalizationCommand`, handler, and validator to support updating localizations, including transaction handling and validation for update operations (`UpdateWhoWeAreContentLocalizationCommand.cs`, `UpdateWhoWeAreContentLocalizationHandler.cs`, `UpdateWhoWeAreContentLocalizationValidator.cs`).

**Refactoring and Shared Validation Logic:**

* Extracted validation and sanitization logic into `WhoWeAreContentLocalizationHandlerHelper`, used by both create and update flows for consistent validation and error handling (`WhoWeAreContentLocalizationHandlerHelper.cs`).
* Updated the create handler to use the shared helper, removing redundant methods and simplifying the flow (`CreateWhoWeAreContentLocalizationHandler.cs`).

**DTO and Mapping Improvements:**

* Unified DTO inheritance so that `UpdateWhoWeAreContentLocalizationDto` implements `ILocalizationIdentity` and `CreateWhoWeAreContentLocalizationDto` inherits from it, ensuring consistent property definitions (`UpdateWhoWeAreContentLocalizationDto.cs`, `CreateWhoWeAreContentLocalizationDto.cs`).
* Updated mapping profiles to support both create and update DTOs, ensuring proper translation status handling (`WhoWeAreContentLocalizationsProfile.cs`).

**Cleanup:**

* Removed unused imports in the create handler for clarity and maintainability (`CreateWhoWeAreContentLocalizationHandler.cs`).

## Testing approach

<img width="1384" height="603" alt="image" src="https://github.com/user-attachments/assets/83afdcca-fa20-438b-96ce-67351116e5cd" />
<img width="1368" height="456" alt="image" src="https://github.com/user-attachments/assets/a15f2cb3-beb7-49c8-be5d-a076fb0822a9" />
<img width="1730" height="132" alt="image" src="https://github.com/user-attachments/assets/12bf83c7-a99a-4ab2-af61-347d2506e3a3" />



## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating localization content in "Who We Are" sections, enabling modifications to existing translations across different content areas through the localization API. Includes comprehensive validation and error handling for various content types and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->