### PR TITLE
Feature/issue-1336 Implement edpoint for updating PDF section content block

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.PdfSection;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfSection.Update;
+
+public record UpdatePdfSectionCommand(PdfSectionDto Dto)
+    : IRequest<Result<PdfSectionDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
@@ -30,6 +30,17 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
+            var count = await _repositoryWrapper.PdfSectionRepository.CountAsync();
+            if (count == 0)
+            {
+                return Result.Fail<PdfSectionDto>(PdfSectionConstants.SectionNotFound);
+            }
+
+            if (count > 1)
+            {
+                return Result.Fail<PdfSectionDto>("Multiple PdfSection records found. Expected exactly one.");
+            }
+
             var pdfSection = await _repositoryWrapper.PdfSectionRepository.GetFirstOrDefaultAsync(
                 new QueryOptions<DAL.Entities.PdfSection>
                 {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
@@ -55,8 +55,6 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
             pdfSection.Title = NormalizeText(request.Dto.Title);
             pdfSection.Description = NormalizeText(request.Dto.Description);
 
-            _repositoryWrapper.PdfSectionRepository.Update(pdfSection);
-
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
                 return Result.Fail<PdfSectionDto>(

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
@@ -1,0 +1,90 @@
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfSection;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfSection.Update;
+
+public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, Result<PdfSectionDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<UpdatePdfSectionCommand> _validator;
+
+    public UpdatePdfSectionHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IValidator<UpdatePdfSectionCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<PdfSectionDto>> Handle(
+        UpdatePdfSectionCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var pdfSection = await _repositoryWrapper.PdfSectionRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<DAL.Entities.PdfSection>
+                {
+                    AsNoTracking = false
+                });
+
+            if (pdfSection == null)
+            {
+                return Result.Fail<PdfSectionDto>(PdfSectionConstants.SectionNotFound);
+            }
+
+            pdfSection.Title = NormalizeText(request.Dto.Title);
+            pdfSection.Description = NormalizeText(request.Dto.Description);
+
+            _repositoryWrapper.PdfSectionRepository.Update(pdfSection);
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<PdfSectionDto>(
+                    ErrorMessagesConstants.FailedToUpdateEntity(typeof(DAL.Entities.PdfSection)));
+            }
+
+            var dto = new PdfSectionDto
+            {
+                Title = pdfSection.Title,
+                Description = pdfSection.Description,
+            };
+
+            return Result.Ok(dto);
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<PdfSectionDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<PdfSectionDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(DAL.Entities.PdfSection)));
+        }
+    }
+
+    private static string NormalizeText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var trimmed = text.Trim();
+
+        while (trimmed.Contains("  "))
+        {
+            trimmed = trimmed.Replace("  ", " ");
+        }
+
+        return trimmed;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
@@ -52,13 +52,20 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
                 return Result.Fail<PdfSectionDto>(PdfSectionConstants.SectionNotFound);
             }
 
-            pdfSection.Title = NormalizeText(request.Dto.Title);
-            pdfSection.Description = NormalizeText(request.Dto.Description);
+            var normalizedTitle = NormalizeText(request.Dto.Title);
+            var normalizedDescription = NormalizeText(request.Dto.Description);
+            var hasChanges = pdfSection.Title != normalizedTitle || pdfSection.Description != normalizedDescription;
 
-            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            if (hasChanges)
             {
-                return Result.Fail<PdfSectionDto>(
-                    ErrorMessagesConstants.FailedToUpdateEntity(typeof(DAL.Entities.PdfSection)));
+                pdfSection.Title = normalizedTitle;
+                pdfSection.Description = normalizedDescription;
+
+                if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+                {
+                    return Result.Fail<PdfSectionDto>(
+                        ErrorMessagesConstants.FailedToUpdateEntity(typeof(DAL.Entities.PdfSection)));
+                }
             }
 
             var dto = new PdfSectionDto
@@ -88,7 +95,6 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
         }
 
         var trimmed = text.Trim();
-
         while (trimmed.Contains("  "))
         {
             trimmed = trimmed.Replace("  ", " ");

--- a/VictoryCenter/VictoryCenter.BLL/Constants/PdfSectionConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/PdfSectionConstants.cs
@@ -3,4 +3,16 @@ namespace VictoryCenter.BLL.Constants;
 public static class PdfSectionConstants
 {
     public static readonly string SectionNotFound = "PDF section not found";
+
+    public static readonly int TitleMinLength = 2;
+    public static readonly int TitleMaxLength = 30;
+    public static readonly string TitleMinLengthErrorMessage = "Не менше 2 символів";
+    public static readonly string TitleMaxLengthErrorMessage = "Не більше 30 символів";
+    public static readonly string TitleRequiredErrorMessage = "Поле обов'язкове";
+
+    public static readonly int DescriptionMinLength = 2;
+    public static readonly int DescriptionMaxLength = 160;
+    public static readonly string DescriptionMinLengthErrorMessage = "Не менше 2 символів";
+    public static readonly string DescriptionMaxLengthErrorMessage = "Не більше 160 символів";
+    public static readonly string DescriptionRequiredErrorMessage = "Поле обов'язкове";
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfSection/PdfSectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfSection/PdfSectionDto.cs
@@ -1,6 +1,6 @@
 namespace VictoryCenter.BLL.DTOs.Admin.PdfSection;
 
-public class PdfSectionWithReportsDto
+public class PdfSectionDto
 {
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionHandler.cs
@@ -2,35 +2,35 @@ using FluentResults;
 using MediatR;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.PdfSection;
-using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
+using PdfSectionEntity = VictoryCenter.DAL.Entities.PdfSection;
 
-namespace VictoryCenter.BLL.Queries.Admin.PdfSectionWithReport;
+namespace VictoryCenter.BLL.Queries.Admin.PdfSection.Get;
 
-public class GetPdfSectionWithReportsHandler
-    : IRequestHandler<GetPdfSectionWithReportsQuery, Result<PdfSectionWithReportsDto>>
+public class GetPdfSectionHandler
+    : IRequestHandler<GetPdfSectionQuery, Result<PdfSectionDto>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
 
-    public GetPdfSectionWithReportsHandler(IRepositoryWrapper repositoryWrapper)
+    public GetPdfSectionHandler(IRepositoryWrapper repositoryWrapper)
     {
         _repositoryWrapper = repositoryWrapper;
     }
 
-    public async Task<Result<PdfSectionWithReportsDto>> Handle(
-        GetPdfSectionWithReportsQuery request,
+    public async Task<Result<PdfSectionDto>> Handle(
+        GetPdfSectionQuery request,
         CancellationToken cancellationToken)
     {
         var section = await _repositoryWrapper.PdfSectionRepository.GetFirstOrDefaultAsync(
-            new QueryOptions<PdfSection> { AsNoTracking = true });
+            new QueryOptions<PdfSectionEntity> { AsNoTracking = true });
 
         if (section == null)
         {
-            return Result.Fail<PdfSectionWithReportsDto>(PdfSectionConstants.SectionNotFound);
+            return Result.Fail<PdfSectionDto>(PdfSectionConstants.SectionNotFound);
         }
 
-        var dto = new PdfSectionWithReportsDto
+        var dto = new PdfSectionDto
         {
             Title = section.Title,
             Description = section.Description,

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.PdfSection;
+
+namespace VictoryCenter.BLL.Queries.Admin.PdfSection.Get;
+
+public record GetPdfSectionQuery : IRequest<Result<PdfSectionDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSectionWithReport/GetPdfSectionWithReportsQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSectionWithReport/GetPdfSectionWithReportsQuery.cs
@@ -1,7 +1,0 @@
-using FluentResults;
-using MediatR;
-using VictoryCenter.BLL.DTOs.Admin.PdfSection;
-
-namespace VictoryCenter.BLL.Queries.Admin.PdfSectionWithReport;
-
-public record GetPdfSectionWithReportsQuery : IRequest<Result<PdfSectionWithReportsDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfSection/UpdatePdfSectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfSection/UpdatePdfSectionValidator.cs
@@ -1,0 +1,60 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.PdfSection.Update;
+using VictoryCenter.BLL.Constants;
+
+namespace VictoryCenter.BLL.Validators.PdfSection;
+
+public class UpdatePdfSectionValidator : AbstractValidator<UpdatePdfSectionCommand>
+{
+    public UpdatePdfSectionValidator()
+    {
+        RuleFor(x => x.Dto)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdatePdfSectionCommand.Dto)));
+
+        When(x => x.Dto != null, () =>
+        {
+            RuleFor(x => x.Dto.Title)
+                .NotEmpty()
+                .WithMessage(PdfSectionConstants.TitleRequiredErrorMessage)
+                .MinimumLength(PdfSectionConstants.TitleMinLength)
+                .WithMessage(PdfSectionConstants.TitleMinLengthErrorMessage)
+                .MaximumLength(PdfSectionConstants.TitleMaxLength)
+                .WithMessage(PdfSectionConstants.TitleMaxLengthErrorMessage)
+                .Must(BeValidTitle)
+                .WithMessage(PdfSectionConstants.TitleRequiredErrorMessage);
+
+            RuleFor(x => x.Dto.Description)
+                .NotEmpty()
+                .WithMessage(PdfSectionConstants.DescriptionRequiredErrorMessage)
+                .MinimumLength(PdfSectionConstants.DescriptionMinLength)
+                .WithMessage(PdfSectionConstants.DescriptionMinLengthErrorMessage)
+                .MaximumLength(PdfSectionConstants.DescriptionMaxLength)
+                .WithMessage(PdfSectionConstants.DescriptionMaxLengthErrorMessage)
+                .Must(BeValidDescription)
+                .WithMessage(PdfSectionConstants.DescriptionRequiredErrorMessage);
+        });
+    }
+
+    private static bool BeValidTitle(string? title)
+    {
+        if (string.IsNullOrEmpty(title))
+        {
+            return false;
+        }
+
+        var trimmed = title.Trim();
+        return !string.IsNullOrEmpty(trimmed);
+    }
+
+    private static bool BeValidDescription(string? description)
+    {
+        if (string.IsNullOrEmpty(description))
+        {
+            return false;
+        }
+
+        var trimmed = description.Trim();
+        return !string.IsNullOrEmpty(trimmed);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfSection/UpdatePdfSectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfSection/UpdatePdfSectionValidator.cs
@@ -20,9 +20,7 @@ public class UpdatePdfSectionValidator : AbstractValidator<UpdatePdfSectionComma
                 .MinimumLength(PdfSectionConstants.TitleMinLength)
                 .WithMessage(PdfSectionConstants.TitleMinLengthErrorMessage)
                 .MaximumLength(PdfSectionConstants.TitleMaxLength)
-                .WithMessage(PdfSectionConstants.TitleMaxLengthErrorMessage)
-                .Must(BeValidTitle)
-                .WithMessage(PdfSectionConstants.TitleRequiredErrorMessage);
+                .WithMessage(PdfSectionConstants.TitleMaxLengthErrorMessage);
 
             RuleFor(x => x.Dto.Description)
                 .NotEmpty()
@@ -30,31 +28,7 @@ public class UpdatePdfSectionValidator : AbstractValidator<UpdatePdfSectionComma
                 .MinimumLength(PdfSectionConstants.DescriptionMinLength)
                 .WithMessage(PdfSectionConstants.DescriptionMinLengthErrorMessage)
                 .MaximumLength(PdfSectionConstants.DescriptionMaxLength)
-                .WithMessage(PdfSectionConstants.DescriptionMaxLengthErrorMessage)
-                .Must(BeValidDescription)
-                .WithMessage(PdfSectionConstants.DescriptionRequiredErrorMessage);
+                .WithMessage(PdfSectionConstants.DescriptionMaxLengthErrorMessage);
         });
-    }
-
-    private static bool BeValidTitle(string? title)
-    {
-        if (string.IsNullOrEmpty(title))
-        {
-            return false;
-        }
-
-        var trimmed = title.Trim();
-        return !string.IsNullOrEmpty(trimmed);
-    }
-
-    private static bool BeValidDescription(string? description)
-    {
-        if (string.IsNullOrEmpty(description))
-        {
-            return false;
-        }
-
-        var trimmed = description.Trim();
-        return !string.IsNullOrEmpty(trimmed);
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfSections/Get/GetPdfSectionTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfSections/Get/GetPdfSectionTests.cs
@@ -5,17 +5,17 @@ using VictoryCenter.BLL.DTOs.Admin.PdfSection;
 using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
 
-namespace VictoryCenter.IntegrationTests.ControllerTests.PdfSections.GetWithReports;
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfSections.Get;
 
-public class GetPdfSectionWithReportsTests : BaseTestClass
+public class GetPdfSectionTests : BaseTestClass
 {
-    public GetPdfSectionWithReportsTests(IntegrationTestDbFixture fixture)
+    public GetPdfSectionTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
     }
 
     [Fact]
-    public async Task GetPdfSectionWithReports_SectionExists_ShouldReturnSectionWithReports()
+    public async Task GetPdfSection_SectionExists_ShouldReturnSection()
     {
         // Arrange
         var expectedSection = await Fixture.DbContext.PdfSections.FirstAsync();
@@ -23,7 +23,7 @@ public class GetPdfSectionWithReportsTests : BaseTestClass
         // Act
         var response = await Fixture.HttpClient.GetAsync("/api/PdfSection/pdf-section");
         var responseString = await response.Content.ReadAsStringAsync();
-        var result = JsonSerializer.Deserialize<PdfSectionWithReportsDto>(responseString, JsonOptions);
+        var result = JsonSerializer.Deserialize<PdfSectionDto>(responseString, JsonOptions);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -33,7 +33,7 @@ public class GetPdfSectionWithReportsTests : BaseTestClass
     }
 
     [Fact]
-    public async Task GetPdfSectionWithReports_NoSection_ShouldReturnNotFound()
+    public async Task GetPdfSection_NoSection_ShouldReturnNotFound()
     {
         // Arrange
         var sections = await Fixture.DbContext.PdfSections.ToListAsync();

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfSections/Update/UpdatePdfSectionTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfSections/Update/UpdatePdfSectionTests.cs
@@ -53,7 +53,6 @@ public class UpdatePdfSectionTests : BaseTestClass
         Assert.Equal("Оновлена назва", result!.Title);
         Assert.Equal("Оновлений опис", result.Description);
 
-        // Refresh from database to ensure changes are persisted
         Fixture.DbContext.ChangeTracker.Clear();
         var updatedSection = await Fixture.DbContext.PdfSections.AsNoTracking().FirstAsync();
         Assert.Equal("Оновлена назва", updatedSection.Title);

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfSections/Update/UpdatePdfSectionTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfSections/Update/UpdatePdfSectionTests.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.PdfSection;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfSections.Update;
+
+public class UpdatePdfSectionTests : BaseTestClass
+{
+    public UpdatePdfSectionTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdatePdfSection_ValidRequest_ShouldUpdateAndReturnSection()
+    {
+        // Arrange
+        var sections = await Fixture.DbContext.PdfSections.ToListAsync();
+        if (!sections.Any())
+        {
+            Fixture.DbContext.PdfSections.Add(new PdfSection
+            {
+                Title = "Тестова секція",
+                Description = "Тестовий опис",
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Оновлена назва",
+            Description = "Оновлений опис"
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(updateDto, JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync("/api/PdfSection", content);
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfSectionDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(result);
+        Assert.Equal("Оновлена назва", result!.Title);
+        Assert.Equal("Оновлений опис", result.Description);
+
+        // Refresh from database to ensure changes are persisted
+        Fixture.DbContext.ChangeTracker.Clear();
+        var updatedSection = await Fixture.DbContext.PdfSections.AsNoTracking().FirstAsync();
+        Assert.Equal("Оновлена назва", updatedSection.Title);
+        Assert.Equal("Оновлений опис", updatedSection.Description);
+    }
+
+    [Fact]
+    public async Task UpdatePdfSection_NoSection_ShouldReturnNotFound()
+    {
+        // Arrange
+        var sections = await Fixture.DbContext.PdfSections.ToListAsync();
+        Fixture.DbContext.PdfSections.RemoveRange(sections);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Оновлена назва",
+            Description = "Оновлений опис"
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(updateDto, JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync("/api/PdfSection", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfSection_EmptyTitle_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var sections = await Fixture.DbContext.PdfSections.ToListAsync();
+        if (!sections.Any())
+        {
+            Fixture.DbContext.PdfSections.Add(new PdfSection
+            {
+                Title = "Тестова секція",
+                Description = "Тестовий опис",
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
+        var updateDto = new PdfSectionDto
+        {
+            Title = "",
+            Description = "Оновлений опис"
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(updateDto, JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync("/api/PdfSection", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfSection_EmptyDescription_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var sections = await Fixture.DbContext.PdfSections.ToListAsync();
+        if (!sections.Any())
+        {
+            Fixture.DbContext.PdfSections.Add(new PdfSection
+            {
+                Title = "Тестова секція",
+                Description = "Тестовий опис",
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Оновлена назва",
+            Description = ""
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(updateDto, JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync("/api/PdfSection", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfSection_NullDto_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var sections = await Fixture.DbContext.PdfSections.ToListAsync();
+        if (!sections.Any())
+        {
+            Fixture.DbContext.PdfSections.Add(new PdfSection
+            {
+                Title = "Тестова секція",
+                Description = "Тестовий опис",
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
+        var content = new StringContent(
+            JsonSerializer.Serialize((object?)null, JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync("/api/PdfSection", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfSection_NormalizesExtraSpaces_ShouldReturnCleanedText()
+    {
+        // Arrange
+        var sections = await Fixture.DbContext.PdfSections.ToListAsync();
+        if (!sections.Any())
+        {
+            Fixture.DbContext.PdfSections.Add(new PdfSection
+            {
+                Title = "Тестова секція",
+                Description = "Тестовий опис",
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
+        var updateDto = new PdfSectionDto
+        {
+            Title = "  Оновлена   назва  ",
+            Description = "  Опис   з   пробілами  "
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(updateDto, JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync("/api/PdfSection", content);
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfSectionDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(result);
+        Assert.Equal("Оновлена назва", result!.Title);
+        Assert.Equal("Опис з пробілами", result.Description);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/GetPdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/GetPdfSectionHandlerTests.cs
@@ -1,18 +1,18 @@
 using Moq;
 using VictoryCenter.BLL.Constants;
-using VictoryCenter.BLL.Queries.Admin.PdfSectionWithReport;
+using VictoryCenter.BLL.Queries.Admin.PdfSection.Get;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfSections;
 
-public class GetPdfSectionWithReportsHandlerTests
+public class GetPdfSectionHandlerTests
 {
     private readonly Mock<IRepositoryWrapper> _mockRepo;
     private readonly PdfSection _pdfSection;
 
-    public GetPdfSectionWithReportsHandlerTests()
+    public GetPdfSectionHandlerTests()
     {
         _mockRepo = new Mock<IRepositoryWrapper>();
         _pdfSection = new PdfSection
@@ -31,10 +31,10 @@ public class GetPdfSectionWithReportsHandlerTests
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_pdfSection);
 
-        var handler = new GetPdfSectionWithReportsHandler(_mockRepo.Object);
+        var handler = new GetPdfSectionHandler(_mockRepo.Object);
 
         // Act
-        var result = await handler.Handle(new GetPdfSectionWithReportsQuery(), CancellationToken.None);
+        var result = await handler.Handle(new GetPdfSectionQuery(), CancellationToken.None);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -49,10 +49,10 @@ public class GetPdfSectionWithReportsHandlerTests
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync((PdfSection?)null);
 
-        var handler = new GetPdfSectionWithReportsHandler(_mockRepo.Object);
+        var handler = new GetPdfSectionHandler(_mockRepo.Object);
 
         // Act
-        var result = await handler.Handle(new GetPdfSectionWithReportsQuery(), CancellationToken.None);
+        var result = await handler.Handle(new GetPdfSectionQuery(), CancellationToken.None);
 
         // Assert
         Assert.False(result.IsSuccess);
@@ -66,10 +66,10 @@ public class GetPdfSectionWithReportsHandlerTests
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_pdfSection);
 
-        var handler = new GetPdfSectionWithReportsHandler(_mockRepo.Object);
+        var handler = new GetPdfSectionHandler(_mockRepo.Object);
 
         // Act
-        var result = await handler.Handle(new GetPdfSectionWithReportsQuery(), CancellationToken.None);
+        var result = await handler.Handle(new GetPdfSectionQuery(), CancellationToken.None);
 
         // Assert
         Assert.True(result.IsSuccess);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
@@ -113,7 +113,37 @@ public class UpdatePdfSectionHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SaveChangesFails_ReturnsFailResult()
+    public async Task Handle_SameDataAsExisting_ReturnsSuccessWithoutSaveChanges()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = _existingSection.Title,
+            Description = _existingSection.Description
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_existingSection.Title, result.Value.Title);
+        Assert.Equal(_existingSection.Description, result.Value.Description);
+
+        _mockRepo.Verify(r => r.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesReturnsZero_ReturnsFailResult()
     {
         // Arrange
         var updateDto = new PdfSectionDto
@@ -212,62 +242,6 @@ public class UpdatePdfSectionHandlerTests
 
         _mockRepo.Setup(r => r.SaveChangesAsync())
                  .ThrowsAsync(new DbUpdateException());
-
-        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-    }
-
-    [Fact]
-    public async Task Handle_SameData_UpdatesSuccessfully()
-    {
-        // Arrange
-        var updateDto = new PdfSectionDto
-        {
-            Title = _existingSection.Title,
-            Description = _existingSection.Description
-        };
-        var command = new UpdatePdfSectionCommand(updateDto);
-
-        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
-                 .ReturnsAsync(1);
-        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
-                 .ReturnsAsync(_existingSection);
-        _mockRepo.Setup(r => r.SaveChangesAsync())
-                 .ReturnsAsync(1);
-
-        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-        Assert.Equal(_existingSection.Title, result.Value.Title);
-        Assert.Equal(_existingSection.Description, result.Value.Description);
-    }
-
-    [Fact]
-    public async Task Handle_DbUpdateConcurrencyException_ReturnsFailResult()
-    {
-        // Arrange
-        var updateDto = new PdfSectionDto
-        {
-            Title = "Нова назва",
-            Description = "Новий опис"
-        };
-        var command = new UpdatePdfSectionCommand(updateDto);
-
-        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
-                 .ReturnsAsync(1);
-        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
-                 .ReturnsAsync(_existingSection);
-        _mockRepo.Setup(r => r.SaveChangesAsync())
-                 .ThrowsAsync(new DbUpdateConcurrencyException());
 
         var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
@@ -41,6 +41,9 @@ public class UpdatePdfSectionHandlerTests
         };
         var command = new UpdatePdfSectionCommand(updateDto);
 
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_existingSection);
 
@@ -63,7 +66,7 @@ public class UpdatePdfSectionHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SectionNotFound_ReturnsFailResult()
+    public async Task Handle_NoSectionExists_ReturnsFailResult()
     {
         // Arrange
         var updateDto = new PdfSectionDto
@@ -73,8 +76,8 @@ public class UpdatePdfSectionHandlerTests
         };
         var command = new UpdatePdfSectionCommand(updateDto);
 
-        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
-                 .ReturnsAsync((PdfSection?)null);
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(0);
 
         var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
 
@@ -87,6 +90,30 @@ public class UpdatePdfSectionHandlerTests
     }
 
     [Fact]
+    public async Task Handle_MultipleSectionsExist_ReturnsFailResult()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = "Новий опис"
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(2);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Multiple", result.Errors.Select(e => e.Message).First());
+    }
+
+    [Fact]
     public async Task Handle_SaveChangesFails_ReturnsFailResult()
     {
         // Arrange
@@ -96,6 +123,9 @@ public class UpdatePdfSectionHandlerTests
             Description = "Новий опис"
         };
         var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
 
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_existingSection);
@@ -143,6 +173,9 @@ public class UpdatePdfSectionHandlerTests
         };
         var command = new UpdatePdfSectionCommand(updateDto);
 
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_existingSection);
 
@@ -171,6 +204,9 @@ public class UpdatePdfSectionHandlerTests
             Description = "Новий опис"
         };
         var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
 
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_existingSection);
@@ -219,6 +255,9 @@ public class UpdatePdfSectionHandlerTests
             Description = description160Chars
         };
         var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
 
         _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
                  .ReturnsAsync(_existingSection);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
@@ -186,4 +186,54 @@ public class UpdatePdfSectionHandlerTests
         // Assert
         Assert.False(result.IsSuccess);
     }
+
+    [Fact]
+    public async Task Handle_DescriptionLongerThan160Chars_ReturnsFailResult()
+    {
+        // Arrange
+        var longDescription = new string('a', 161);
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = longDescription
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_DescriptionExactly160Chars_UpdatesSuccessfully()
+    {
+        // Arrange
+        var description160Chars = new string('a', 160);
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = description160Chars
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ReturnsAsync(1);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(description160Chars, result.Value.Description);
+    }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
@@ -1,0 +1,189 @@
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.PdfSection.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfSection;
+using VictoryCenter.BLL.Validators.PdfSection;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfSections;
+
+public class UpdatePdfSectionHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _mockRepo;
+    private readonly IValidator<UpdatePdfSectionCommand> _validator;
+    private readonly PdfSection _existingSection;
+
+    public UpdatePdfSectionHandlerTests()
+    {
+        _mockRepo = new Mock<IRepositoryWrapper>();
+        _validator = new UpdatePdfSectionValidator();
+        _existingSection = new PdfSection
+        {
+            Id = 1,
+            Title = "Стара назва",
+            Description = "Старий опис",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesSectionAndReturnsUpdatedDto()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = "Новий опис"
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ReturnsAsync(1);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal("Нова назва", result.Value.Title);
+        Assert.Equal("Новий опис", result.Value.Description);
+
+        _mockRepo.Verify(r => r.PdfSectionRepository.Update(It.IsAny<PdfSection>()), Times.Once);
+        _mockRepo.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SectionNotFound_ReturnsFailResult()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = "Новий опис"
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync((PdfSection?)null);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(PdfSectionConstants.SectionNotFound, result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesFails_ReturnsFailResult()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = "Новий опис"
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ReturnsAsync(0);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ValidationFails_ReturnsFailResult()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "",
+            Description = ""
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_NormalizesTextWithExtraSpaces_UpdatesWithCleanedText()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "  Назва   з   пробілами  ",
+            Description = "  Опис   з   пробілами  "
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ReturnsAsync(1);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal("Назва з пробілами", result.Value.Title);
+        Assert.Equal("Опис з пробілами", result.Value.Description);
+    }
+
+    [Fact]
+    public async Task Handle_DbUpdateException_ReturnsFailResult()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = "Новий опис"
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ThrowsAsync(new DbUpdateException());
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSections/UpdatePdfSectionHandlerTests.cs
@@ -61,7 +61,6 @@ public class UpdatePdfSectionHandlerTests
         Assert.Equal("Нова назва", result.Value.Title);
         Assert.Equal("Новий опис", result.Value.Description);
 
-        _mockRepo.Verify(r => r.PdfSectionRepository.Update(It.IsAny<PdfSection>()), Times.Once);
         _mockRepo.Verify(r => r.SaveChangesAsync(), Times.Once);
     }
 
@@ -213,6 +212,62 @@ public class UpdatePdfSectionHandlerTests
 
         _mockRepo.Setup(r => r.SaveChangesAsync())
                  .ThrowsAsync(new DbUpdateException());
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_SameData_UpdatesSuccessfully()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = _existingSection.Title,
+            Description = _existingSection.Description
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ReturnsAsync(1);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_existingSection.Title, result.Value.Title);
+        Assert.Equal(_existingSection.Description, result.Value.Description);
+    }
+
+    [Fact]
+    public async Task Handle_DbUpdateConcurrencyException_ReturnsFailResult()
+    {
+        // Arrange
+        var updateDto = new PdfSectionDto
+        {
+            Title = "Нова назва",
+            Description = "Новий опис"
+        };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(_existingSection);
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ThrowsAsync(new DbUpdateConcurrencyException());
 
         var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
 

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfSectionController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfSectionController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.PdfSection.Update;
 using VictoryCenter.BLL.DTOs.Admin.PdfSection;
-using VictoryCenter.BLL.Queries.Admin.PdfSectionWithReport;
+using VictoryCenter.BLL.Queries.Admin.PdfSection.Get;
 using VictoryCenter.WebAPI.Controllers.Common;
 
 namespace VictoryCenter.WebAPI.Controllers.Admin;
@@ -8,10 +9,19 @@ namespace VictoryCenter.WebAPI.Controllers.Admin;
 public class PdfSectionController : AuthorizedApiController
 {
     [HttpGet("pdf-section")]
-    [ProducesResponseType(typeof(PdfSectionWithReportsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PdfSectionDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetPdfSection()
     {
-        return HandleResult(await Mediator.Send(new GetPdfSectionWithReportsQuery()));
+        return HandleResult(await Mediator.Send(new GetPdfSectionQuery()));
+    }
+
+    [HttpPut]
+    [ProducesResponseType(typeof(PdfSectionDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> UpdatePdfSection([FromBody] PdfSectionDto dto)
+    {
+        return HandleResult(await Mediator.Send(new UpdatePdfSectionCommand(dto)));
     }
 }


### PR DESCRIPTION
## GitHub ticket

* [Issue-1336](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1336)

## Summary of issue

The PDF section content block (title and description) did not have dedicated endpoints for retrieval and update. It relied on an outdated DTO with reports, which complicated usage and did not meet current requirements.

## How it looks like

<img width="1061" height="191" alt="image" src="https://github.com/user-attachments/assets/74925736-30cb-405f-8842-e92f9051f01a" />
<img width="585" height="141" alt="image" src="https://github.com/user-attachments/assets/23151399-5719-4b03-96eb-11b0e83beea8" />
<img width="882" height="200" alt="image" src="https://github.com/user-attachments/assets/79738a44-85b5-46d7-8e12-8ae467a7e4fa" />
<img width="1038" height="203" alt="image" src="https://github.com/user-attachments/assets/a4e5a03f-c063-4ef2-b698-1e14cc39bcfe" />
<img width="600" height="126" alt="image" src="https://github.com/user-attachments/assets/560f200f-7c2f-4801-8fca-8bf9f6f3099b" />

## Summary of change

Added separate GET and PUT endpoints for the PDF section. Introduced a simplified PdfSectionDto without reports. Implemented UpdatePdfSectionCommand with validation, text normalization, and error handling. Updated handlers, validators, and tests to align with the new logic.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PUT endpoint to update PDF section; returns 200/404/400 and normalizes whitespace.

* **Validation**
  * Title: 2–30 chars; Description: 2–160 chars; required messages added (Ukrainian strings); validator enforces rules and surfaces 400 responses.

* **Refactor**
  * GET endpoint and DTO simplified (reports removed; response type updated).

* **Tests**
  * Added unit and integration tests covering update flows, validation, normalization, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->