### PR TITLE
Feature/issue 918 [Company Profile] Implement Company Profile Business Logic and Endpoints

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+
+namespace VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+
+public record CreateCompanyProfileCommand(CreateCompanyProfileDto CreateCompanyProfileDto) : IRequest<Result<CompanyProfileDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileHandler.cs
@@ -5,6 +5,9 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -15,15 +18,21 @@ public class CreateCompanyProfileHandler : IRequestHandler<CreateCompanyProfileC
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IMapper _mapper;
     private readonly IValidator<CreateCompanyProfileCommand> _validator;
+    private readonly ILocalizationService<CompanyProfileContact, CompanyProfileContactLocalization> _localizationContactService;
+    private readonly ILocalizationService<CompanyProfileRequisite, CompanyProfileRequisiteLocalization> _localizationRequisiteService;
 
     public CreateCompanyProfileHandler(
         IRepositoryWrapper repositoryWrapper,
         IMapper mapper,
-        IValidator<CreateCompanyProfileCommand> validator)
+        IValidator<CreateCompanyProfileCommand> validator,
+        ILocalizationService<CompanyProfileContact, CompanyProfileContactLocalization> localizationContactService,
+        ILocalizationService<CompanyProfileRequisite, CompanyProfileRequisiteLocalization> localizationRequisite)
     {
         _repositoryWrapper = repositoryWrapper;
         _mapper = mapper;
         _validator = validator;
+        _localizationContactService = localizationContactService;
+        _localizationRequisiteService = localizationRequisite;
     }
 
     public async Task<Result<CompanyProfileDto>> Handle(CreateCompanyProfileCommand request, CancellationToken cancellationToken)
@@ -39,18 +48,33 @@ public class CreateCompanyProfileHandler : IRequestHandler<CreateCompanyProfileC
 
             var entity = _mapper.Map<DAL.Entities.CompanyProfile>(request.CreateCompanyProfileDto);
 
-            var now = DateTimeOffset.UtcNow;
-            entity.CreatedAt = now;
-            entity.Contact.CreatedAt = now;
-            entity.Requisite.CreatedAt = now;
-
-            foreach (var socialLink in entity.SocialLinks)
+            using (var scope = _repositoryWrapper.BeginTransaction())
             {
-                socialLink.CreatedAt = now;
-            }
+                await _repositoryWrapper.CompanyProfileRepository.CreateAsync(entity);
 
-            await _repositoryWrapper.CompanyProfileRepository.CreateAsync(entity);
-            await _repositoryWrapper.SaveChangesAsync();
+                if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+                {
+                    return Result.Fail<CompanyProfileDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(DAL.Entities.CompanyProfile)));
+                }
+
+                foreach (var localizationDto in request.CreateCompanyProfileDto.Contacts.Localization)
+                {
+                    var localization = _mapper.Map<CompanyProfileContactLocalization>(localizationDto);
+                    localization.EntityId = entity.Contact.Id;
+                    await _localizationContactService.TrackEntityLocalizationAsync(localization);
+                }
+
+                foreach (var localizationDto in request.CreateCompanyProfileDto.Requisites.Localization)
+                {
+                    var localization = _mapper.Map<CompanyProfileRequisiteLocalization>(localizationDto);
+                    localization.EntityId = entity.Requisite.Id;
+                    await _localizationRequisiteService.TrackEntityLocalizationAsync(localization);
+                }
+
+                await _repositoryWrapper.SaveChangesAsync();
+
+                scope.Complete();
+            }
 
             var created = await _repositoryWrapper.CompanyProfileRepository.GetFirstOrDefaultAsync(new QueryOptions<DAL.Entities.CompanyProfile>
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileHandler.cs
@@ -57,14 +57,14 @@ public class CreateCompanyProfileHandler : IRequestHandler<CreateCompanyProfileC
                     return Result.Fail<CompanyProfileDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(DAL.Entities.CompanyProfile)));
                 }
 
-                foreach (var localizationDto in request.CreateCompanyProfileDto.Contacts.Localization)
+                foreach (var localizationDto in request.CreateCompanyProfileDto.Contacts.Localizations)
                 {
                     var localization = _mapper.Map<CompanyProfileContactLocalization>(localizationDto);
                     localization.EntityId = entity.Contact.Id;
                     await _localizationContactService.TrackEntityLocalizationAsync(localization);
                 }
 
-                foreach (var localizationDto in request.CreateCompanyProfileDto.Requisites.Localization)
+                foreach (var localizationDto in request.CreateCompanyProfileDto.Requisites.Localizations)
                 {
                     var localization = _mapper.Map<CompanyProfileRequisiteLocalization>(localizationDto);
                     localization.EntityId = entity.Requisite.Id;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Create/CreateCompanyProfileHandler.cs
@@ -1,0 +1,81 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+
+public class CreateCompanyProfileHandler : IRequestHandler<CreateCompanyProfileCommand, Result<CompanyProfileDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly IValidator<CreateCompanyProfileCommand> _validator;
+
+    public CreateCompanyProfileHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IMapper mapper,
+        IValidator<CreateCompanyProfileCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<CompanyProfileDto>> Handle(CreateCompanyProfileCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            if ((await _repositoryWrapper.CompanyProfileRepository.GetFirstOrDefaultAsync()) is not null)
+            {
+                return Result.Fail<CompanyProfileDto>(errorMessage: ErrorMessagesConstants.OnlyOneEntityOfTypeIsAllowed(nameof(DAL.Entities.CompanyProfile)));
+            }
+
+            var entity = _mapper.Map<DAL.Entities.CompanyProfile>(request.CreateCompanyProfileDto);
+
+            var now = DateTimeOffset.UtcNow;
+            entity.CreatedAt = now;
+            entity.Contact.CreatedAt = now;
+            entity.Requisite.CreatedAt = now;
+
+            foreach (var socialLink in entity.SocialLinks)
+            {
+                socialLink.CreatedAt = now;
+            }
+
+            await _repositoryWrapper.CompanyProfileRepository.CreateAsync(entity);
+            await _repositoryWrapper.SaveChangesAsync();
+
+            var created = await _repositoryWrapper.CompanyProfileRepository.GetFirstOrDefaultAsync(new QueryOptions<DAL.Entities.CompanyProfile>
+            {
+                Filter = p => p.Id == entity.Id,
+                Include = q => q
+                    .Include(p => p.Contact)
+                        .ThenInclude(c => c.Localizations)
+                        .ThenInclude(l => l.Language)
+                    .Include(p => p.Requisite)
+                        .ThenInclude(r => r.Localizations)
+                        .ThenInclude(l => l.Language)
+                    .Include(p => p.SocialLinks)
+            });
+
+            var resultDto = _mapper.Map<CompanyProfileDto>(created);
+            return Result.Ok(resultDto);
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<CompanyProfileDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<CompanyProfileDto>(
+                ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(DAL.Entities.CompanyProfile)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+
+namespace VictoryCenter.BLL.Commands.Admin.CompanyProfile.Update;
+
+public record UpdateCompanyProfileCommand(UpdateCompanyProfileDto UpdateCompanyProfileDto) : IRequest<Result<CompanyProfileDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileHandler.cs
@@ -70,6 +70,18 @@ public class UpdateCompanyProfileHandler : IRequestHandler<UpdateCompanyProfileC
                 var contactLocalizationByLanguage = entity.Contact.Localizations.ToDictionary(l => l.LanguageId);
                 var requisiteLocalizationByLanguage = entity.Requisite.Localizations.ToDictionary(l => l.LanguageId);
 
+                var requestPlatforms = request.UpdateCompanyProfileDto.SocialLinks
+                    .Select(sl => sl.SocialPlatform)
+                    .ToHashSet();
+
+                foreach (var (platform, linkToRemove) in linksByPlatform)
+                {
+                    if (!requestPlatforms.Contains(platform))
+                    {
+                        entity.SocialLinks.Remove(linkToRemove);
+                    }
+                }
+
                 foreach (var dto in request.UpdateCompanyProfileDto.SocialLinks)
                 {
                     if (linksByPlatform.TryGetValue(dto.SocialPlatform, out var existingLink))

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileHandler.cs
@@ -95,7 +95,7 @@ public class UpdateCompanyProfileHandler : IRequestHandler<UpdateCompanyProfileC
                     entity.SocialLinks.Add(link);
                 }
 
-                foreach (var localizationDto in request.UpdateCompanyProfileDto.Contacts.Localization)
+                foreach (var localizationDto in request.UpdateCompanyProfileDto.Contacts.Localizations)
                 {
                     if(contactLocalizationByLanguage.TryGetValue(localizationDto.LanguageId, out var existingLocalization))
                     {
@@ -108,7 +108,7 @@ public class UpdateCompanyProfileHandler : IRequestHandler<UpdateCompanyProfileC
                     await _localizationContactService.TrackEntityLocalizationForUpdateAsync(localization);
                 }
 
-                foreach (var localizationDto in request.UpdateCompanyProfileDto.Requisites.Localization)
+                foreach (var localizationDto in request.UpdateCompanyProfileDto.Requisites.Localizations)
                 {
                     if(requisiteLocalizationByLanguage.TryGetValue(localizationDto.LanguageId, out var existingLocalization))
                     {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/CompanyProfile/Update/UpdateCompanyProfileHandler.cs
@@ -1,0 +1,143 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.CompanyProfile.Update;
+
+public class UpdateCompanyProfileHandler : IRequestHandler<UpdateCompanyProfileCommand, Result<CompanyProfileDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<CompanyProfileContact, CompanyProfileContactLocalization> _localizationContactService;
+    private readonly ILocalizationService<CompanyProfileRequisite, CompanyProfileRequisiteLocalization> _localizationRequisiteService;
+    private readonly IValidator<UpdateCompanyProfileCommand> _validator;
+
+    public UpdateCompanyProfileHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IMapper mapper,
+        ILocalizationService<CompanyProfileContact, CompanyProfileContactLocalization> localizationContactService,
+        ILocalizationService<CompanyProfileRequisite, CompanyProfileRequisiteLocalization> localizationRequisiteService,
+        IValidator<UpdateCompanyProfileCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _localizationContactService = localizationContactService;
+        _localizationRequisiteService = localizationRequisiteService;
+        _validator = validator;
+    }
+
+    public async Task<Result<CompanyProfileDto>> Handle(UpdateCompanyProfileCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var entity = await _repositoryWrapper.CompanyProfileRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<DAL.Entities.CompanyProfile>
+                {
+                    AsNoTracking = false,
+                    Include = q => q
+                        .Include(p => p.Contact)
+                            .ThenInclude(c => c.Localizations)
+                            .ThenInclude(l => l.Language)
+                        .Include(p => p.Requisite)
+                            .ThenInclude(r => r.Localizations)
+                            .ThenInclude(l => l.Language)
+                        .Include(p => p.SocialLinks)
+                });
+
+            if (entity is null)
+            {
+                return Result.Fail<CompanyProfileDto>(
+                    ErrorMessagesConstants.NotFound());
+            }
+
+            using (var scope = _repositoryWrapper.BeginTransaction())
+            {
+                _mapper.Map(request.UpdateCompanyProfileDto.Contacts, entity.Contact);
+                _mapper.Map(request.UpdateCompanyProfileDto.Requisites, entity.Requisite);
+
+                var linksByPlatform = entity.SocialLinks.ToDictionary(sl => sl.SocialPlatform);
+                var contactLocalizationByLanguage = entity.Contact.Localizations.ToDictionary(l => l.LanguageId);
+                var requisiteLocalizationByLanguage = entity.Requisite.Localizations.ToDictionary(l => l.LanguageId);
+
+                foreach (var dto in request.UpdateCompanyProfileDto.SocialLinks)
+                {
+                    if (linksByPlatform.TryGetValue(dto.SocialPlatform, out var existingLink))
+                    {
+                        _mapper.Map(dto, existingLink);
+                        continue;
+                    }
+
+                    var link = _mapper.Map<CompanyProfileSocialLink>(dto);
+                    link.ProfileId = entity.Id;
+                    entity.SocialLinks.Add(link);
+                }
+
+                foreach (var localizationDto in request.UpdateCompanyProfileDto.Contacts.Localization)
+                {
+                    if(contactLocalizationByLanguage.TryGetValue(localizationDto.LanguageId, out var existingLocalization))
+                    {
+                        _mapper.Map(localizationDto, existingLocalization);
+                        continue;
+                    }
+
+                    var localization = _mapper.Map<CompanyProfileContactLocalization>(localizationDto);
+                    localization.EntityId = entity.Contact.Id;
+                    await _localizationContactService.TrackEntityLocalizationForUpdateAsync(localization);
+                }
+
+                foreach (var localizationDto in request.UpdateCompanyProfileDto.Requisites.Localization)
+                {
+                    if(requisiteLocalizationByLanguage.TryGetValue(localizationDto.LanguageId, out var existingLocalization))
+                    {
+                        _mapper.Map(localizationDto, existingLocalization);
+                        continue;
+                    }
+
+                    var localization = _mapper.Map<CompanyProfileRequisiteLocalization>(localizationDto);
+                    localization.EntityId = entity.Requisite.Id;
+                    await _localizationRequisiteService.TrackEntityLocalizationForUpdateAsync(localization);
+                }
+
+                await _repositoryWrapper.SaveChangesAsync();
+
+                scope.Complete();
+            }
+
+            var created = await _repositoryWrapper.CompanyProfileRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<DAL.Entities.CompanyProfile>
+                {
+                    Filter = p => p.Id == entity.Id,
+                    Include = q => q
+                        .Include(p => p.Contact)
+                            .ThenInclude(c => c.Localizations)
+                            .ThenInclude(l => l.Language)
+                        .Include(p => p.Requisite)
+                            .ThenInclude(r => r.Localizations)
+                            .ThenInclude(l => l.Language)
+                        .Include(p => p.SocialLinks)
+                });
+
+            return Result.Ok(_mapper.Map<CompanyProfileDto>(created));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<CompanyProfileDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<CompanyProfileDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(DAL.Entities.CompanyProfile)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/CompanyProfileConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/CompanyProfileConstants.cs
@@ -42,4 +42,9 @@ public static class CompanyProfileConstants
     {
         public static readonly int MaxLength = 500;
     }
+
+    public static class SocialLinks
+    {
+        public static readonly int MaxCount = 4;
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/CompanyProfileConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/CompanyProfileConstants.cs
@@ -1,0 +1,45 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class CompanyProfileConstants
+{
+    public static class Phone
+    {
+        public static readonly int MaxLength = 20;
+    }
+
+    public static class Address
+    {
+        public static readonly int MaxLength = 100;
+    }
+
+    public static class Email
+    {
+        public static readonly int MaxLength = 50;
+    }
+
+    public static class CorrespondenceEmail
+    {
+        public static readonly int MaxLength = 50;
+    }
+
+    public static class Motto
+    {
+        public static readonly int MaxLength = 200;
+    }
+
+    public static class Recipient
+    {
+        public static readonly int MaxLength = 100;
+    }
+
+    public static class Edrpou
+    {
+        public static readonly int MaxLength = 8;
+        public static readonly int MinLength = 8;
+    }
+
+    public static class SocialLinkUrl
+    {
+        public static readonly int MaxLength = 500;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -36,6 +36,11 @@ public static class ErrorMessagesConstants
         return $"Cannot update and delete the same entity {entityType.Name}. Conflicting IDs: {string.Join(", ", ids)}";
     }
 
+    public static string OnlyOneEntityOfTypeIsAllowed(string entityTypeName)
+    {
+        return $"Only one instance of {entityTypeName} is allowed";
+    }
+
     public static string FailedToCreateEntity(Type entityType)
     {
         ArgumentNullException.ThrowIfNull(entityType);

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/BaseCompanyProfileContactsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/BaseCompanyProfileContactsDto.cs
@@ -1,0 +1,10 @@
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+
+public record BaseCompanyProfileContactsDto
+{
+    public string Phone { get; set; } = null!;
+    public string Address { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string CorrespondenceEmail { get; set; } = null!;
+    public string Motto { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/CompanyProfileContactsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/CompanyProfileContactsDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+
+public record CompanyProfileContactsDto : BaseCompanyProfileContactsDto
+{
+    public List<CompanyProfileContactLocalizationDto> Localizations { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/CreateCompanyProfileContactsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/CreateCompanyProfileContactsDto.cs
@@ -4,5 +4,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
 
 public record CreateCompanyProfileContactsDto : BaseCompanyProfileContactsDto
 {
-    public List<CreateCompanyProfileContactLocalizationDto> Localization { get; set; } = [];
+    public List<CreateCompanyProfileContactLocalizationDto> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/CreateCompanyProfileContactsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/CreateCompanyProfileContactsDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+
+public record CreateCompanyProfileContactsDto : BaseCompanyProfileContactsDto
+{
+    public List<CreateCompanyProfileContactLocalizationDto> Localization { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/UpdateCompanyProfileContactDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/UpdateCompanyProfileContactDto.cs
@@ -1,6 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
 namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
 
 public record UpdateCompanyProfileContactDto : BaseCompanyProfileContactsDto
 {
-
+    public List<UpdateCompanyProfileContactLocalizationDto> Localization { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/UpdateCompanyProfileContactDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/UpdateCompanyProfileContactDto.cs
@@ -4,5 +4,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
 
 public record UpdateCompanyProfileContactDto : BaseCompanyProfileContactsDto
 {
-    public List<UpdateCompanyProfileContactLocalizationDto> Localization { get; set; } = [];
+    public List<UpdateCompanyProfileContactLocalizationDto> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/UpdateCompanyProfileContactDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileContacts/UpdateCompanyProfileContactDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+
+public record UpdateCompanyProfileContactDto : BaseCompanyProfileContactsDto
+{
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/BaseCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/BaseCompanyProfileRequisiteDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+
+public record BaseCompanyProfileRequisiteDto
+{
+    public string Recipient { get; set; } = null!;
+    public string Edrpou { get; set; } = null!;
+    public string Address { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/BaseCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/BaseCompanyProfileRequisiteDto.cs
@@ -1,4 +1,4 @@
-namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record BaseCompanyProfileRequisiteDto
 {

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CompanyProfileRequisiteDto.cs
@@ -1,6 +1,6 @@
 using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 
-namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record CompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
 {

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CompanyProfileRequisiteDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+
+public record CompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
+{
+    public List<CompanyProfileRequisiteLocalizationDto> Localizations { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CreateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CreateCompanyProfileRequisiteDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+
+public record CreateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
+{
+    public List<CreateCompanyProfileRequisiteLocalizationDto> Localization { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CreateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CreateCompanyProfileRequisiteDto.cs
@@ -1,6 +1,6 @@
 using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 
-namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record CreateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
 {

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CreateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/CreateCompanyProfileRequisiteDto.cs
@@ -4,5 +4,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record CreateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
 {
-    public List<CreateCompanyProfileRequisiteLocalizationDto> Localization { get; set; } = [];
+    public List<CreateCompanyProfileRequisiteLocalizationDto> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
@@ -1,6 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
 namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record UpdateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
 {
-
+    public List<UpdateCompanyProfileRequisiteLocalizationDto> Localization { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
@@ -1,4 +1,4 @@
-namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record UpdateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
 {

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+
+public record UpdateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
+{
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfileRequisites/UpdateCompanyProfileRequisiteDto.cs
@@ -4,5 +4,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 public record UpdateCompanyProfileRequisiteDto : BaseCompanyProfileRequisiteDto
 {
-    public List<UpdateCompanyProfileRequisiteLocalizationDto> Localization { get; set; } = [];
+    public List<UpdateCompanyProfileRequisiteLocalizationDto> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/BaseCompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/BaseCompanyProfileDto.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+
+public class BaseCompanyProfileDto<TContacts, TRequisites, TSocialLink>
+    where TContacts : BaseCompanyProfileContactsDto
+    where TRequisites : BaseCompanyProfileRequisiteDto
+    where TSocialLink : BaseSocialLinkDto
+{
+    public TContacts Contacts { get; set; } = null!;
+    public TRequisites Requisites { get; set; } = null!;
+    public List<TSocialLink> SocialLinks { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CompanyProfileDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+
+public record CompanyProfileDto
+{
+    public CompanyProfileContactsDto Contacts { get; set; } = null!;
+    public CompanyProfileRequisiteDto Requisites { get; set; } = null!;
+    public List<SocialLinkDto> SocialLinks { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CompanyProfileDto.cs
@@ -1,5 +1,5 @@
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
-using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
 
 namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CreateCompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CreateCompanyProfileDto.cs
@@ -1,6 +1,5 @@
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
-using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
 
 namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CreateCompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CreateCompanyProfileDto.cs
@@ -1,5 +1,5 @@
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
-using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CreateCompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/CreateCompanyProfileDto.cs
@@ -1,0 +1,13 @@
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+
+public class CreateCompanyProfileDto
+{
+    public CreateCompanyProfileContactsDto Contacts { get; set; } = null!;
+    public CreateCompanyProfileRequisiteDto Requisites { get; set; } = null!;
+    public List<CreateSocialLinkDto> SocialLinks { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/UpdateCompanyProfileDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/CompanyProfiles/UpdateCompanyProfileDto.cs
@@ -4,7 +4,7 @@ using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
 
 namespace VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
 
-public class CreateCompanyProfileDto
-    : BaseCompanyProfileDto<CreateCompanyProfileContactsDto, CreateCompanyProfileRequisiteDto, CreateSocialLinkDto>
+public class UpdateCompanyProfileDto
+    : BaseCompanyProfileDto<UpdateCompanyProfileContactDto, UpdateCompanyProfileRequisiteDto, UpdateSocialLinkDto>
 {
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/BaseCompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/BaseCompanyProfileContactLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record BaseCompanyProfileContactLocalizationDto
+{
+    public string? Address { get; init; }
+    public string? Motto { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/BaseCompanyProfileRequisiteLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/BaseCompanyProfileRequisiteLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record BaseCompanyProfileRequisiteLocalizationDto
+{
+    public string? Recipient { get; init; }
+    public string? Address { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileContactLocalizationDto.cs
@@ -10,5 +10,4 @@ public record CompanyProfileContactLocalizationDto : BaseCompanyProfileContactLo
     public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
 
     public TranslationStatus TranslationStatus { get; init; }
-
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileContactLocalizationDto.cs
@@ -1,5 +1,5 @@
 using VictoryCenter.BLL.DTOs.Common;
-using VictoryCenter.DAL.Migrations;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 
@@ -9,6 +9,6 @@ public record CompanyProfileContactLocalizationDto : BaseCompanyProfileContactLo
 
     public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
 
-    public TranslationStatus TranslationStatus { get; init; } = null!;
+    public TranslationStatus TranslationStatus { get; init; }
 
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileContactLocalizationDto.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Migrations;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record CompanyProfileContactLocalizationDto : BaseCompanyProfileContactLocalizationDto
+{
+    public long EntityId { get; init; }
+
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+
+    public TranslationStatus TranslationStatus { get; init; } = null!;
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileRequisiteLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileRequisiteLocalizationDto.cs
@@ -1,5 +1,5 @@
 using VictoryCenter.BLL.DTOs.Common;
-using VictoryCenter.DAL.Migrations;
+using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 
@@ -9,6 +9,6 @@ public record CompanyProfileRequisiteLocalizationDto : BaseCompanyProfileRequisi
 
     public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
 
-    public TranslationStatus TranslationStatus { get; init; } = null!;
+    public TranslationStatus TranslationStatus { get; init; }
 
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileRequisiteLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CompanyProfileRequisiteLocalizationDto.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Migrations;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record CompanyProfileRequisiteLocalizationDto : BaseCompanyProfileRequisiteLocalizationDto
+{
+    public long EntityId { get; init; }
+
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+
+    public TranslationStatus TranslationStatus { get; init; } = null!;
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CreateCompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CreateCompanyProfileContactLocalizationDto.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record CreateCompanyProfileContactLocalizationDto : BaseCompanyProfileContactLocalizationDto, ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CreateCompanyProfileRequisiteLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/CreateCompanyProfileRequisiteLocalizationDto.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record CreateCompanyProfileRequisiteLocalizationDto : BaseCompanyProfileRequisiteLocalizationDto, ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileContactLocalizationDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record UpdateCompanyProfileContactLocalizationDto : BaseCompanyProfileContactLocalizationDto
+{
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileContactLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileContactLocalizationDto.cs
@@ -2,5 +2,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 
 public record UpdateCompanyProfileContactLocalizationDto : BaseCompanyProfileContactLocalizationDto
 {
-
+    public long LanguageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileRequisiteLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileRequisiteLocalizationDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+
+public record UpdateCompanyProfileRequisiteLocalizationDto : BaseCompanyProfileRequisiteLocalizationDto
+{
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileRequisiteLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/CompanyProfile/UpdateCompanyProfileRequisiteLocalizationDto.cs
@@ -2,5 +2,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 
 public record UpdateCompanyProfileRequisiteLocalizationDto : BaseCompanyProfileRequisiteLocalizationDto
 {
-
+    public long LanguageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/BaseSocialLinkDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/BaseSocialLinkDto.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+public record BaseSocialLinkDto
+{
+    public SocialPlatform SocialPlatform { get; set; }
+    public string Url { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/CreateSocialLinkDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/CreateSocialLinkDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+public record CreateSocialLinkDto : BaseSocialLinkDto
+{
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/SocialLinkDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/SocialLinkDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+public record SocialLinkDto : BaseSocialLinkDto
+{
+
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/UpdateSocialLinkDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/UpdateSocialLinkDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+public record UpdateSocialLinkDto : BaseSocialLinkDto
+{
+    public long Id { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/UpdateSocialLinkDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/SocialLinks/UpdateSocialLinkDto.cs
@@ -2,5 +2,4 @@ namespace VictoryCenter.BLL.DTOs.Admin.SocialLinks;
 
 public record UpdateSocialLinkDto : BaseSocialLinkDto
 {
-    public long Id { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/CompanyProfile/CompanyProfileMappingProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/CompanyProfile/CompanyProfileMappingProfile.cs
@@ -1,6 +1,6 @@
 using AutoMapper;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
-using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
 using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
 using VictoryCenter.BLL.DTOs.Admin.SocialLinks;

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/CompanyProfile/CompanyProfileMappingProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/CompanyProfile/CompanyProfileMappingProfile.cs
@@ -1,0 +1,71 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using CompanyProfileEntity = VictoryCenter.DAL.Entities.CompanyProfile;
+
+namespace VictoryCenter.BLL.Mapping.CompanyProfile;
+
+public class CompanyProfileMappingProfile : Profile
+{
+    public CompanyProfileMappingProfile()
+    {
+        CreateMap<CreateCompanyProfileDto, CompanyProfileEntity>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Contact, opt => opt.MapFrom(src => src.Contacts))
+            .ForMember(dest => dest.Requisite, opt => opt.MapFrom(src => src.Requisites))
+            .ForMember(dest => dest.SocialLinks, opt => opt.MapFrom(src => src.SocialLinks));
+
+        CreateMap<CreateCompanyProfileContactsDto, CompanyProfileContact>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
+            .ForMember(dest => dest.Profile, opt => opt.Ignore())
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore());
+
+        CreateMap<CreateCompanyProfileRequisiteDto, CompanyProfileRequisite>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
+            .ForMember(dest => dest.Profile, opt => opt.Ignore())
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore());
+
+        CreateMap<CreateSocialLinkDto, CompanyProfileSocialLink>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
+            .ForMember(dest => dest.Profile, opt => opt.Ignore());
+
+        CreateMap<CompanyProfileEntity, CompanyProfileDto>()
+            .ForMember(dest => dest.Contacts, opt => opt.MapFrom(src => src.Contact))
+            .ForMember(dest => dest.Requisites, opt => opt.MapFrom(src => src.Requisite));
+
+        CreateMap<CompanyProfileContact, CompanyProfileContactsDto>();
+        CreateMap<CompanyProfileRequisite, CompanyProfileRequisiteDto>();
+        CreateMap<CompanyProfileSocialLink, SocialLinkDto>();
+
+        CreateMap<CompanyProfileContactLocalization, CompanyProfileContactLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+
+        CreateMap<CompanyProfileRequisiteLocalization, CompanyProfileRequisiteLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+
+        CreateMap<CreateCompanyProfileContactLocalizationDto, CompanyProfileContactLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateCompanyProfileContactLocalizationDto, CompanyProfileContactLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<CreateCompanyProfileRequisiteLocalizationDto, CompanyProfileRequisiteLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateCompanyProfileRequisiteLocalizationDto, CompanyProfileRequisiteLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/CompanyProfile/CompanyProfileMappingProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/CompanyProfile/CompanyProfileMappingProfile.cs
@@ -42,6 +42,32 @@ public class CompanyProfileMappingProfile : Profile
             .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
             .ForMember(dest => dest.Profile, opt => opt.Ignore());
 
+        CreateMap<UpdateCompanyProfileDto, CompanyProfileEntity>()
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Contact, opt => opt.MapFrom(src => src.Contacts))
+            .ForMember(dest => dest.Requisite, opt => opt.MapFrom(src => src.Requisites))
+            .ForMember(dest => dest.SocialLinks, opt => opt.MapFrom(src => src.SocialLinks));
+
+        CreateMap<UpdateCompanyProfileContactDto, CompanyProfileContact>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
+            .ForMember(dest => dest.Profile, opt => opt.Ignore())
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore());
+
+        CreateMap<UpdateCompanyProfileRequisiteDto, CompanyProfileRequisite>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
+            .ForMember(dest => dest.Profile, opt => opt.Ignore())
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore());
+
+        CreateMap<UpdateSocialLinkDto, CompanyProfileSocialLink>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.ProfileId, opt => opt.Ignore())
+            .ForMember(dest => dest.Profile, opt => opt.Ignore());
+
         CreateMap<CompanyProfileEntity, CompanyProfileDto>()
             .ForMember(dest => dest.Contacts, opt => opt.MapFrom(src => src.Contact))
             .ForMember(dest => dest.Requisites, opt => opt.MapFrom(src => src.Requisite));
@@ -60,12 +86,20 @@ public class CompanyProfileMappingProfile : Profile
             .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
 
         CreateMap<UpdateCompanyProfileContactLocalizationDto, CompanyProfileContactLocalization>()
-            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant))
+            .ForMember(dest => dest.EntityId, opt => opt.Ignore())
+            .ForMember(dest => dest.Entity, opt => opt.Ignore())
+            .ForMember(dest => dest.Language, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore());
 
         CreateMap<CreateCompanyProfileRequisiteLocalizationDto, CompanyProfileRequisiteLocalization>()
             .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
 
         CreateMap<UpdateCompanyProfileRequisiteLocalizationDto, CompanyProfileRequisiteLocalization>()
-            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant))
+            .ForMember(dest => dest.EntityId, opt => opt.Ignore())
+            .ForMember(dest => dest.Entity, opt => opt.Ignore())
+            .ForMember(dest => dest.Language, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore());
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileHandler.cs
@@ -1,0 +1,47 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Public.CompanyProfile.Get;
+
+public class GetCompanyProfileHandler : IRequestHandler<GetCompanyProfileQuery, Result<CompanyProfileDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+
+    public GetCompanyProfileHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<CompanyProfileDto>> Handle(GetCompanyProfileQuery request, CancellationToken cancellationToken)
+    {
+        var entity = await _repositoryWrapper.CompanyProfileRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<DAL.Entities.CompanyProfile>
+            {
+                Include = q => q
+                    .Include(p => p.Contact)
+                        .ThenInclude(c => c.Localizations)
+                        .ThenInclude(l => l.Language)
+                    .Include(p => p.Requisite)
+                        .ThenInclude(r => r.Localizations)
+                        .ThenInclude(l => l.Language)
+                    .Include(p => p.SocialLinks),
+                AsNoTracking = true
+            });
+
+        if (entity is null)
+        {
+            return Result.Fail<CompanyProfileDto>(
+                ErrorMessagesConstants.NotFound(null, typeof(DAL.Entities.CompanyProfile)));
+        }
+
+        return Result.Ok(_mapper.Map<CompanyProfileDto>(entity));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileHandler.cs
@@ -39,7 +39,7 @@ public class GetCompanyProfileHandler : IRequestHandler<GetCompanyProfileQuery, 
         if (entity is null)
         {
             return Result.Fail<CompanyProfileDto>(
-                ErrorMessagesConstants.NotFound(null, typeof(DAL.Entities.CompanyProfile)));
+                ErrorMessagesConstants.NotFound());
         }
 
         return Result.Ok(_mapper.Map<CompanyProfileDto>(entity));

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+
+namespace VictoryCenter.BLL.Queries.Public.CompanyProfile.Get;
+
+public record GetCompanyProfileQuery : IRequest<Result<CompanyProfileDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/CreateCompanyProfileCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/CreateCompanyProfileCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+using VictoryCenter.BLL.Validators.CompanyProfile.Dto;
+
+namespace VictoryCenter.BLL.Validators.CompanyProfile.Commands;
+
+public class CreateCompanyProfileCommandValidator : AbstractValidator<CreateCompanyProfileCommand>
+{
+    public CreateCompanyProfileCommandValidator()
+    {
+        RuleFor(x => x.CreateCompanyProfileDto)
+            .NotNull();
+
+        RuleFor(x => x.CreateCompanyProfileDto.Contacts)
+            .NotNull()
+            .SetValidator(new BaseCompanyProfileContactDtoValidator())
+            .When(x => x.CreateCompanyProfileDto is not null);
+
+        RuleFor(x => x.CreateCompanyProfileDto.Requisites)
+            .NotNull()
+            .SetValidator(new BaseCompanyProfileRequisiteDtoValidator())
+            .When(x => x.CreateCompanyProfileDto is not null);
+
+        RuleForEach(x => x.CreateCompanyProfileDto.SocialLinks)
+            .SetValidator(new BaseSocialLinkDtoValidator())
+            .When(x => x.CreateCompanyProfileDto is not null);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/CreateCompanyProfileCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/CreateCompanyProfileCommandValidator.cs
@@ -16,7 +16,6 @@ public class CreateCompanyProfileCommandValidator : AbstractValidator<CreateComp
             .SetValidator(new BaseCompanyProfileDtoValidator<
                 CreateCompanyProfileContactsDto,
                 CreateCompanyProfileRequisiteDto,
-                CreateSocialLinkDto>())
-            .When(x => x.CreateCompanyProfileDto is not null);
+                CreateSocialLinkDto>());
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/CreateCompanyProfileCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/CreateCompanyProfileCommandValidator.cs
@@ -1,5 +1,8 @@
 using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
 using VictoryCenter.BLL.Validators.CompanyProfile.Dto;
 
 namespace VictoryCenter.BLL.Validators.CompanyProfile.Commands;
@@ -9,20 +12,11 @@ public class CreateCompanyProfileCommandValidator : AbstractValidator<CreateComp
     public CreateCompanyProfileCommandValidator()
     {
         RuleFor(x => x.CreateCompanyProfileDto)
-            .NotNull();
-
-        RuleFor(x => x.CreateCompanyProfileDto.Contacts)
             .NotNull()
-            .SetValidator(new BaseCompanyProfileContactDtoValidator())
-            .When(x => x.CreateCompanyProfileDto is not null);
-
-        RuleFor(x => x.CreateCompanyProfileDto.Requisites)
-            .NotNull()
-            .SetValidator(new BaseCompanyProfileRequisiteDtoValidator())
-            .When(x => x.CreateCompanyProfileDto is not null);
-
-        RuleForEach(x => x.CreateCompanyProfileDto.SocialLinks)
-            .SetValidator(new BaseSocialLinkDtoValidator())
+            .SetValidator(new BaseCompanyProfileDtoValidator<
+                CreateCompanyProfileContactsDto,
+                CreateCompanyProfileRequisiteDto,
+                CreateSocialLinkDto>())
             .When(x => x.CreateCompanyProfileDto is not null);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/UpdateCompanyProfileCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/UpdateCompanyProfileCommandValidator.cs
@@ -18,8 +18,7 @@ public class UpdateCompanyProfileCommandValidator : AbstractValidator<UpdateComp
             .SetValidator(new BaseCompanyProfileDtoValidator<
                 UpdateCompanyProfileContactDto,
                 UpdateCompanyProfileRequisiteDto,
-                UpdateSocialLinkDto>())
-            .When(x => x.UpdateCompanyProfileDto is not null);
+                UpdateSocialLinkDto>());
 
         When(x => x.UpdateCompanyProfileDto is not null, () =>
         {

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/UpdateCompanyProfileCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/UpdateCompanyProfileCommandValidator.cs
@@ -22,14 +22,14 @@ public class UpdateCompanyProfileCommandValidator : AbstractValidator<UpdateComp
 
         When(x => x.UpdateCompanyProfileDto is not null, () =>
         {
-            RuleForEach(x => x.UpdateCompanyProfileDto.Contacts.Localization)
+            RuleForEach(x => x.UpdateCompanyProfileDto.Contacts.Localizations)
                 .ChildRules(l => l
                     .RuleFor(x => x.LanguageId)
                     .GreaterThan(0)
                     .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateCompanyProfileContactLocalizationDto.LanguageId))))
                 .When(x => x.UpdateCompanyProfileDto.Contacts is not null);
 
-            RuleForEach(x => x.UpdateCompanyProfileDto.Requisites.Localization)
+            RuleForEach(x => x.UpdateCompanyProfileDto.Requisites.Localizations)
                 .ChildRules(l => l
                     .RuleFor(x => x.LanguageId)
                     .GreaterThan(0)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/UpdateCompanyProfileCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Commands/UpdateCompanyProfileCommandValidator.cs
@@ -1,0 +1,41 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+using VictoryCenter.BLL.Validators.CompanyProfile.Dto;
+
+namespace VictoryCenter.BLL.Validators.CompanyProfile.Commands;
+
+public class UpdateCompanyProfileCommandValidator : AbstractValidator<UpdateCompanyProfileCommand>
+{
+    public UpdateCompanyProfileCommandValidator()
+    {
+        RuleFor(x => x.UpdateCompanyProfileDto)
+            .NotNull()
+            .SetValidator(new BaseCompanyProfileDtoValidator<
+                UpdateCompanyProfileContactDto,
+                UpdateCompanyProfileRequisiteDto,
+                UpdateSocialLinkDto>())
+            .When(x => x.UpdateCompanyProfileDto is not null);
+
+        When(x => x.UpdateCompanyProfileDto is not null, () =>
+        {
+            RuleForEach(x => x.UpdateCompanyProfileDto.Contacts.Localization)
+                .ChildRules(l => l
+                    .RuleFor(x => x.LanguageId)
+                    .GreaterThan(0)
+                    .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateCompanyProfileContactLocalizationDto.LanguageId))))
+                .When(x => x.UpdateCompanyProfileDto.Contacts is not null);
+
+            RuleForEach(x => x.UpdateCompanyProfileDto.Requisites.Localization)
+                .ChildRules(l => l
+                    .RuleFor(x => x.LanguageId)
+                    .GreaterThan(0)
+                    .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateCompanyProfileRequisiteLocalizationDto.LanguageId))))
+                .When(x => x.UpdateCompanyProfileDto.Requisites is not null);
+        });
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileContactDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileContactDtoValidator.cs
@@ -1,0 +1,53 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+
+namespace VictoryCenter.BLL.Validators.CompanyProfile.Dto;
+
+public class BaseCompanyProfileContactDtoValidator : AbstractValidator<BaseCompanyProfileContactsDto>
+{
+    public BaseCompanyProfileContactDtoValidator()
+    {
+        RuleFor(x => x.Phone)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.Phone)))
+            .MaximumLength(CompanyProfileConstants.Phone.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileContactsDto.Phone), CompanyProfileConstants.Phone.MaxLength));
+
+        RuleFor(x => x.Address)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.Address)))
+            .MaximumLength(CompanyProfileConstants.Address.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileContactsDto.Address), CompanyProfileConstants.Address.MaxLength));
+
+        RuleFor(x => x.Email)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.Email)))
+            .MaximumLength(CompanyProfileConstants.Email.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileContactsDto.Email), CompanyProfileConstants.Email.MaxLength))
+            .EmailAddress()
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(BaseCompanyProfileContactsDto.Email)));
+
+        RuleFor(x => x.CorrespondenceEmail)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.CorrespondenceEmail)))
+            .MaximumLength(CompanyProfileConstants.CorrespondenceEmail.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileContactsDto.CorrespondenceEmail), CompanyProfileConstants.CorrespondenceEmail.MaxLength))
+            .EmailAddress()
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(BaseCompanyProfileContactsDto.CorrespondenceEmail)));
+
+        RuleFor(x => x.Motto)
+            .MaximumLength(CompanyProfileConstants.Motto.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileContactsDto.Motto), CompanyProfileConstants.Motto.MaxLength))
+            .When(x => x.Motto is not null);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+namespace VictoryCenter.BLL.Validators.CompanyProfile.Dto;
+
+public class BaseCompanyProfileDtoValidator<TContacts, TRequisites, TSocialLink>
+    : AbstractValidator<BaseCompanyProfileDto<TContacts, TRequisites, TSocialLink>>
+    where TContacts : BaseCompanyProfileContactsDto
+    where TRequisites : BaseCompanyProfileRequisiteDto
+    where TSocialLink : BaseSocialLinkDto
+{
+    public BaseCompanyProfileDtoValidator()
+    {
+        RuleFor(x => x.Contacts)
+            .NotNull()
+            .SetValidator(new BaseCompanyProfileContactDtoValidator())
+            .When(x => x.Contacts is not null);
+
+        RuleFor(x => x.Requisites)
+            .NotNull()
+            .SetValidator(new BaseCompanyProfileRequisiteDtoValidator())
+            .When(x => x.Requisites is not null);
+
+        RuleForEach(x => x.SocialLinks)
+            .SetValidator(new BaseSocialLinkDtoValidator());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
@@ -21,6 +22,15 @@ public class BaseCompanyProfileDtoValidator<TContacts, TRequisites, TSocialLink>
         RuleFor(x => x.Requisites)
             .NotNull()
             .SetValidator(new BaseCompanyProfileRequisiteDtoValidator());
+
+        RuleFor(x => x.SocialLinks)
+            .Must(list => list.Count <= CompanyProfileConstants.SocialLinks.MaxCount)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(BaseCompanyProfileDto<TContacts, TRequisites, TSocialLink>.SocialLinks),
+                CompanyProfileConstants.SocialLinks.MaxCount))
+            .Must(list => list.Select(sl => sl.SocialPlatform).Distinct().Count() == list.Count)
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(BaseCompanyProfileDto<TContacts, TRequisites, TSocialLink>.SocialLinks)));
 
         RuleForEach(x => x.SocialLinks)
             .SetValidator(new BaseSocialLinkDtoValidator());

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
@@ -16,13 +16,11 @@ public class BaseCompanyProfileDtoValidator<TContacts, TRequisites, TSocialLink>
     {
         RuleFor(x => x.Contacts)
             .NotNull()
-            .SetValidator(new BaseCompanyProfileContactDtoValidator())
-            .When(x => x.Contacts is not null);
+            .SetValidator(new BaseCompanyProfileContactDtoValidator());
 
         RuleFor(x => x.Requisites)
             .NotNull()
-            .SetValidator(new BaseCompanyProfileRequisiteDtoValidator())
-            .When(x => x.Requisites is not null);
+            .SetValidator(new BaseCompanyProfileRequisiteDtoValidator());
 
         RuleForEach(x => x.SocialLinks)
             .SetValidator(new BaseSocialLinkDtoValidator());

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileDtoValidator.cs
@@ -24,11 +24,11 @@ public class BaseCompanyProfileDtoValidator<TContacts, TRequisites, TSocialLink>
             .SetValidator(new BaseCompanyProfileRequisiteDtoValidator());
 
         RuleFor(x => x.SocialLinks)
-            .Must(list => list.Count <= CompanyProfileConstants.SocialLinks.MaxCount)
+            .Must(list => list is null || list.Count <= CompanyProfileConstants.SocialLinks.MaxCount)
             .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
                 nameof(BaseCompanyProfileDto<TContacts, TRequisites, TSocialLink>.SocialLinks),
                 CompanyProfileConstants.SocialLinks.MaxCount))
-            .Must(list => list.Select(sl => sl.SocialPlatform).Distinct().Count() == list.Count)
+            .Must(list => list is null || list.Select(sl => sl.SocialPlatform).Distinct().Count() == list.Count)
             .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
                 nameof(BaseCompanyProfileDto<TContacts, TRequisites, TSocialLink>.SocialLinks)));
 

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileRequisiteDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileRequisiteDtoValidator.cs
@@ -1,6 +1,6 @@
 using FluentValidation;
 using VictoryCenter.BLL.Constants;
-using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 
 namespace VictoryCenter.BLL.Validators.CompanyProfile.Dto;
 

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileRequisiteDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseCompanyProfileRequisiteDtoValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisite;
+
+namespace VictoryCenter.BLL.Validators.CompanyProfile.Dto;
+
+public class BaseCompanyProfileRequisiteDtoValidator : AbstractValidator<BaseCompanyProfileRequisiteDto>
+{
+    public BaseCompanyProfileRequisiteDtoValidator()
+    {
+        RuleFor(x => x.Recipient)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileRequisiteDto.Recipient)))
+            .MaximumLength(CompanyProfileConstants.Recipient.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileRequisiteDto.Recipient), CompanyProfileConstants.Recipient.MaxLength));
+
+        RuleFor(x => x.Edrpou)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileRequisiteDto.Edrpou)))
+            .Length(CompanyProfileConstants.Edrpou.MinLength, CompanyProfileConstants.Edrpou.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveALengthOfNCharacters(
+                nameof(BaseCompanyProfileRequisiteDto.Edrpou), CompanyProfileConstants.Edrpou.MaxLength))
+            .Matches(ErrorMessagesConstants.OnlyDigitsExpression)
+            .WithMessage(ErrorMessagesConstants.PropertyMustContainOnlyDigits(nameof(BaseCompanyProfileRequisiteDto.Edrpou)));
+
+        RuleFor(x => x.Address)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileRequisiteDto.Address)))
+            .MaximumLength(CompanyProfileConstants.Address.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseCompanyProfileRequisiteDto.Address), CompanyProfileConstants.Address.MaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseSocialLinkDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/CompanyProfile/Dto/BaseSocialLinkDtoValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+
+namespace VictoryCenter.BLL.Validators.CompanyProfile.Dto;
+
+public class BaseSocialLinkDtoValidator : AbstractValidator<BaseSocialLinkDto>
+{
+    public BaseSocialLinkDtoValidator()
+    {
+        RuleFor(x => x.SocialPlatform)
+            .IsInEnum()
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(BaseSocialLinkDto.SocialPlatform)));
+
+        RuleFor(x => x.Url)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseSocialLinkDto.Url)))
+            .MaximumLength(CompanyProfileConstants.SocialLinkUrl.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseSocialLinkDto.Url), CompanyProfileConstants.SocialLinkUrl.MaxLength))
+            .Must(url => Uri.TryCreate(url, UriKind.Absolute, out _))
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(nameof(BaseSocialLinkDto.Url)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -22,6 +22,8 @@ using VictoryCenter.DAL.Repositories.Interfaces.PdfSection;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -63,6 +65,12 @@ public interface IRepositoryWrapper
     IReportFundsExpendituresCategoriesRepository ReportFundsExpendituresCategoriesRepository { get; }
     IReportFundsExpendituresRecordsRepository ReportFundsExpendituresRecordsRepository { get; }
     IReportFundsExpendituresSettingsRepository ReportFundsExpendituresSettingsRepository { get; }
+
+    ICompanyProfileRepository CompanyProfileRepository { get; }
+    ICompanyProfileContactRepository CompanyProfileContactRepository { get; }
+    ICompanyProfileRequisiteRepository CompanyProfileRequisiteRepository { get; }
+    ICompanyProfileContactLocalizationsRepository CompanyProfileContactLocalizationsRepository { get; }
+    ICompanyProfileRequisiteLocalizationsRepository CompanyProfileRequisiteLocalizationsRepository { get; }
 
     IRepositoryBase<TEntity> GetRepository<TEntity>()
         where TEntity : class;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/CompanyProfile/ICompanyProfileContactRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/CompanyProfile/ICompanyProfileContactRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+
+public interface ICompanyProfileContactRepository : IRepositoryBase<CompanyProfileContact>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/CompanyProfile/ICompanyProfileRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/CompanyProfile/ICompanyProfileRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using CompanyProfileEntity = VictoryCenter.DAL.Entities.CompanyProfile;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+
+public interface ICompanyProfileRepository : IRepositoryBase<CompanyProfileEntity>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/CompanyProfile/ICompanyProfileRequisiteRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/CompanyProfile/ICompanyProfileRequisiteRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+
+public interface ICompanyProfileRequisiteRepository : IRepositoryBase<CompanyProfileRequisite>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/CompanyProfile/ICompanyProfileContactLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/CompanyProfile/ICompanyProfileContactLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+
+public interface ICompanyProfileContactLocalizationsRepository : IRepositoryBase<CompanyProfileContactLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/CompanyProfile/ICompanyProfileRequisiteLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/CompanyProfile/ICompanyProfileRequisiteLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+
+public interface ICompanyProfileRequisiteLocalizationsRepository : IRepositoryBase<CompanyProfileRequisiteLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -48,6 +48,10 @@ using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreSections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyPrograms;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyPrograms;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.CompanyProfile;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -87,6 +91,11 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IHippotherapyProgramsLocalizationsRepository? _programsLocalizationsRepository;
     private IProgramSectionContentsRepository? _programSectionContentsRepository;
     private IProgramSectionContentLocalizationsRepository? _programSectionContentLocalizationsRepository;
+    private ICompanyProfileRepository? _companyProfileRepository;
+    private ICompanyProfileContactRepository? _companyProfileContactRepository;
+    private ICompanyProfileRequisiteRepository? _companyProfileRequisiteRepository;
+    private ICompanyProfileContactLocalizationsRepository? _companyProfileContactLocalizationsRepository;
+    private ICompanyProfileRequisiteLocalizationsRepository? _companyProfileRequisiteLocalizationsRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -145,6 +154,17 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public IReportFundsExpendituresSettingsRepository ReportFundsExpendituresSettingsRepository =>
         _reportFundsExpendituresSettingsRepository ??= new ReportFundsExpendituresSettingsRepository(_victoryCenterDbContext);
+
+    public ICompanyProfileRepository CompanyProfileRepository =>
+        _companyProfileRepository ??= new CompanyProfileRepository(_victoryCenterDbContext);
+    public ICompanyProfileContactRepository CompanyProfileContactRepository =>
+        _companyProfileContactRepository ??= new CompanyProfileContactRepository(_victoryCenterDbContext);
+    public ICompanyProfileRequisiteRepository CompanyProfileRequisiteRepository =>
+        _companyProfileRequisiteRepository ??= new CompanyProfileRequisiteRepository(_victoryCenterDbContext);
+    public ICompanyProfileContactLocalizationsRepository CompanyProfileContactLocalizationsRepository =>
+        _companyProfileContactLocalizationsRepository ??= new CompanyProfileContactLocalizationsRepository(_victoryCenterDbContext);
+    public ICompanyProfileRequisiteLocalizationsRepository CompanyProfileRequisiteLocalizationsRepository =>
+        _companyProfileRequisiteLocalizationsRepository ??= new CompanyProfileRequisiteLocalizationsRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/CompanyProfile/CompanyProfileContactRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/CompanyProfile/CompanyProfileContactRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.CompanyProfile;
+
+public class CompanyProfileContactRepository : RepositoryBase<CompanyProfileContact>, ICompanyProfileContactRepository
+{
+    public CompanyProfileContactRepository(VictoryCenterDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/CompanyProfile/CompanyProfileRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/CompanyProfile/CompanyProfileRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+using CompanyProfileEntity = VictoryCenter.DAL.Entities.CompanyProfile;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.CompanyProfile;
+
+public class CompanyProfileRepository : RepositoryBase<CompanyProfileEntity>, ICompanyProfileRepository
+{
+    public CompanyProfileRepository(VictoryCenterDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/CompanyProfile/CompanyProfileRequisiteRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/CompanyProfile/CompanyProfileRequisiteRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.CompanyProfile;
+
+public class CompanyProfileRequisiteRepository : RepositoryBase<CompanyProfileRequisite>, ICompanyProfileRequisiteRepository
+{
+    public CompanyProfileRequisiteRepository(VictoryCenterDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/CompanyProfile/CompanyProfileContactLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/CompanyProfile/CompanyProfileContactLocalizationsRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.CompanyProfile;
+
+public class CompanyProfileContactLocalizationsRepository : RepositoryBase<CompanyProfileContactLocalization>, ICompanyProfileContactLocalizationsRepository
+{
+    public CompanyProfileContactLocalizationsRepository(VictoryCenterDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/CompanyProfile/CompanyProfileRequisiteLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/CompanyProfile/CompanyProfileRequisiteLocalizationsRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.CompanyProfile;
+
+public class CompanyProfileRequisiteLocalizationsRepository : RepositoryBase<CompanyProfileRequisiteLocalization>, ICompanyProfileRequisiteLocalizationsRepository
+{
+    public CompanyProfileRequisiteLocalizationsRepository(VictoryCenterDbContext dbContext)
+        : base(dbContext)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/CreateCompanyProfileHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/CreateCompanyProfileHandlerTests.cs
@@ -238,7 +238,7 @@ public class CreateCompanyProfileHandlerTests
             Email = "test@test.com",
             CorrespondenceEmail = "corr@test.com",
             Motto = "Motto",
-            Localization =
+            Localizations =
             [
                 new CreateCompanyProfileContactLocalizationDto { EntityId = 0, LanguageId = 1, Address = "Addr UA" }
             ]
@@ -248,7 +248,7 @@ public class CreateCompanyProfileHandlerTests
             Recipient = "Recipient",
             Edrpou = "12345678",
             Address = "Requisite Address",
-            Localization =
+            Localizations =
             [
                 new CreateCompanyProfileRequisiteLocalizationDto { EntityId = 0, LanguageId = 1, Recipient = "Recipient UA" }
             ]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/CreateCompanyProfileHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/CreateCompanyProfileHandlerTests.cs
@@ -1,0 +1,261 @@
+using System.Transactions;
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.CompanyProfile.Commands;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.CompanyProfile;
+
+public class CreateCompanyProfileHandlerTests
+{
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<ICompanyProfileRepository> _companyProfileRepositoryMock = new();
+    private readonly Mock<ILocalizationService<CompanyProfileContact, CompanyProfileContactLocalization>> _localizationContactServiceMock = new();
+    private readonly Mock<ILocalizationService<CompanyProfileRequisite, CompanyProfileRequisiteLocalization>> _localizationRequisiteServiceMock = new();
+    private readonly IValidator<CreateCompanyProfileCommand> _validator = new CreateCompanyProfileCommandValidator();
+
+    private readonly DAL.Entities.CompanyProfile _entity = new()
+    {
+        Id = 1,
+        Contact = new CompanyProfileContact { Id = 10, Phone = "+380501234567", Address = "Kyiv, Str 1", Email = "test@test.com", CorrespondenceEmail = "corr@test.com", Motto = "Motto" },
+        Requisite = new CompanyProfileRequisite { Id = 20, Recipient = "Recipient", Edrpou = "12345678", Address = "Requisite Address" },
+        SocialLinks = []
+    };
+
+    private readonly CompanyProfileDto _dto = new()
+    {
+        Contacts = new CompanyProfileContactsDto { Phone = "+380501234567" },
+        Requisites = new CompanyProfileRequisiteDto { Recipient = "Recipient" },
+        SocialLinks = []
+    };
+
+    public CreateCompanyProfileHandlerTests()
+    {
+        _repositoryWrapperMock
+            .SetupGet(x => x.CompanyProfileRepository)
+            .Returns(_companyProfileRepositoryMock.Object);
+
+        _repositoryWrapperMock
+            .Setup(x => x.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateProfile_WhenRequestIsValid()
+    {
+        // Arrange
+        SetupSuccessfulCreate();
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new CreateCompanyProfileCommand(GetValidCreateDto()),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _companyProfileRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<DAL.Entities.CompanyProfile>()), Times.Once);
+        _localizationContactServiceMock.Verify(
+            x => x.TrackEntityLocalizationAsync(It.IsAny<CompanyProfileContactLocalization>()), Times.Once);
+        _localizationRequisiteServiceMock.Verify(
+            x => x.TrackEntityLocalizationAsync(It.IsAny<CompanyProfileRequisiteLocalization>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        // Arrange
+        var invalidDto = new CreateCompanyProfileDto
+        {
+            Contacts = null!,
+            Requisites = null!,
+            SocialLinks = []
+        };
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new CreateCompanyProfileCommand(invalidDto),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenProfileAlreadyExists()
+    {
+        // Arrange
+        _companyProfileRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync(_entity);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new CreateCompanyProfileCommand(GetValidCreateDto()),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.OnlyOneEntityOfTypeIsAllowed(nameof(DAL.Entities.CompanyProfile)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenFirstSaveChangesFails()
+    {
+        // Arrange
+        _companyProfileRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync((DAL.Entities.CompanyProfile?)null);
+
+        _companyProfileRepositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .ReturnsAsync(_entity);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.CompanyProfile>(It.IsAny<CreateCompanyProfileDto>()))
+            .Returns(_entity);
+
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(0);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new CreateCompanyProfileCommand(GetValidCreateDto()),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(DAL.Entities.CompanyProfile)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        _companyProfileRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync((DAL.Entities.CompanyProfile?)null);
+
+        _companyProfileRepositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .ReturnsAsync(_entity);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.CompanyProfile>(It.IsAny<CreateCompanyProfileDto>()))
+            .Returns(_entity);
+
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ThrowsAsync(new DbUpdateException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new CreateCompanyProfileCommand(GetValidCreateDto()),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(DAL.Entities.CompanyProfile)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupSuccessfulCreate()
+    {
+        _companyProfileRepositoryMock
+            .SetupSequence(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync((DAL.Entities.CompanyProfile?)null)
+            .ReturnsAsync(_entity);
+
+        _companyProfileRepositoryMock
+            .Setup(x => x.CreateAsync(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .ReturnsAsync(_entity);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.CompanyProfile>(It.IsAny<CreateCompanyProfileDto>()))
+            .Returns(_entity);
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileContactLocalization>(It.IsAny<CreateCompanyProfileContactLocalizationDto>()))
+            .Returns(new CompanyProfileContactLocalization { LanguageId = 1 });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileRequisiteLocalization>(It.IsAny<CreateCompanyProfileRequisiteLocalizationDto>()))
+            .Returns(new CompanyProfileRequisiteLocalization { LanguageId = 1 });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileDto>(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .Returns(_dto);
+
+        _localizationContactServiceMock
+            .Setup(x => x.TrackEntityLocalizationAsync(It.IsAny<CompanyProfileContactLocalization>()))
+            .ReturnsAsync(new CompanyProfileContactLocalization());
+
+        _localizationRequisiteServiceMock
+            .Setup(x => x.TrackEntityLocalizationAsync(It.IsAny<CompanyProfileRequisiteLocalization>()))
+            .ReturnsAsync(new CompanyProfileRequisiteLocalization());
+
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+    }
+
+    private CreateCompanyProfileHandler CreateHandler() => new(
+        _repositoryWrapperMock.Object,
+        _mapperMock.Object,
+        _validator,
+        _localizationContactServiceMock.Object,
+        _localizationRequisiteServiceMock.Object);
+
+    private static CreateCompanyProfileDto GetValidCreateDto() => new()
+    {
+        Contacts = new CreateCompanyProfileContactsDto
+        {
+            Phone = "+380501234567",
+            Address = "Kyiv, Str 1",
+            Email = "test@test.com",
+            CorrespondenceEmail = "corr@test.com",
+            Motto = "Motto",
+            Localization =
+            [
+                new CreateCompanyProfileContactLocalizationDto { EntityId = 0, LanguageId = 1, Address = "Addr UA" }
+            ]
+        },
+        Requisites = new CreateCompanyProfileRequisiteDto
+        {
+            Recipient = "Recipient",
+            Edrpou = "12345678",
+            Address = "Requisite Address",
+            Localization =
+            [
+                new CreateCompanyProfileRequisiteLocalizationDto { EntityId = 0, LanguageId = 1, Recipient = "Recipient UA" }
+            ]
+        },
+        SocialLinks =
+        [
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test" }
+        ]
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/GetCompanyProfileHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/GetCompanyProfileHandlerTests.cs
@@ -1,0 +1,111 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.Queries.Public.CompanyProfile.Get;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.CompanyProfile;
+
+public class GetCompanyProfileHandlerTests
+{
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<ICompanyProfileRepository> _companyProfileRepositoryMock = new();
+
+    private readonly DAL.Entities.CompanyProfile _entity = new()
+    {
+        Id = 1,
+        Contact = new CompanyProfileContact
+        {
+            Id = 10,
+            Phone = "+380501234567",
+            Address = "Kyiv, Str 1",
+            Email = "test@test.com",
+            CorrespondenceEmail = "corr@test.com",
+            Motto = "Motto"
+        },
+        Requisite = new CompanyProfileRequisite
+        {
+            Id = 20,
+            Recipient = "Recipient",
+            Edrpou = "12345678",
+            Address = "Requisite Address"
+        },
+        SocialLinks = []
+    };
+
+    private readonly CompanyProfileDto _dto = new()
+    {
+        Contacts = new CompanyProfileContactsDto
+        {
+            Phone = "+380501234567",
+            Address = "Kyiv, Str 1",
+            Email = "test@test.com",
+            CorrespondenceEmail = "corr@test.com",
+            Motto = "Motto"
+        },
+        Requisites = new CompanyProfileRequisiteDto
+        {
+            Recipient = "Recipient",
+            Edrpou = "12345678",
+            Address = "Requisite Address"
+        },
+        SocialLinks = []
+    };
+
+    public GetCompanyProfileHandlerTests()
+    {
+        _repositoryWrapperMock
+            .SetupGet(x => x.CompanyProfileRepository)
+            .Returns(_companyProfileRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnProfile_WhenProfileExists()
+    {
+        // Arrange
+        _companyProfileRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync(_entity);
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileDto>(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .Returns(_dto);
+
+        var handler = new GetCompanyProfileHandler(_repositoryWrapperMock.Object, _mapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(new GetCompanyProfileQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_dto.Contacts.Phone, result.Value.Contacts.Phone);
+        Assert.Equal(_dto.Requisites.Recipient, result.Value.Requisites.Recipient);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenProfileNotFound()
+    {
+        // Arrange
+        _companyProfileRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync((DAL.Entities.CompanyProfile?)null);
+
+        var handler = new GetCompanyProfileHandler(_repositoryWrapperMock.Object, _mapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(new GetCompanyProfileQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(),
+            result.Errors[0].Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/UpdateCompanyProfileHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/UpdateCompanyProfileHandlerTests.cs
@@ -1,0 +1,311 @@
+using System.Transactions;
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.CompanyProfile.Commands;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.CompanyProfile;
+
+public class UpdateCompanyProfileHandlerTests
+{
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<ICompanyProfileRepository> _companyProfileRepositoryMock = new();
+    private readonly Mock<ILocalizationService<CompanyProfileContact, CompanyProfileContactLocalization>> _localizationContactServiceMock = new();
+    private readonly Mock<ILocalizationService<CompanyProfileRequisite, CompanyProfileRequisiteLocalization>> _localizationRequisiteServiceMock = new();
+    private readonly IValidator<UpdateCompanyProfileCommand> _validator = new UpdateCompanyProfileCommandValidator();
+
+    private readonly CompanyProfileDto _dto = new()
+    {
+        Contacts = new CompanyProfileContactsDto { Phone = "+380501234567" },
+        Requisites = new CompanyProfileRequisiteDto { Recipient = "Recipient" },
+        SocialLinks = []
+    };
+
+    public UpdateCompanyProfileHandlerTests()
+    {
+        _repositoryWrapperMock
+            .SetupGet(x => x.CompanyProfileRepository)
+            .Returns(_companyProfileRepositoryMock.Object);
+
+        _repositoryWrapperMock
+            .Setup(x => x.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateProfile_WhenExistingLocalizationsAndLinksAreUpdated()
+    {
+        // Arrange
+        var existingLocalization = new CompanyProfileContactLocalization { EntityId = 10, LanguageId = 1 };
+        var existingRequisiteLocalization = new CompanyProfileRequisiteLocalization { EntityId = 20, LanguageId = 1 };
+        var existingLink = new CompanyProfileSocialLink { Id = 5, SocialPlatform = SocialPlatform.Facebook, Url = "https://old.com" };
+
+        var entity = BuildEntity(
+            contactLocalizations: [existingLocalization],
+            requisiteLocalizations: [existingRequisiteLocalization],
+            socialLinks: [existingLink]);
+
+        SetupRepositorySequence(entity);
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileDto>(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .Returns(_dto);
+
+        var request = new UpdateCompanyProfileCommand(BuildValidUpdateDto(
+            languageId: 1,
+            platform: SocialPlatform.Facebook));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _mapperMock.Verify(
+            x => x.Map(It.IsAny<UpdateCompanyProfileContactLocalizationDto>(), It.IsAny<CompanyProfileContactLocalization>()),
+            Times.Once);
+        _mapperMock.Verify(
+            x => x.Map(It.IsAny<UpdateCompanyProfileRequisiteLocalizationDto>(), It.IsAny<CompanyProfileRequisiteLocalization>()),
+            Times.Once);
+        _mapperMock.Verify(
+            x => x.Map(It.IsAny<UpdateSocialLinkDto>(), It.IsAny<CompanyProfileSocialLink>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateProfile_WhenNewLocalizationsAndLinksAreAdded()
+    {
+        // Arrange
+        var entity = BuildEntity(
+            contactLocalizations: [],
+            requisiteLocalizations: [],
+            socialLinks: []);
+
+        SetupRepositorySequence(entity);
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileSocialLink>(It.IsAny<UpdateSocialLinkDto>()))
+            .Returns(new CompanyProfileSocialLink { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/new" });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileContactLocalization>(It.IsAny<UpdateCompanyProfileContactLocalizationDto>()))
+            .Returns(new CompanyProfileContactLocalization { LanguageId = 1 });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileRequisiteLocalization>(It.IsAny<UpdateCompanyProfileRequisiteLocalizationDto>()))
+            .Returns(new CompanyProfileRequisiteLocalization { LanguageId = 1 });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileDto>(It.IsAny<DAL.Entities.CompanyProfile>()))
+            .Returns(_dto);
+
+        _localizationContactServiceMock
+            .Setup(x => x.TrackEntityLocalizationForUpdateAsync(It.IsAny<CompanyProfileContactLocalization>()))
+            .Returns(Task.CompletedTask);
+
+        _localizationRequisiteServiceMock
+            .Setup(x => x.TrackEntityLocalizationForUpdateAsync(It.IsAny<CompanyProfileRequisiteLocalization>()))
+            .Returns(Task.CompletedTask);
+
+        var request = new UpdateCompanyProfileCommand(BuildValidUpdateDto(
+            languageId: 1,
+            platform: SocialPlatform.Facebook));
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _localizationContactServiceMock.Verify(
+            x => x.TrackEntityLocalizationForUpdateAsync(It.IsAny<CompanyProfileContactLocalization>()),
+            Times.Once);
+        _localizationRequisiteServiceMock.Verify(
+            x => x.TrackEntityLocalizationForUpdateAsync(It.IsAny<CompanyProfileRequisiteLocalization>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        // Arrange
+        var invalidDto = new UpdateCompanyProfileDto
+        {
+            Contacts = null!,
+            Requisites = null!,
+            SocialLinks = []
+        };
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new UpdateCompanyProfileCommand(invalidDto),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenProfileNotFound()
+    {
+        // Arrange
+        _companyProfileRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync((DAL.Entities.CompanyProfile?)null);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new UpdateCompanyProfileCommand(BuildValidUpdateDto()),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        var entity = BuildEntity([], [], []);
+        SetupRepositorySequence(entity);
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileSocialLink>(It.IsAny<UpdateSocialLinkDto>()))
+            .Returns(new CompanyProfileSocialLink { SocialPlatform = SocialPlatform.Instagram, Url = "https://instagram.com/test" });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileContactLocalization>(It.IsAny<UpdateCompanyProfileContactLocalizationDto>()))
+            .Returns(new CompanyProfileContactLocalization { LanguageId = 1 });
+
+        _mapperMock
+            .Setup(x => x.Map<CompanyProfileRequisiteLocalization>(It.IsAny<UpdateCompanyProfileRequisiteLocalizationDto>()))
+            .Returns(new CompanyProfileRequisiteLocalization { LanguageId = 1 });
+
+        _localizationContactServiceMock
+            .Setup(x => x.TrackEntityLocalizationForUpdateAsync(It.IsAny<CompanyProfileContactLocalization>()))
+            .Returns(Task.CompletedTask);
+
+        _localizationRequisiteServiceMock
+            .Setup(x => x.TrackEntityLocalizationForUpdateAsync(It.IsAny<CompanyProfileRequisiteLocalization>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new UpdateCompanyProfileCommand(BuildValidUpdateDto()),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(DAL.Entities.CompanyProfile)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupRepositorySequence(DAL.Entities.CompanyProfile entity)
+    {
+        _companyProfileRepositoryMock
+            .SetupSequence(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.CompanyProfile>?>()))
+            .ReturnsAsync(entity)
+            .ReturnsAsync(entity);
+    }
+
+    private UpdateCompanyProfileHandler CreateHandler() => new(
+        _repositoryWrapperMock.Object,
+        _mapperMock.Object,
+        _localizationContactServiceMock.Object,
+        _localizationRequisiteServiceMock.Object,
+        _validator);
+
+    private static DAL.Entities.CompanyProfile BuildEntity(
+        ICollection<CompanyProfileContactLocalization> contactLocalizations,
+        ICollection<CompanyProfileRequisiteLocalization> requisiteLocalizations,
+        ICollection<CompanyProfileSocialLink> socialLinks) => new()
+    {
+        Id = 1,
+        Contact = new CompanyProfileContact
+        {
+            Id = 10,
+            Phone = "+380501234567",
+            Address = "Kyiv, Str 1",
+            Email = "test@test.com",
+            CorrespondenceEmail = "corr@test.com",
+            Motto = "Old Motto",
+            Localizations = contactLocalizations
+        },
+        Requisite = new CompanyProfileRequisite
+        {
+            Id = 20,
+            Recipient = "Old Recipient",
+            Edrpou = "12345678",
+            Address = "Old Address",
+            Localizations = requisiteLocalizations
+        },
+        SocialLinks = socialLinks
+    };
+
+    private static UpdateCompanyProfileDto BuildValidUpdateDto(
+        long languageId = 1,
+        SocialPlatform platform = SocialPlatform.Instagram) => new()
+    {
+        Contacts = new UpdateCompanyProfileContactDto
+        {
+            Phone = "+380501234567",
+            Address = "Kyiv, Str 1",
+            Email = "test@test.com",
+            CorrespondenceEmail = "corr@test.com",
+            Motto = "New Motto",
+            Localization =
+            [
+                new UpdateCompanyProfileContactLocalizationDto { LanguageId = languageId, Address = "New Addr" }
+            ]
+        },
+        Requisites = new UpdateCompanyProfileRequisiteDto
+        {
+            Recipient = "New Recipient",
+            Edrpou = "12345678",
+            Address = "New Address",
+            Localization =
+            [
+                new UpdateCompanyProfileRequisiteLocalizationDto { LanguageId = languageId, Recipient = "New Recipient UA" }
+            ]
+        },
+        SocialLinks =
+        [
+            new UpdateSocialLinkDto { SocialPlatform = platform, Url = "https://instagram.com/test" }
+        ]
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/UpdateCompanyProfileHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/UpdateCompanyProfileHandlerTests.cs
@@ -288,7 +288,7 @@ public class UpdateCompanyProfileHandlerTests
             Email = "test@test.com",
             CorrespondenceEmail = "corr@test.com",
             Motto = "New Motto",
-            Localization =
+            Localizations =
             [
                 new UpdateCompanyProfileContactLocalizationDto { LanguageId = languageId, Address = "New Addr" }
             ]
@@ -298,7 +298,7 @@ public class UpdateCompanyProfileHandlerTests
             Recipient = "New Recipient",
             Edrpou = "12345678",
             Address = "New Address",
-            Localization =
+            Localizations =
             [
                 new UpdateCompanyProfileRequisiteLocalizationDto { LanguageId = languageId, Recipient = "New Recipient UA" }
             ]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/CreateCompanyProfileCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/CreateCompanyProfileCommandValidatorTests.cs
@@ -1,0 +1,204 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+using VictoryCenter.BLL.Validators.CompanyProfile.Commands;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.CompanyProfile;
+
+public class CreateCompanyProfileCommandValidatorTests
+{
+    private readonly CreateCompanyProfileCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(GetValidDto()));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDtoIsNull()
+    {
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(null!));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenContactsIsNull()
+    {
+        var dto = GetValidDto();
+        dto.Contacts = null!;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Contacts);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenPhoneIsEmpty(string? phone)
+    {
+        var contacts = GetValidContacts();
+        contacts.Phone = phone!;
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Contacts.Phone)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.Phone)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenPhoneExceedsMaxLength()
+    {
+        var contacts = GetValidContacts();
+        contacts.Phone = new string('1', CompanyProfileConstants.Phone.MaxLength + 1);
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Contacts.Phone);
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("missing@")]
+    [InlineData("@nodomain.com")]
+    public void Validate_ShouldHaveError_WhenEmailIsInvalid(string email)
+    {
+        var contacts = GetValidContacts();
+        contacts.Email = email;
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Contacts.Email);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenContactAddressIsEmpty(string? address)
+    {
+        var contacts = GetValidContacts();
+        contacts.Address = address!;
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Contacts.Address)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.Address)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMottoExceedsMaxLength()
+    {
+        var contacts = GetValidContacts();
+        contacts.Motto = new string('x', CompanyProfileConstants.Motto.MaxLength + 1);
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Contacts.Motto);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenRequisitesIsNull()
+    {
+        var dto = GetValidDto();
+        dto.Requisites = null!;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Requisites);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenRecipientIsEmpty(string? recipient)
+    {
+        var requisites = GetValidRequisites();
+        requisites.Recipient = recipient!;
+        var dto = GetValidDto();
+        dto.Requisites = requisites;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Requisites.Recipient)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileRequisiteDto.Recipient)));
+    }
+
+    [Theory]
+    [InlineData("1234567")]
+    [InlineData("123456789")]
+    public void Validate_ShouldHaveError_WhenEdrpouHasWrongLength(string edrpou)
+    {
+        var requisites = GetValidRequisites();
+        requisites.Edrpou = edrpou;
+        var dto = GetValidDto();
+        dto.Requisites = requisites;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Requisites.Edrpou);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenEdrpouContainsNonDigits()
+    {
+        var requisites = GetValidRequisites();
+        requisites.Edrpou = "1234567a";
+        var dto = GetValidDto();
+        dto.Requisites = requisites;
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.CreateCompanyProfileDto.Requisites.Edrpou)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustContainOnlyDigits(nameof(BaseCompanyProfileRequisiteDto.Edrpou)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    public void Validate_ShouldHaveError_WhenSocialLinkUrlIsInvalid(string? url)
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks = [new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = url! }];
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenSocialLinkUrlExceedsMaxLength()
+    {
+        var longUrl = "https://" + new string('a', CompanyProfileConstants.SocialLinkUrl.MaxLength) + ".com";
+        var dto = GetValidDto();
+        dto.SocialLinks = [new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = longUrl }];
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    private static CreateCompanyProfileDto GetValidDto() => new()
+    {
+        Contacts = GetValidContacts(),
+        Requisites = GetValidRequisites(),
+        SocialLinks =
+        [
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/victory" }
+        ]
+    };
+
+    private static CreateCompanyProfileContactsDto GetValidContacts() => new()
+    {
+        Phone = "+380501234567",
+        Address = "Kyiv, Str 1",
+        Email = "test@test.com",
+        CorrespondenceEmail = "corr@test.com",
+        Motto = "Our motto",
+        Localization = []
+    };
+
+    private static CreateCompanyProfileRequisiteDto GetValidRequisites() => new()
+    {
+        Recipient = "Recipient Name",
+        Edrpou = "12345678",
+        Address = "Requisite Address",
+        Localization = []
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/CreateCompanyProfileCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/CreateCompanyProfileCommandValidatorTests.cs
@@ -174,6 +174,50 @@ public class CreateCompanyProfileCommandValidatorTests
         Assert.NotEmpty(result.Errors);
     }
 
+    [Fact]
+    public void Validate_ShouldHaveError_WhenSocialLinksExceedMaxCount()
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks =
+        [
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Instagram, Url = "https://instagram.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.X, Url = "https://twitter.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.YouTube, Url = "https://youtube.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Telegram, Url = "https://t.me/test" }
+        ];
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenSocialLinksContainDuplicatePlatforms()
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks =
+        [
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test1" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test2" }
+        ];
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenSocialLinksHaveExactlyMaxCount()
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks =
+        [
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.Instagram, Url = "https://instagram.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.X, Url = "https://twitter.com/test" },
+            new CreateSocialLinkDto { SocialPlatform = SocialPlatform.YouTube, Url = "https://youtube.com/test" }
+        ];
+        var result = _validator.TestValidate(new CreateCompanyProfileCommand(dto));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
     private static CreateCompanyProfileDto GetValidDto() => new()
     {
         Contacts = GetValidContacts(),

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/CreateCompanyProfileCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/CreateCompanyProfileCommandValidatorTests.cs
@@ -191,7 +191,7 @@ public class CreateCompanyProfileCommandValidatorTests
         Email = "test@test.com",
         CorrespondenceEmail = "corr@test.com",
         Motto = "Our motto",
-        Localization = []
+        Localizations = []
     };
 
     private static CreateCompanyProfileRequisiteDto GetValidRequisites() => new()
@@ -199,6 +199,6 @@ public class CreateCompanyProfileCommandValidatorTests
         Recipient = "Recipient Name",
         Edrpou = "12345678",
         Address = "Requisite Address",
-        Localization = []
+        Localizations = []
     };
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/UpdateCompanyProfileCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/UpdateCompanyProfileCommandValidatorTests.cs
@@ -1,0 +1,173 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.DTOs.Admin.Localization.CompanyProfile;
+using VictoryCenter.BLL.DTOs.Admin.SocialLinks;
+using VictoryCenter.BLL.Validators.CompanyProfile.Commands;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.CompanyProfile;
+
+public class UpdateCompanyProfileCommandValidatorTests
+{
+    private readonly UpdateCompanyProfileCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(GetValidDto()));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenLocalizationsAreValid()
+    {
+        var dto = GetValidDto();
+        dto.Contacts = GetValidContacts();
+        dto.Contacts.Localization =
+        [
+            new UpdateCompanyProfileContactLocalizationDto { LanguageId = 1, Address = "Addr UA" },
+            new UpdateCompanyProfileContactLocalizationDto { LanguageId = 2, Address = "Addr EN" }
+        ];
+        dto.Requisites = GetValidRequisites();
+        dto.Requisites.Localization =
+        [
+            new UpdateCompanyProfileRequisiteLocalizationDto { LanguageId = 1, Recipient = "Recipient UA" }
+        ];
+
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDtoIsNull()
+    {
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(null!));
+        result.ShouldHaveValidationErrorFor(x => x.UpdateCompanyProfileDto);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenContactsIsNull()
+    {
+        var dto = GetValidDto();
+        dto.Contacts = null!;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.UpdateCompanyProfileDto.Contacts);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenRequisitesIsNull()
+    {
+        var dto = GetValidDto();
+        dto.Requisites = null!;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.UpdateCompanyProfileDto.Requisites);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenPhoneIsEmpty(string? phone)
+    {
+        var contacts = GetValidContacts();
+        contacts.Phone = phone!;
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.UpdateCompanyProfileDto.Contacts.Phone)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseCompanyProfileContactsDto.Phone)));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("missing@")]
+    public void Validate_ShouldHaveError_WhenEmailIsInvalid(string email)
+    {
+        var contacts = GetValidContacts();
+        contacts.Email = email;
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.UpdateCompanyProfileDto.Contacts.Email);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenContactLocalizationLanguageIdIsZero()
+    {
+        var contacts = GetValidContacts();
+        contacts.Localization =
+        [
+            new UpdateCompanyProfileContactLocalizationDto { LanguageId = 0 }
+        ];
+        var dto = GetValidDto();
+        dto.Contacts = contacts;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenRequisiteLocalizationLanguageIdIsZero()
+    {
+        var requisites = GetValidRequisites();
+        requisites.Localization =
+        [
+            new UpdateCompanyProfileRequisiteLocalizationDto { LanguageId = 0 }
+        ];
+        var dto = GetValidDto();
+        dto.Requisites = requisites;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenEdrpouContainsNonDigits()
+    {
+        var requisites = GetValidRequisites();
+        requisites.Edrpou = "1234567a";
+        var dto = GetValidDto();
+        dto.Requisites = requisites;
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldHaveValidationErrorFor(x => x.UpdateCompanyProfileDto.Requisites.Edrpou);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    public void Validate_ShouldHaveError_WhenSocialLinkUrlIsInvalid(string? url)
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks = [new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = url! }];
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    private static UpdateCompanyProfileDto GetValidDto() => new()
+    {
+        Contacts = GetValidContacts(),
+        Requisites = GetValidRequisites(),
+        SocialLinks = []
+    };
+
+    private static UpdateCompanyProfileContactDto GetValidContacts() => new()
+    {
+        Phone = "+380501234567",
+        Address = "Kyiv, Str 1",
+        Email = "test@test.com",
+        CorrespondenceEmail = "corr@test.com",
+        Motto = "Our motto",
+        Localization = []
+    };
+
+    private static UpdateCompanyProfileRequisiteDto GetValidRequisites() => new()
+    {
+        Recipient = "Recipient Name",
+        Edrpou = "12345678",
+        Address = "Requisite Address",
+        Localization = []
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/UpdateCompanyProfileCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/UpdateCompanyProfileCommandValidatorTests.cs
@@ -146,6 +146,50 @@ public class UpdateCompanyProfileCommandValidatorTests
         Assert.NotEmpty(result.Errors);
     }
 
+    [Fact]
+    public void Validate_ShouldHaveError_WhenSocialLinksExceedMaxCount()
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks =
+        [
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Instagram, Url = "https://instagram.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.X, Url = "https://x.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.YouTube, Url = "https://youtube.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Telegram, Url = "https://t.me/test" }
+        ];
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenSocialLinksContainDuplicatePlatforms()
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks =
+        [
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test1" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test2" }
+        ];
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenSocialLinksHaveExactlyMaxCount()
+    {
+        var dto = GetValidDto();
+        dto.SocialLinks =
+        [
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Facebook, Url = "https://facebook.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.Instagram, Url = "https://instagram.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.X, Url = "https://x.com/test" },
+            new UpdateSocialLinkDto { SocialPlatform = SocialPlatform.YouTube, Url = "https://youtube.com/test" }
+        ];
+        var result = _validator.TestValidate(new UpdateCompanyProfileCommand(dto));
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
     private static UpdateCompanyProfileDto GetValidDto() => new()
     {
         Contacts = GetValidContacts(),

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/UpdateCompanyProfileCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/CompanyProfile/UpdateCompanyProfileCommandValidatorTests.cs
@@ -27,13 +27,13 @@ public class UpdateCompanyProfileCommandValidatorTests
     {
         var dto = GetValidDto();
         dto.Contacts = GetValidContacts();
-        dto.Contacts.Localization =
+        dto.Contacts.Localizations =
         [
             new UpdateCompanyProfileContactLocalizationDto { LanguageId = 1, Address = "Addr UA" },
             new UpdateCompanyProfileContactLocalizationDto { LanguageId = 2, Address = "Addr EN" }
         ];
         dto.Requisites = GetValidRequisites();
-        dto.Requisites.Localization =
+        dto.Requisites.Localizations =
         [
             new UpdateCompanyProfileRequisiteLocalizationDto { LanguageId = 1, Recipient = "Recipient UA" }
         ];
@@ -99,7 +99,7 @@ public class UpdateCompanyProfileCommandValidatorTests
     public void Validate_ShouldHaveError_WhenContactLocalizationLanguageIdIsZero()
     {
         var contacts = GetValidContacts();
-        contacts.Localization =
+        contacts.Localizations =
         [
             new UpdateCompanyProfileContactLocalizationDto { LanguageId = 0 }
         ];
@@ -113,7 +113,7 @@ public class UpdateCompanyProfileCommandValidatorTests
     public void Validate_ShouldHaveError_WhenRequisiteLocalizationLanguageIdIsZero()
     {
         var requisites = GetValidRequisites();
-        requisites.Localization =
+        requisites.Localizations =
         [
             new UpdateCompanyProfileRequisiteLocalizationDto { LanguageId = 0 }
         ];
@@ -160,7 +160,7 @@ public class UpdateCompanyProfileCommandValidatorTests
         Email = "test@test.com",
         CorrespondenceEmail = "corr@test.com",
         Motto = "Our motto",
-        Localization = []
+        Localizations = []
     };
 
     private static UpdateCompanyProfileRequisiteDto GetValidRequisites() => new()
@@ -168,6 +168,6 @@ public class UpdateCompanyProfileCommandValidatorTests
         Recipient = "Recipient Name",
         Edrpou = "12345678",
         Address = "Requisite Address",
-        Localization = []
+        Localizations = []
     };
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/CompanyProfileController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/CompanyProfileController.cs
@@ -1,0 +1,17 @@
+using VictoryCenter.WebAPI.Controllers.Common;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using Microsoft.AspNetCore.Mvc;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class CompanyProfileController : AuthorizedApiController
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(CompanyProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateCompanyProfile([FromBody] CreateCompanyProfileDto createCompanyProfileDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateCompanyProfileCommand(createCompanyProfileDto)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/CompanyProfileController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/CompanyProfileController.cs
@@ -1,7 +1,8 @@
-using VictoryCenter.WebAPI.Controllers.Common;
-using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
-using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
 using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Create;
+using VictoryCenter.BLL.Commands.Admin.CompanyProfile.Update;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.WebAPI.Controllers.Common;
 
 namespace VictoryCenter.WebAPI.Controllers.Admin;
 
@@ -13,5 +14,14 @@ public class CompanyProfileController : AuthorizedApiController
     public async Task<IActionResult> CreateCompanyProfile([FromBody] CreateCompanyProfileDto createCompanyProfileDto)
     {
         return HandleResult(await Mediator.Send(new CreateCompanyProfileCommand(createCompanyProfileDto)));
+    }
+
+    [HttpPut]
+    [ProducesResponseType(typeof(CompanyProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateCompanyProfile([FromBody] UpdateCompanyProfileDto updateCompanyProfileDto)
+    {
+        return HandleResult(await Mediator.Send(new UpdateCompanyProfileCommand(updateCompanyProfileDto)));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/CompanyProfileController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/CompanyProfileController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
+using VictoryCenter.BLL.Queries.Public.CompanyProfile.Get;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Public;
+
+public class CompanyProfileController : BaseApiController
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(CompanyProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetCompanyProfile()
+    {
+        return HandleResult(await Mediator.Send(new GetCompanyProfileQuery()));
+    }
+}


### PR DESCRIPTION
dev
## GitHub

* [Main GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/915)

## Summary of change

I implemented GET, POST, PUT endpoints for creating, updating, and retrieving the company profile. I also developed the core business logic and ensured it is properly covered with tests, including validation. Part of the localization logic was implemented directly in the handlers, as required by the user story and this flow.
Additionally, all changes were implemented with the assumption that the Company Profile entity is a singleton, meaning only one instance can exist in accordance with the requirements.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin create and update endpoints for company profile (contacts, requisites, social links) with localization support.
  * Public GET endpoint to retrieve the company profile.
  * Comprehensive server-side validation for phones, emails, addresses, IDs and social URLs with clear error messages.
  * Enforced single-company-profile constraint to prevent duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->