### PR TITLE
Fix/issue-1935 -Fix bug that occur while edit the photos for program after this localization became outdated

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -125,14 +125,19 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             var oldSections = program.Sections.ToList();
 
-            var sectionsChanged = EnsureReplaceSameSections(oldSections, request.UpdateProgramDto.Sections, imagesByIdResult.Value);
-            if (!sectionsChanged)
+            var sectionsMatched = EnsureReplaceSameSections(
+                oldSections,
+                request.UpdateProgramDto.Sections,
+                imagesByIdResult.Value,
+                out var programContentsChanged);
+
+            if (!sectionsMatched)
             {
                 ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
                 program.Localizations.Clear();
             }
 
-            if (programFieldsChanged || sectionsChanged)
+            if (programFieldsChanged || programContentsChanged)
             {
                 SerTranslationsToOutdated(program);
             }
@@ -200,8 +205,11 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
     private static bool EnsureReplaceSameSections(
         List<HippotherapyProgramSection> oldSections,
         List<CreateHippotherapyProgramSectionDto> newSections,
-        IReadOnlyDictionary<long, Image> imagesById)
+        IReadOnlyDictionary<long, Image> imagesById,
+        out bool anyContentChanged)
     {
+        anyContentChanged = false;
+
         if (oldSections.Count != newSections.Count)
         {
             return false;
@@ -275,8 +283,10 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                     return false;
                 }
 
-                if (contentChanged)
+                if (contentChanged && oldContent.ContentType != ContentType.Image)
                 {
+                    anyContentChanged = true;
+
                     foreach (var loc in oldContent.Localizations)
                     {
                         loc.TranslationStatus = TranslationStatus.Outdated;

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -267,7 +267,7 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
-    public async Task Handle_ProgramFieldsUnchanged_MarksProgramLocalizationsOutdated()
+    public async Task Handle_ProgramFieldsUnchanged_MarksProgramLocalizationsRelevant()
     {
         var program = Program();
         program.Name = "SameName";
@@ -290,7 +290,7 @@ public class UpdateHippotherapyProgramTests
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
     }
 
     [Fact]


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1935)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of translation status tracking for hippotherapy program updates. Translations are now correctly marked as relevant when program content remains unchanged, providing more precise translation management.
  * Enhanced content change detection during program updates to better handle different content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->