### PR TITLE
Add MainPage logic

### DIFF
--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ImpactStatisticsConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ImpactStatisticsConfig.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+internal class ImpactStatisticsConfig : IEntityTypeConfiguration<ImpactStatistics>
+{
+    public void Configure(EntityTypeBuilder<ImpactStatistics> entity)
+    {
+        entity
+            .HasKey(e => e.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Description)
+            .IsRequired();
+
+        entity
+            .Property(e => e.ImageId);
+
+        entity
+            .HasOne(e => e.Image)
+            .WithOne()
+            .HasForeignKey<ImpactStatistics>(e => e.ImageId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        entity
+            .Property(e => e.MainPageId)
+            .IsRequired();
+
+        entity
+            .HasMany(e => e.Metrics)
+            .WithOne(e => e.Statistics)
+            .HasForeignKey(e => e.StatisticId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity
+            .Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainAboutUsConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainAboutUsConfig.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+internal class MainAboutUsConfig : IEntityTypeConfiguration<MainAboutUs>
+{
+    public void Configure(EntityTypeBuilder<MainAboutUs> entity)
+    {
+        entity
+            .HasKey(e => e.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Title)
+            .IsRequired();
+
+        entity
+            .Property(e => e.Description)
+            .IsRequired();
+
+        entity
+            .Property(e => e.MainPageId)
+            .IsRequired();
+
+        entity
+            .Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPageConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPageConfig.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+internal class MainPageConfig : IEntityTypeConfiguration<MainPage>
+{
+    public void Configure(EntityTypeBuilder<MainPage> entity)
+    {
+        entity
+            .HasKey(e => e.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Title)
+            .IsRequired();
+
+        entity
+            .Property(e => e.Description)
+            .IsRequired();
+
+        entity
+            .Property(e => e.ImageId);
+
+        entity
+            .HasOne(e => e.Image)
+            .WithOne()
+            .HasForeignKey<MainPage>(e => e.ImageId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        entity
+            .HasOne(e => e.MainAboutUs)
+            .WithOne(e => e.MainPage)
+            .HasForeignKey<MainAboutUs>(e => e.MainPageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity
+            .HasOne(e => e.MainPartners)
+            .WithOne(e => e.MainPage)
+            .HasForeignKey<MainPartners>(e => e.MainPageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity
+            .HasMany(e => e.ImpactStatistics)
+            .WithOne(e => e.MainPage)
+            .HasForeignKey(e => e.MainPageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity
+            .Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPartnersConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPartnersConfig.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+internal class MainPartnersConfig : IEntityTypeConfiguration<MainPartners>
+{
+    public void Configure(EntityTypeBuilder<MainPartners> entity)
+    {
+        entity
+            .HasKey(e => e.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Title)
+            .IsRequired();
+
+        entity
+            .Property(e => e.Description)
+            .IsRequired();
+
+        entity
+            .Property(e => e.MainPageId)
+            .IsRequired();
+
+        entity
+            .Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+internal class MetricConfig : IEntityTypeConfiguration<Metric>
+{
+    public void Configure(EntityTypeBuilder<Metric> entity)
+    {
+        entity
+            .HasKey(e => e.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Value)
+            .IsRequired();
+
+        entity
+            .Property(e => e.Signature)
+            .IsRequired();
+
+        entity
+            .Property(e => e.StatisticId)
+            .IsRequired();
+
+        entity
+            .Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -93,6 +93,16 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<ReportFundsExpendituresRecord> ReportFundsExpendituresRecords { get; set; }
 
+    public DbSet<MainPage> MainPages { get; set; }
+
+    public DbSet<MainAboutUs> MainAboutUs { get; set; }
+
+    public DbSet<MainPartners> MainPartners { get; set; }
+
+    public DbSet<ImpactStatistics> ImpactStatistics { get; set; }
+
+    public DbSet<Metric> Metrics { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ImpactStatistics.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ImpactStatistics.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+namespace VictoryCenter.DAL.Entities;
+
+public class ImpactStatistics : BaseEntity
+{
+    public string Description { get; set; } = null!;
+    public long? ImageId { get; set; }
+    public Image? Image { get; set; }
+
+    public long MainPageId { get; set; }
+    public MainPage MainPage { get; set; } = null!;
+
+    public ICollection<Metric> Metrics { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/MainAboutUs.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/MainAboutUs.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class MainAboutUs : BaseEntity
+{
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+
+    public long MainPageId { get; set; }
+    public MainPage MainPage { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/MainPage.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/MainPage.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+namespace VictoryCenter.DAL.Entities;
+
+public class MainPage : BaseEntity
+{
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+
+    public long? ImageId { get; set; }
+    public Image? Image { get; set; }
+
+    public MainAboutUs? MainAboutUs { get; set; }
+    public MainPartners? MainPartners { get; set; }
+    public ICollection<ImpactStatistics> ImpactStatistics { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/MainPartners.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/MainPartners.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class MainPartners : BaseEntity
+{
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+
+    public long MainPageId { get; set; }
+    public MainPage MainPage { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+namespace VictoryCenter.DAL.Entities;
+
+public class Metric : BaseEntity
+{
+    public long StatisticId { get; set; }
+    public ImpactStatistics Statistics { get; set; } = null!;
+    public string Value { get; set; } = null!;
+    public string Signature { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260404140054_AddMainPage.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260404140054_AddMainPage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404140054_AddMainPage")]
+    partial class AddMainPage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260404140054_AddMainPage.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260404140054_AddMainPage.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMainPage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MainPages",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ImageId = table.Column<long>(type: "bigint", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MainPages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MainPages_Images_ImageId",
+                        column: x => x.ImageId,
+                        principalSchema: "media",
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ImpactStatistics",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ImageId = table.Column<long>(type: "bigint", nullable: true),
+                    MainPageId = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImpactStatistics", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ImpactStatistics_Images_ImageId",
+                        column: x => x.ImageId,
+                        principalSchema: "media",
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ImpactStatistics_MainPages_MainPageId",
+                        column: x => x.MainPageId,
+                        principalTable: "MainPages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MainAboutUs",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    MainPageId = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MainAboutUs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MainAboutUs_MainPages_MainPageId",
+                        column: x => x.MainPageId,
+                        principalTable: "MainPages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MainPartners",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    MainPageId = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MainPartners", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MainPartners_MainPages_MainPageId",
+                        column: x => x.MainPageId,
+                        principalTable: "MainPages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Metrics",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    StatisticId = table.Column<long>(type: "bigint", nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Signature = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Metrics", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Metrics_ImpactStatistics_StatisticId",
+                        column: x => x.StatisticId,
+                        principalTable: "ImpactStatistics",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImpactStatistics_ImageId",
+                table: "ImpactStatistics",
+                column: "ImageId",
+                unique: true,
+                filter: "[ImageId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImpactStatistics_MainPageId",
+                table: "ImpactStatistics",
+                column: "MainPageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainAboutUs_MainPageId",
+                table: "MainAboutUs",
+                column: "MainPageId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainPages_ImageId",
+                table: "MainPages",
+                column: "ImageId",
+                unique: true,
+                filter: "[ImageId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainPartners_MainPageId",
+                table: "MainPartners",
+                column: "MainPageId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Metrics_StatisticId",
+                table: "Metrics",
+                column: "StatisticId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MainAboutUs");
+
+            migrationBuilder.DropTable(
+                name: "MainPartners");
+
+            migrationBuilder.DropTable(
+                name: "Metrics");
+
+            migrationBuilder.DropTable(
+                name: "ImpactStatistics");
+
+            migrationBuilder.DropTable(
+                name: "MainPages");
+        }
+    }
+}


### PR DESCRIPTION
dev
## GitHHub

* [Main JIRA ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2112)

## Summary of issue

<img width="892" height="760" alt="image" src="https://github.com/user-attachments/assets/eebdcba7-25d9-4ef2-a00e-770e250bf7a2" />

Implemented new Main Page entities based on the Figma design and user stories. Added corresponding entity configurations and generated database migrations.



## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for managing impact statistics with descriptions, associated metrics, and image attachments.
  * Added main page content management functionality with title, description, and image support.
  * Added "About Us" section management linked to main pages.
  * Added partners section management with title and description.
  * Enabled metric tracking with configurable value and signature fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->