### PR TITLE
Feature/issue 1323/24: Implement Delete and View PDF files 

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportCommand.cs
@@ -1,0 +1,6 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
+
+public record DeletePdfReportCommand(long Id) : IRequest<Result<Unit>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
@@ -47,14 +47,11 @@ public class DeletePdfReportHandler : IRequestHandler<DeletePdfReportCommand, Re
             using var transaction = _repositoryWrapper.BeginTransaction();
 
             var blobName = pdfReport.BlobName;
-            _repositoryWrapper.PdfReportRepository.Delete(pdfReport);
-            await _reorderService.RenumberPriorityAsync<PdfReport>();
 
-            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
-            {
-                return Result.Fail<Unit>(
-                    ErrorMessagesConstants.FailedToDeleteEntity(typeof(PdfReport)));
-            }
+            _repositoryWrapper.PdfReportRepository.Delete(pdfReport);
+            await _repositoryWrapper.SaveChangesAsync();
+
+            await _reorderService.RenumberPriorityAsync<PdfReport>();
 
             transaction.Complete();
             _pdfService.DeletePdf(blobName);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
@@ -48,6 +48,7 @@ public class DeletePdfReportHandler : IRequestHandler<DeletePdfReportCommand, Re
 
             var blobName = pdfReport.BlobName;
             _repositoryWrapper.PdfReportRepository.Delete(pdfReport);
+            await _reorderService.RenumberPriorityAsync<PdfReport>();
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
@@ -55,12 +56,8 @@ public class DeletePdfReportHandler : IRequestHandler<DeletePdfReportCommand, Re
                     ErrorMessagesConstants.FailedToDeleteEntity(typeof(PdfReport)));
             }
 
-            _pdfService.DeletePdf(blobName);
-            await _reorderService.RenumberPriorityAsync<PdfReport>();
-
-            await _repositoryWrapper.SaveChangesAsync();
-
             transaction.Complete();
+            _pdfService.DeletePdf(blobName);
 
             return Result.Ok(Unit.Value);
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
@@ -1,0 +1,73 @@
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.BLL.Interfaces.ReorderService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
+
+public class DeletePdfReportHandler : IRequestHandler<DeletePdfReportCommand, Result<Unit>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IPdfService _pdfService;
+    private readonly IReorderService _reorderService;
+
+    public DeletePdfReportHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IPdfService pdfService,
+        IReorderService reorderService)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _pdfService = pdfService;
+        _reorderService = reorderService;
+    }
+
+    public async Task<Result<Unit>> Handle(
+        DeletePdfReportCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var pdfReport = await _repositoryWrapper.PdfReportRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<PdfReport>
+                {
+                    Filter = pr => pr.Id == request.Id,
+                    AsNoTracking = false
+                });
+
+            if (pdfReport == null)
+            {
+                return Result.Fail<Unit>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
+            }
+
+            using var transaction = _repositoryWrapper.BeginTransaction();
+
+            var blobName = pdfReport.BlobName;
+            _repositoryWrapper.PdfReportRepository.Delete(pdfReport);
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<Unit>(
+                    ErrorMessagesConstants.FailedToDeleteEntity(typeof(PdfReport)));
+            }
+
+            _pdfService.DeletePdf(blobName);
+            await _reorderService.RenumberPriorityAsync<PdfReport>();
+
+            await _repositoryWrapper.SaveChangesAsync();
+
+            transaction.Complete();
+
+            return Result.Ok(Unit.Value);
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<Unit>(
+                ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(PdfReport)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Delete/DeletePdfReportHandler.cs
@@ -1,7 +1,9 @@
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.BLL.Interfaces.ReorderService;
 using VictoryCenter.DAL.Entities;
@@ -15,53 +17,63 @@ public class DeletePdfReportHandler : IRequestHandler<DeletePdfReportCommand, Re
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IPdfService _pdfService;
     private readonly IReorderService _reorderService;
+    private readonly ILogger<DeletePdfReportHandler> _logger;
 
     public DeletePdfReportHandler(
         IRepositoryWrapper repositoryWrapper,
         IPdfService pdfService,
-        IReorderService reorderService)
+        IReorderService reorderService,
+        ILogger<DeletePdfReportHandler> logger)
     {
         _repositoryWrapper = repositoryWrapper;
         _pdfService = pdfService;
         _reorderService = reorderService;
+        _logger = logger;
     }
 
     public async Task<Result<Unit>> Handle(
         DeletePdfReportCommand request,
         CancellationToken cancellationToken)
     {
+        var pdfReport = await _repositoryWrapper.PdfReportRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<PdfReport>
+            {
+                Filter = pr => pr.Id == request.Id,
+                AsNoTracking = false
+            });
+
+        if (pdfReport == null)
+        {
+            return Result.Fail<Unit>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
+        }
+
+        var blobName = pdfReport.BlobName;
+
         try
         {
-            var pdfReport = await _repositoryWrapper.PdfReportRepository.GetFirstOrDefaultAsync(
-                new QueryOptions<PdfReport>
-                {
-                    Filter = pr => pr.Id == request.Id,
-                    AsNoTracking = false
-                });
-
-            if (pdfReport == null)
-            {
-                return Result.Fail<Unit>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
-            }
-
             using var transaction = _repositoryWrapper.BeginTransaction();
-
-            var blobName = pdfReport.BlobName;
 
             _repositoryWrapper.PdfReportRepository.Delete(pdfReport);
             await _repositoryWrapper.SaveChangesAsync();
-
             await _reorderService.RenumberPriorityAsync<PdfReport>();
 
             transaction.Complete();
-            _pdfService.DeletePdf(blobName);
-
-            return Result.Ok(Unit.Value);
         }
         catch (DbUpdateException)
         {
             return Result.Fail<Unit>(
                 ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(PdfReport)));
         }
+
+        try
+        {
+            _pdfService.DeletePdf(blobName);
+        }
+        catch (BlobFileSystemException ex)
+        {
+            _logger.LogError(ex, "Failed to delete blob {BlobName} after deleting PdfReport with Id {PdfReportId}", blobName, request.Id);
+        }
+
+        return Result.Ok(Unit.Value);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -172,6 +172,11 @@ public static class ErrorMessagesConstants
         return "Failed to retrieve image from storage";
     }
 
+    public static string FailedToRetrievePdf()
+    {
+        return "Failed to retrieve PDF from storage";
+    }
+
     public static string PropertyMustContainOnlyDigits(string property)
     {
         return $"{property} must contain only digits";

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdHandler.cs
@@ -36,8 +36,14 @@ public class GetPdfReportByIdHandler : IRequestHandler<GetPdfReportByIdQuery, Re
             return Result.Fail<Stream>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
         }
 
-        var pdfStream = await _pdfService.GetPdfAsync(pdfReport.BlobName);
-
-        return Result.Ok<Stream>(pdfStream);
+        try
+        {
+            var pdfStream = await _pdfService.GetPdfAsync(pdfReport.BlobName);
+            return Result.Ok<Stream>(pdfStream);
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail<Stream>($"Failed to retrieve PDF file: {ex.Message}");
+        }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdHandler.cs
@@ -1,6 +1,7 @@
 using FluentResults;
 using MediatR;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -41,9 +42,13 @@ public class GetPdfReportByIdHandler : IRequestHandler<GetPdfReportByIdQuery, Re
             var pdfStream = await _pdfService.GetPdfAsync(pdfReport.BlobName);
             return Result.Ok<Stream>(pdfStream);
         }
-        catch (Exception ex)
+        catch (BlobNotFoundException)
         {
-            return Result.Fail<Stream>($"Failed to retrieve PDF file: {ex.Message}");
+            return Result.Fail<Stream>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
+        }
+        catch (BlobFileSystemException)
+        {
+            return Result.Fail<Stream>(ErrorMessagesConstants.FailedToRetrievePdf());
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdHandler.cs
@@ -1,0 +1,43 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetById;
+
+public class GetPdfReportByIdHandler : IRequestHandler<GetPdfReportByIdQuery, Result<Stream>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IPdfService _pdfService;
+
+    public GetPdfReportByIdHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IPdfService pdfService)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _pdfService = pdfService;
+    }
+
+    public async Task<Result<Stream>> Handle(GetPdfReportByIdQuery request, CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<PdfReport>
+        {
+            AsNoTracking = true,
+            Filter = p => p.Id == request.Id
+        };
+        var pdfReport = await _repositoryWrapper.PdfReportRepository
+            .GetFirstOrDefaultAsync(queryOptions);
+
+        if (pdfReport == null)
+        {
+            return Result.Fail<Stream>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
+        }
+
+        var pdfStream = await _pdfService.GetPdfAsync(pdfReport.BlobName);
+
+        return Result.Ok<Stream>(pdfStream);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetById/GetPdfReportByIdQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetById;
+
+public record GetPdfReportByIdQuery(long Id)
+    : IRequest<Result<Stream>>;

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Delete/DeletePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Delete/DeletePdfReportTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.Delete;
+
+public class DeletePdfReportTests : BaseTestClass
+{
+    private static readonly byte[] PdfSignatureBytes =
+        [0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34];
+
+    public DeletePdfReportTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_ValidRequest_ShouldDeleteAndReturnOk()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("delete-valid-test", 1);
+        var countBefore = await Fixture.DbContext.PdfReports.CountAsync();
+
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/PdfReports/{report.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        var countAfter = await Fixture.DbContext.PdfReports.CountAsync();
+        Assert.Equal(countBefore - 1, countAfter);
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_ShouldRemoveFileFromDisk()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("delete-file-cleanup", 1);
+
+        var filePath = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, report.BlobName);
+        Assert.True(File.Exists(filePath), $"File should exist before delete: {filePath}");
+
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/PdfReports/{report.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(File.Exists(filePath), $"File should be removed after delete: {filePath}");
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_AfterDelete_ReportShouldNotExistInDatabase()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("delete-db-check", 1);
+        var savedId = report.Id;
+
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/PdfReports/{savedId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        var stillExists = await Fixture.DbContext.PdfReports.AnyAsync(r => r.Id == savedId);
+        Assert.False(stillExists);
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_InvalidId_ShouldReturnNotFound()
+    {
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync("/api/PdfReports/999999");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_ShouldReorderRemainingPriorities()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+
+        var report1 = await CreateReportWithFileAsync("reorder-1", 1);
+        var report2 = await CreateReportWithFileAsync("reorder-2", 2);
+        var report3 = await CreateReportWithFileAsync("reorder-3", 3);
+
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/PdfReports/{report1.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        var remaining = await Fixture.DbContext.PdfReports
+            .OrderBy(r => r.Priority)
+            .ToListAsync();
+
+        Assert.Equal(2, remaining.Count);
+
+        for (var i = 0; i < remaining.Count; i++)
+        {
+            Assert.Equal(i + 1, remaining[i].Priority);
+        }
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_DeleteMiddleReport_ShouldReorderCorrectly()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+
+        var report1 = await CreateReportWithFileAsync("middle-1", 1);
+        var report2 = await CreateReportWithFileAsync("middle-2", 2);
+        var report3 = await CreateReportWithFileAsync("middle-3", 3);
+
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/PdfReports/{report2.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        var remaining = await Fixture.DbContext.PdfReports
+            .OrderBy(r => r.Priority)
+            .ToListAsync();
+
+        Assert.Equal(2, remaining.Count);
+        Assert.Equal(1, remaining[0].Priority);
+        Assert.Equal(2, remaining[1].Priority);
+    }
+
+    [Fact]
+    public async Task DeletePdfReport_OnlyOneReport_ShouldDeleteSuccessfully()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("single-report", 1);
+
+        // Act
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/PdfReports/{report.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        Assert.Equal(0, await Fixture.DbContext.PdfReports.CountAsync());
+    }
+
+    /// <summary>
+    /// Removes all PdfReport rows and their files so each test starts clean.
+    /// </summary>
+    private async Task ClearPdfReportsAsync()
+    {
+        var all = await Fixture.DbContext.PdfReports.ToListAsync();
+
+        foreach (var r in all)
+        {
+            var fp = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, r.BlobName);
+            if (File.Exists(fp))
+            {
+                File.Delete(fp);
+            }
+        }
+
+        Fixture.DbContext.PdfReports.RemoveRange(all);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+    }
+
+    /// <summary>
+    /// Writes a real PDF file to disk and inserts a matching DB record.
+    /// BlobName is always "{baseName}.pdf" — exactly what PdfService produces.
+    /// </summary>
+    private async Task<PdfReport> CreateReportWithFileAsync(string baseName, int priority)
+    {
+        var blobName = $"{baseName}.pdf";
+        var filePath = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, blobName);
+
+        Directory.CreateDirectory(Fixture.PdfEnvironmentVariables.FullPath);
+
+        await File.WriteAllBytesAsync(filePath, PdfSignatureBytes);
+
+        var report = new PdfReport
+        {
+            Name = baseName,
+            BlobName = blobName,
+            FileSizeBytes = PdfSignatureBytes.Length,
+            Priority = priority,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        Fixture.DbContext.PdfReports.Add(report);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        return report;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Delete/DeletePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Delete/DeletePdfReportTests.cs
@@ -100,11 +100,16 @@ public class DeletePdfReportTests : BaseTestClass
 
         Fixture.DbContext.ChangeTracker.Clear();
 
+        var deletedStillExists = await Fixture.DbContext.PdfReports.AnyAsync(r => r.Id == report1.Id);
+        Assert.False(deletedStillExists, "Deleted report should not exist in database");
+
         var remaining = await Fixture.DbContext.PdfReports
             .OrderBy(r => r.Priority)
             .ToListAsync();
 
         Assert.Equal(2, remaining.Count);
+        Assert.Equal(report2.Id, remaining[0].Id);
+        Assert.Equal(report3.Id, remaining[1].Id);
 
         for (var i = 0; i < remaining.Count; i++)
         {
@@ -130,11 +135,16 @@ public class DeletePdfReportTests : BaseTestClass
 
         Fixture.DbContext.ChangeTracker.Clear();
 
+        var deletedStillExists = await Fixture.DbContext.PdfReports.AnyAsync(r => r.Id == report2.Id);
+        Assert.False(deletedStillExists, "Deleted report should not exist in database");
+
         var remaining = await Fixture.DbContext.PdfReports
             .OrderBy(r => r.Priority)
             .ToListAsync();
 
         Assert.Equal(2, remaining.Count);
+        Assert.Equal(report1.Id, remaining[0].Id);
+        Assert.Equal(report3.Id, remaining[1].Id);
         Assert.Equal(1, remaining[0].Priority);
         Assert.Equal(2, remaining[1].Priority);
     }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetById/GetPdfReportByIdTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetById/GetPdfReportByIdTests.cs
@@ -149,6 +149,14 @@ public class GetPdfReportByIdTests : BaseTestClass
         }
 
         Fixture.DbContext.PdfReports.RemoveRange(all);
+
+        foreach (var entry in Fixture.DbContext.ChangeTracker.Entries()
+        .Where(e => !all.Contains(e.Entity))
+        .ToList())
+        {
+            entry.State = EntityState.Detached;
+        }
+
         await Fixture.DbContext.SaveChangesAsync();
         Fixture.DbContext.ChangeTracker.Clear();
     }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetById/GetPdfReportByIdTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetById/GetPdfReportByIdTests.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.GetById;
+
+public class GetPdfReportByIdTests : BaseTestClass
+{
+    private static readonly byte[] PdfSignatureBytes =
+        [0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34];
+
+    public GetPdfReportByIdTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_ValidId_ShouldReturnOk()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("get-valid-test", 1);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_ValidId_ShouldReturnPdfContentType()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("get-content-type-test", 1);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_ValidId_ShouldReturnCorrectFileBytes()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("get-bytes-test", 1);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report.Id}");
+        var responseBytes = await response.Content.ReadAsByteArrayAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(PdfSignatureBytes, responseBytes);
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_ValidId_ShouldNotAlterDatabaseRecord()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("get-no-alter-test", 1);
+        var countBefore = await Fixture.DbContext.PdfReports.CountAsync();
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report.Id}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        var countAfter = await Fixture.DbContext.PdfReports.CountAsync();
+        Assert.Equal(countBefore, countAfter);
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_InvalidId_ShouldReturnNotFound()
+    {
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("/api/PdfReports/999999");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_ValidId_ResponseShouldNotBeEmpty()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("get-not-empty-test", 1);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report.Id}");
+        var responseBytes = await response.Content.ReadAsByteArrayAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotEmpty(responseBytes);
+    }
+
+    [Fact]
+    public async Task GetPdfReportById_MultipleReports_ShouldReturnCorrectOne()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report1 = await CreateReportWithFileAsync("multi-get-1", 1);
+        var report2 = await CreateReportWithFileAsync("multi-get-2", 2);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report2.Id}");
+        var responseBytes = await response.Content.ReadAsByteArrayAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(PdfSignatureBytes, responseBytes);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        var fetchedReport = await Fixture.DbContext.PdfReports
+            .FirstOrDefaultAsync(r => r.Id == report2.Id);
+
+        Assert.NotNull(fetchedReport);
+        Assert.Equal(report2.BlobName, fetchedReport.BlobName);
+    }
+
+    /// <summary>
+    /// Removes all PdfReport rows and their files so each test starts clean.
+    /// </summary>
+    private async Task ClearPdfReportsAsync()
+    {
+        var all = await Fixture.DbContext.PdfReports.ToListAsync();
+
+        foreach (var r in all)
+        {
+            var fp = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, r.BlobName);
+            if (File.Exists(fp))
+            {
+                File.Delete(fp);
+            }
+        }
+
+        Fixture.DbContext.PdfReports.RemoveRange(all);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+    }
+
+    /// <summary>
+    /// Writes a real PDF file to disk and inserts a matching DB record.
+    /// BlobName is always "{baseName}.pdf" — exactly what PdfService produces.
+    /// </summary>
+    private async Task<PdfReport> CreateReportWithFileAsync(string baseName, int priority)
+    {
+        var blobName = $"{baseName}.pdf";
+        var filePath = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, blobName);
+
+        Directory.CreateDirectory(Fixture.PdfEnvironmentVariables.FullPath);
+
+        await File.WriteAllBytesAsync(filePath, PdfSignatureBytes);
+
+        var report = new PdfReport
+        {
+            Name = baseName,
+            BlobName = blobName,
+            FileSizeBytes = PdfSignatureBytes.Length,
+            Priority = priority,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        Fixture.DbContext.PdfReports.Add(report);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        return report;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetById/GetPdfReportByIdTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/GetById/GetPdfReportByIdTests.cs
@@ -111,8 +111,10 @@ public class GetPdfReportByIdTests : BaseTestClass
     {
         // Arrange
         await ClearPdfReportsAsync();
-        var report1 = await CreateReportWithFileAsync("multi-get-1", 1);
-        var report2 = await CreateReportWithFileAsync("multi-get-2", 2);
+        var bytes1 = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x01 };
+        var bytes2 = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x02 };
+        var report1 = await CreateReportWithFileAsync("multi-get-1", 1, bytes1);
+        var report2 = await CreateReportWithFileAsync("multi-get-2", 2, bytes2);
 
         // Act
         var response = await Fixture.HttpClient.GetAsync($"/api/PdfReports/{report2.Id}");
@@ -120,7 +122,7 @@ public class GetPdfReportByIdTests : BaseTestClass
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.Equal(PdfSignatureBytes, responseBytes);
+        Assert.Equal(bytes2, responseBytes);
 
         Fixture.DbContext.ChangeTracker.Clear();
         var fetchedReport = await Fixture.DbContext.PdfReports
@@ -155,20 +157,24 @@ public class GetPdfReportByIdTests : BaseTestClass
     /// Writes a real PDF file to disk and inserts a matching DB record.
     /// BlobName is always "{baseName}.pdf" — exactly what PdfService produces.
     /// </summary>
-    private async Task<PdfReport> CreateReportWithFileAsync(string baseName, int priority)
+    private async Task<PdfReport> CreateReportWithFileAsync(
+        string baseName,
+        int priority,
+        byte[] fileBytes = null!)
     {
         var blobName = $"{baseName}.pdf";
         var filePath = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, blobName);
 
         Directory.CreateDirectory(Fixture.PdfEnvironmentVariables.FullPath);
 
-        await File.WriteAllBytesAsync(filePath, PdfSignatureBytes);
+        var content = fileBytes ?? PdfSignatureBytes;
+        await File.WriteAllBytesAsync(filePath, content);
 
         var report = new PdfReport
         {
             Name = baseName,
             BlobName = blobName,
-            FileSizeBytes = PdfSignatureBytes.Length,
+            FileSizeBytes = content.Length,
             Priority = priority,
             CreatedAt = DateTimeOffset.UtcNow
         };

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/DeletePdfReportHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/DeletePdfReportHandlerTests.cs
@@ -1,0 +1,154 @@
+using System.Transactions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.BLL.Interfaces.ReorderService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
+
+public class DeletePdfReportHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _mockRepo;
+    private readonly Mock<IPdfService> _mockPdfService;
+    private readonly Mock<IReorderService> _mockReorderService;
+    private readonly PdfReport _existingReport;
+
+    public DeletePdfReportHandlerTests()
+    {
+        _mockRepo = new Mock<IRepositoryWrapper>();
+        _mockPdfService = new Mock<IPdfService>();
+        _mockReorderService = new Mock<IReorderService>();
+        _existingReport = new PdfReport
+        {
+            Id = 1,
+            Name = "Report 2024",
+            BlobName = "blob-name-123",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _mockRepo.Setup(r => r.BeginTransaction())
+                 .Returns(() => new TransactionScope(
+                     TransactionScopeOption.Suppress,
+                     TransactionScopeAsyncFlowOption.Enabled));
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_DeletesReportAndReorders()
+    {
+        // Arrange
+        var command = new DeletePdfReportCommand(1);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.GetFirstOrDefaultAsync(
+                     It.IsAny<QueryOptions<PdfReport>>()))
+                 .ReturnsAsync(_existingReport);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.Delete(It.IsAny<PdfReport>()));
+
+        _mockRepo.SetupSequence(r => r.SaveChangesAsync())
+                 .ReturnsAsync(1)
+                 .ReturnsAsync(1);
+
+        _mockPdfService.Setup(p => p.DeletePdf(It.IsAny<string>()));
+
+        _mockReorderService.Setup(r => r.RenumberPriorityAsync<PdfReport>(
+                                It.IsAny<System.Linq.Expressions.Expression<Func<PdfReport, bool>>>()))
+                           .Returns(Task.CompletedTask);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _mockRepo.Verify(r => r.PdfReportRepository.Delete(_existingReport), Times.Once);
+        _mockPdfService.Verify(p => p.DeletePdf(_existingReport.BlobName), Times.Once);
+        _mockReorderService.Verify(
+            r => r.RenumberPriorityAsync<PdfReport>(
+            It.IsAny<System.Linq.Expressions.Expression<Func<PdfReport, bool>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReportNotFound_ReturnsFailResult()
+    {
+        // Arrange
+        var command = new DeletePdfReportCommand(999);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.GetFirstOrDefaultAsync(
+                     It.IsAny<QueryOptions<PdfReport>>()))
+                 .ReturnsAsync((PdfReport)null!);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(999, typeof(PdfReport)),
+            result.Errors.Select(e => e.Message));
+        _mockRepo.Verify(r => r.PdfReportRepository.Delete(It.IsAny<PdfReport>()), Times.Never);
+        _mockPdfService.Verify(p => p.DeletePdf(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesAfterDeleteFails_ReturnsFailResult()
+    {
+        // Arrange
+        var command = new DeletePdfReportCommand(1);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.GetFirstOrDefaultAsync(
+                     It.IsAny<QueryOptions<PdfReport>>()))
+                 .ReturnsAsync(_existingReport);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.Delete(It.IsAny<PdfReport>()));
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ReturnsAsync(0);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        _mockPdfService.Verify(p => p.DeletePdf(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DbUpdateException_ReturnsFailResult()
+    {
+        // Arrange
+        var command = new DeletePdfReportCommand(1);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.GetFirstOrDefaultAsync(
+                     It.IsAny<QueryOptions<PdfReport>>()))
+                 .ReturnsAsync(_existingReport);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.Delete(It.IsAny<PdfReport>()));
+
+        _mockRepo.Setup(r => r.SaveChangesAsync())
+                 .ThrowsAsync(new DbUpdateException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        _mockPdfService.Verify(p => p.DeletePdf(It.IsAny<string>()), Times.Never);
+    }
+
+    private DeletePdfReportHandler CreateHandler() =>
+        new(_mockRepo.Object, _mockPdfService.Object, _mockReorderService.Object);
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/DeletePdfReportHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/DeletePdfReportHandlerTests.cs
@@ -100,31 +100,6 @@ public class DeletePdfReportHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SaveChangesAfterDeleteFails_ReturnsFailResult()
-    {
-        // Arrange
-        var command = new DeletePdfReportCommand(1);
-
-        _mockRepo.Setup(r => r.PdfReportRepository.GetFirstOrDefaultAsync(
-                     It.IsAny<QueryOptions<PdfReport>>()))
-                 .ReturnsAsync(_existingReport);
-
-        _mockRepo.Setup(r => r.PdfReportRepository.Delete(It.IsAny<PdfReport>()));
-
-        _mockRepo.Setup(r => r.SaveChangesAsync())
-                 .ReturnsAsync(0);
-
-        var handler = CreateHandler();
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        _mockPdfService.Verify(p => p.DeletePdf(It.IsAny<string>()), Times.Never);
-    }
-
-    [Fact]
     public async Task Handle_DbUpdateException_ReturnsFailResult()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/DeletePdfReportHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/DeletePdfReportHandlerTests.cs
@@ -1,8 +1,10 @@
 using System.Transactions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.BLL.Interfaces.ReorderService;
 using VictoryCenter.DAL.Entities;
@@ -16,6 +18,7 @@ public class DeletePdfReportHandlerTests
     private readonly Mock<IRepositoryWrapper> _mockRepo;
     private readonly Mock<IPdfService> _mockPdfService;
     private readonly Mock<IReorderService> _mockReorderService;
+    private readonly Mock<ILogger<DeletePdfReportHandler>> _mockLogger;
     private readonly PdfReport _existingReport;
 
     public DeletePdfReportHandlerTests()
@@ -23,6 +26,7 @@ public class DeletePdfReportHandlerTests
         _mockRepo = new Mock<IRepositoryWrapper>();
         _mockPdfService = new Mock<IPdfService>();
         _mockReorderService = new Mock<IReorderService>();
+        _mockLogger = new Mock<ILogger<DeletePdfReportHandler>>();
         _existingReport = new PdfReport
         {
             Id = 1,
@@ -124,6 +128,46 @@ public class DeletePdfReportHandlerTests
         _mockPdfService.Verify(p => p.DeletePdf(It.IsAny<string>()), Times.Never);
     }
 
+    [Fact]
+    public async Task Handle_BlobDeleteThrows_ReturnsSuccessAndLogsError()
+    {
+        // Arrange
+        var command = new DeletePdfReportCommand(1);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.GetFirstOrDefaultAsync(
+                     It.IsAny<QueryOptions<PdfReport>>()))
+                 .ReturnsAsync(_existingReport);
+
+        _mockRepo.Setup(r => r.PdfReportRepository.Delete(It.IsAny<PdfReport>()));
+
+        _mockRepo.SetupSequence(r => r.SaveChangesAsync())
+                 .ReturnsAsync(1);
+
+        _mockPdfService.Setup(p => p.DeletePdf(It.IsAny<string>()))
+               .Throws(new BlobFileSystemException("blob-name-123", "Failed to delete"));
+
+        _mockReorderService.Setup(r => r.RenumberPriorityAsync<PdfReport>(
+                                It.IsAny<System.Linq.Expressions.Expression<Func<PdfReport, bool>>>()))
+                           .Returns(Task.CompletedTask);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _mockPdfService.Verify(p => p.DeletePdf(_existingReport.BlobName), Times.Once);
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     private DeletePdfReportHandler CreateHandler() =>
-        new(_mockRepo.Object, _mockPdfService.Object, _mockReorderService.Object);
+        new(_mockRepo.Object, _mockPdfService.Object, _mockReorderService.Object, _mockLogger.Object);
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPdfReportByIdHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPdfReportByIdHandlerTests.cs
@@ -1,5 +1,6 @@
 using Moq;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Exceptions.BlobStorageExceptions;
 using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.BLL.Queries.Admin.PdfReports.GetById;
 using VictoryCenter.DAL.Entities;
@@ -92,32 +93,41 @@ public class GetPdfReportByIdHandlerTests
     }
 
     [Fact]
-    public async Task Handle_PdfServiceThrowsException_ReturnsFailResult()
+    public async Task Handle_BlobNotFound_ReturnsFailResult()
     {
-        // Arrange
         _mockRepositoryWrapper
             .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
             .ReturnsAsync(_testPdfReport);
 
         _mockPdfService
             .Setup(x => x.GetPdfAsync(_testPdfReport.BlobName))
-            .ThrowsAsync(new IOException("File not found"));
+            .ThrowsAsync(new BlobNotFoundException("report-2024.pdf", "Not found"));
 
-        var query = new GetPdfReportByIdQuery(1);
+        var result = await CreateHandler().Handle(new GetPdfReportByIdQuery(1), CancellationToken.None);
 
-        // Act
-        var result = await CreateHandler().Handle(query, CancellationToken.None);
-
-        // Assert
         Assert.False(result.IsSuccess);
-        Assert.Contains("Failed to retrieve PDF file", result.Errors.Select(e => e.Message).FirstOrDefault() ?? string.Empty);
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(1, typeof(PdfReport)),
+            result.Errors.Select(e => e.Message));
+    }
 
-        _mockRepositoryWrapper.Verify(
-            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
-            Times.Once);
-        _mockPdfService.Verify(
-            x => x.GetPdfAsync(_testPdfReport.BlobName),
-            Times.Once);
+    [Fact]
+    public async Task Handle_BlobFileSystemException_ReturnsFailResult()
+    {
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockPdfService
+            .Setup(x => x.GetPdfAsync(_testPdfReport.BlobName))
+            .ThrowsAsync(new BlobFileSystemException("report-2024.pdf", "Read failed"));
+
+        var result = await CreateHandler().Handle(new GetPdfReportByIdQuery(1), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToRetrievePdf(),
+            result.Errors.Select(e => e.Message));
     }
 
     private GetPdfReportByIdHandler CreateHandler() =>

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPdfReportByIdHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPdfReportByIdHandlerTests.cs
@@ -105,11 +105,18 @@ public class GetPdfReportByIdHandlerTests
 
         var query = new GetPdfReportByIdQuery(1);
 
-        // Act & Assert
-        await Assert.ThrowsAsync<IOException>(() => CreateHandler().Handle(query, CancellationToken.None));
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Failed to retrieve PDF file", result.Errors.Select(e => e.Message).FirstOrDefault() ?? string.Empty);
 
         _mockRepositoryWrapper.Verify(
             x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Once);
+        _mockPdfService.Verify(
+            x => x.GetPdfAsync(_testPdfReport.BlobName),
             Times.Once);
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPdfReportByIdHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPdfReportByIdHandlerTests.cs
@@ -1,0 +1,118 @@
+using Moq;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.PdfStorage;
+using VictoryCenter.BLL.Queries.Admin.PdfReports.GetById;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
+
+public class GetPdfReportByIdHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IPdfService> _mockPdfService;
+
+    private readonly PdfReport _testPdfReport;
+
+    public GetPdfReportByIdHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockPdfService = new Mock<IPdfService>();
+
+        _testPdfReport = new PdfReport
+        {
+            Id = 1,
+            Name = "Звіт 2024",
+            BlobName = "report-2024.pdf",
+            Priority = 1,
+            FileSizeBytes = 1024,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    [Fact]
+    public async Task Handle_ValidPdfReportId_ReturnsPdfStream()
+    {
+        // Arrange
+        var pdfBytes = new byte[] { 37, 80, 68, 70 }; // PDF magic bytes: %PDF
+        var pdfStream = new MemoryStream(pdfBytes);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockPdfService
+            .Setup(x => x.GetPdfAsync(_testPdfReport.BlobName))
+            .ReturnsAsync(pdfStream);
+
+        var query = new GetPdfReportByIdQuery(1);
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Same(pdfStream, result.Value);
+
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Once);
+        _mockPdfService.Verify(
+            x => x.GetPdfAsync(_testPdfReport.BlobName),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PdfReportNotFound_ReturnsFailResult()
+    {
+        // Arrange
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync((PdfReport?)null);
+
+        var query = new GetPdfReportByIdQuery(999);
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(999, typeof(PdfReport)),
+            result.Errors.Select(e => e.Message));
+
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Once);
+        _mockPdfService.Verify(
+            x => x.GetPdfAsync(It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_PdfServiceThrowsException_ReturnsFailResult()
+    {
+        // Arrange
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockPdfService
+            .Setup(x => x.GetPdfAsync(_testPdfReport.BlobName))
+            .ThrowsAsync(new IOException("File not found"));
+
+        var query = new GetPdfReportByIdQuery(1);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<IOException>(() => CreateHandler().Handle(query, CancellationToken.None));
+
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Once);
+    }
+
+    private GetPdfReportByIdHandler CreateHandler() =>
+        new(_mockRepositoryWrapper.Object, _mockPdfService.Object);
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -5,6 +5,7 @@ using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
+using VictoryCenter.BLL.Queries.Admin.PdfReports.GetById;
 using VictoryCenter.WebAPI.Controllers.Common;
 
 namespace VictoryCenter.WebAPI.Controllers.Admin;
@@ -24,6 +25,21 @@ public class PdfReportsController : AuthorizedApiController
     public async Task<IActionResult> GetAllPdfReports([FromQuery] BaseFilterDto filter)
     {
         return HandleResult(await Mediator.Send(new GetAllPdfReportsQuery(filter)));
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPdfReportById(long id)
+    {
+        var result = await Mediator.Send(new GetPdfReportByIdQuery(id));
+
+        if (!result.IsSuccess)
+        {
+            return HandleResult(result);
+        }
+
+        return File(result.Value, "application/pdf", fileDownloadName: null);
     }
 
     [HttpDelete("{id}")]

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
 using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.DTOs.Common;
@@ -23,5 +24,13 @@ public class PdfReportsController : AuthorizedApiController
     public async Task<IActionResult> GetAllPdfReports([FromQuery] BaseFilterDto filter)
     {
         return HandleResult(await Mediator.Send(new GetAllPdfReportsQuery(filter)));
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeletePdfReport(long id)
+    {
+        return HandleResult(await Mediator.Send(new DeletePdfReportCommand(id)));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -28,6 +28,7 @@ public class PdfReportsController : AuthorizedApiController
     }
 
     [HttpGet("{id}")]
+    [Produces("application/pdf")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetPdfReportById(long id)


### PR DESCRIPTION
## Github ticket

* [Github ticket 1323](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1323)
* [Github ticket 1324](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1324)

## Summary of issue

There was no ability to retrieve a PDF report by its ID from storage.
There was no functionality to delete a PDF report, including both database record and associated file in blob storage.
Missing error handling for cases when a PDF report does not exist.
API endpoints for managing PDF reports were incomplete.

## Summary of change

- Added GetPdfReportByIdQuery and handler to retrieve a PDF file stream by report ID.
- Implemented DeletePdfReportCommand and handler to:
- Remove the PDF report from the database
- Delete the corresponding file from blob storage
- Reorder remaining entities after deletion
- Extended PdfReportsController with:
- GET /{id} endpoint for downloading PDF reports
- DELETE /{id} endpoint for removing reports
- Added integration and unit tests for both retrieving and deleting PDF reports.
- Introduced proper validation and error handling using FluentResults.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve/download individual PDF reports by ID (returns PDF content)
  * Delete PDF reports via API — removes associated file and reorders remaining report priorities sequentially

* **Tests**
  * Integration and unit tests covering GET by ID, DELETE behavior, file removal, not-found cases, DB error handling, and priority reordering after deletions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->