### PR TITLE
Chore/issue-1895: Extend coderabbit auto-review base branch coverage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -96,7 +96,13 @@ reviews:
     enabled: true
     auto_incremental_review: true
     drafts: true
-    base_branches: ["main", "^release\/.*", "^feature\/.*", "^hotfix\/.*"]
+    base_branches:
+    - "main"
+    - "develop"
+    - "^release\/.*"
+    - "^hotfix\/.*"
+    - "^feature\/.*"
+    - "^fix\/.*"
 
 chat:
   auto_reply: true


### PR DESCRIPTION
dev

https://github.com/ita-social-projects/VictoryCenter-Back/issues/1895


## Summary of issue

The current .coderabbit.yaml configuration has auto_review enabled, but base_branches only partially covers the branch naming conventions used across the project. CodeRabbit will not trigger automated reviews on PRs targeting branches that are not explicitly listed.

## Summary of change

Updated auto_review.base_branches in .coderabbit.yaml

## Testing approach

1. Pull latest changes from the release branch
2. Open a test PR targeting feature, or fix/ branch
3. Verify CodeRabbit automatically triggers a review on each PR

## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automatic code review configuration to expand branch pattern coverage for automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->