### PR TITLE
Feature/issue 2167 Added GET and POST endpoints for the Main Page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+namespace VictoryCenter.BLL.Commands.Admin.MainPage.Create;
+
+public record CreateMainPageCommand(CreateMainPageDto CreateMainPageDto)
+    : IRequest<Result<MainPageDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageHandler.cs
@@ -1,0 +1,121 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
+
+namespace VictoryCenter.BLL.Commands.Admin.MainPage.Create;
+
+public class CreateMainPageHandler : IRequestHandler<CreateMainPageCommand, Result<MainPageDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly IValidator<CreateMainPageCommand> _validator;
+
+    public CreateMainPageHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IMapper mapper,
+        IValidator<CreateMainPageCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<MainPageDto>> Handle(CreateMainPageCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            using var transaction = _repositoryWrapper.BeginTransaction();
+
+            var entityIsExists = (await _repositoryWrapper.MainPageRepository
+                .CountAsync()) > 0;
+
+            if (entityIsExists)
+            {
+                return Result.Fail<MainPageDto>(
+                    ErrorMessagesConstants.OnlyOneEntityOfTypeIsAllowed(nameof(DAL.Entities.MainPage)));
+            }
+
+            var requestedImageIds = new List<long>();
+
+            if (request.CreateMainPageDto.ImageId.HasValue)
+            {
+                requestedImageIds.Add(request.CreateMainPageDto.ImageId.Value);
+            }
+
+            requestedImageIds.AddRange(request.CreateMainPageDto.ImpactStatistics
+                .Where(s => s.ImageId.HasValue)
+                .Select(s => s.ImageId!.Value));
+
+            if (requestedImageIds.Count > 0)
+            {
+                var existingImageIds = (await _repositoryWrapper.ImageRepository
+                    .GetAllAsync(new QueryOptions<Image>
+                    {
+                        Filter = i => requestedImageIds.Contains(i.Id)
+                    }))
+                    .Select(i => i.Id)
+                    .ToList();
+
+                var nonExistingImageIds = requestedImageIds.Except(existingImageIds).ToList();
+
+                if (nonExistingImageIds.Count > 0)
+                {
+                    return Result.Fail<MainPageDto>(
+                        ErrorMessagesConstants.NotFound(nonExistingImageIds, typeof(Image)));
+                }
+            }
+
+            var mainPageEntity = _mapper.Map<CreateMainPageDto, MainPageEntity>(request.CreateMainPageDto);
+
+            await _repositoryWrapper.MainPageRepository
+                .CreateAsync(mainPageEntity);
+
+            await _repositoryWrapper.SaveChangesAsync();
+
+            var resultEntity = await _repositoryWrapper.MainPageRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<MainPageEntity>
+                {
+                    Filter = e => e.Id == mainPageEntity.Id,
+                    Include = q => q
+                        .Include(e => e.Image)
+                        .Include(e => e.MainAboutUs)
+                        .Include(e => e.MainPartners)
+                        .Include(e => e.ImpactStatistics)
+                        .ThenInclude(s => s.Image)
+                        .Include(e => e.ImpactStatistics)
+                        .ThenInclude(s => s.Metrics)
+                });
+
+            if (resultEntity is null)
+            {
+                return Result.Fail<MainPageDto>(
+                    ErrorMessagesConstants.FailedToCreateEntity(typeof(MainPageEntity)));
+            }
+
+            var resultDto = _mapper.Map<MainPageEntity, MainPageDto>(resultEntity);
+
+            transaction.Complete();
+
+            return Result.Ok(resultDto);
+        }
+         catch (ValidationException vex)
+        {
+            return Result.Fail<MainPageDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<MainPageDto>(
+                ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(MainPageEntity)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageHandler.cs
@@ -11,7 +11,6 @@ using VictoryCenter.DAL.Repositories.Options;
 using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
 
 namespace VictoryCenter.BLL.Commands.Admin.MainPage.Create;
-
 public class CreateMainPageHandler : IRequestHandler<CreateMainPageCommand, Result<MainPageDto>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;

--- a/VictoryCenter/VictoryCenter.BLL/Constants/MainPageConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/MainPageConstants.cs
@@ -1,0 +1,42 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class MainPageConstants
+{
+    public static class Title
+    {
+        public const int MinLength = 5;
+        public const int MaxLength = 150;
+    }
+
+    public static class Description
+    {
+        public const int MinLength = 10;
+        public const int MaxLength = 1000;
+    }
+
+    public static class ImpactStatistic
+    {
+        public const int MaxCount = 20;
+
+        public static class Description
+        {
+            public const int MinLength = 5;
+            public const int MaxLength = 500;
+        }
+    }
+
+    public static class Metric
+    {
+        public static class Value
+        {
+            public const int MinLength = 1;
+            public const int MaxLength = 50;
+        }
+
+        public static class Signature
+        {
+            public const int MinLength = 1;
+            public const int MaxLength = 100;
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/BaseImpactStatisticDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/BaseImpactStatisticDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+
+public abstract record BaseImpactStatisticDto
+{
+    public string Description { get; init; } = null!;
+    public long? ImageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/CreateImpactStatisticDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/CreateImpactStatisticDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+
+public record CreateImpactStatisticDto : BaseImpactStatisticDto
+{
+    public ICollection<CreateMetricDto> Metrics { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/ImpactStatisticDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/ImpactStatisticDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+
+public record ImpactStatisticDto
+{
+    public long Id { get; init; }
+    public string Description { get; init; } = null!;
+    public ImageDto? Image { get; init; } = null!;
+    public ICollection<MetricDto> Metrics { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/BaseMetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/BaseMetricDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+public abstract record BaseMetricDto
+{
+    public string Value { get; init; } = null!;
+    public string Signature { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/CreateMetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/CreateMetricDto.cs
@@ -1,0 +1,5 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+public record CreateMetricDto : BaseMetricDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
@@ -1,0 +1,9 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+public record MetricDto
+{
+    public long Id { get; init; }
+
+    public string Value { get; set; } = null!;
+    public string Signature { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainAboutUs/BaseMainAboutUsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainAboutUs/BaseMainAboutUsDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+
+public abstract record BaseMainAboutUsDto
+{
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainAboutUs/CreateMainAboutUsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainAboutUs/CreateMainAboutUsDto.cs
@@ -1,0 +1,5 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+
+public record CreateMainAboutUsDto : BaseMainAboutUsDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainAboutUs/MainAboutUsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainAboutUs/MainAboutUsDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+
+public record MainAboutUsDto
+{
+    public long Id { get; init; }
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/BaseMainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/BaseMainPageDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+public abstract record BaseMainPageDto
+{
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+    public long? ImageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/CreateMainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/CreateMainPageDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+
+namespace VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+public record CreateMainPageDto : BaseMainPageDto
+{
+    public CreateMainAboutUsDto? MainAboutUs { get; init; }
+    public CreateMainPartnersDto? MainPartners { get; init; }
+    public ICollection<CreateImpactStatisticDto> ImpactStatistics { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/MainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/MainPageDto.cs
@@ -12,7 +12,7 @@ public record MainPageDto
     public string Description { get; init; } = null!;
     public ImageDto? Image { get; init; }
 
-    public MainAboutUsDto MainAboutUs { get; init; } = null!;
-    public MainPartnersDto MainPartners { get; init; } = null!;
+    public MainAboutUsDto? MainAboutUs { get; init; }
+    public MainPartnersDto? MainPartners { get; init; }
     public ICollection<ImpactStatisticDto> ImpactStatistics { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/MainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/MainPageDto.cs
@@ -1,0 +1,18 @@
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+public record MainPageDto
+{
+    public long Id { get; init; }
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+    public ImageDto? Image { get; init; }
+
+    public MainAboutUsDto MainAboutUs { get; init; } = null!;
+    public MainPartnersDto MainPartners { get; init; } = null!;
+    public ICollection<ImpactStatisticDto> ImpactStatistics { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPartners/BaseMainPartnersDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPartners/BaseMainPartnersDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainPartners;
+
+public abstract record BaseMainPartnersDto
+{
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPartners/CreateMainPartnersDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPartners/CreateMainPartnersDto.cs
@@ -1,0 +1,5 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainPartners;
+
+public record CreateMainPartnersDto : BaseMainPartnersDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPartners/MainPartnersDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPartners/MainPartnersDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainPartners;
+
+public record MainPartnersDto
+{
+    public long Id { get; init; }
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/MainPage/MainPageProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/MainPage/MainPageProfile.cs
@@ -1,0 +1,52 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+using VictoryCenter.DAL.Entities;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
+
+namespace VictoryCenter.BLL.Mapping.MainPage;
+
+public class MainPageProfile : Profile
+{
+    public MainPageProfile()
+    {
+        CreateMap<CreateMainPageDto, MainPageEntity>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Image, opt => opt.Ignore());
+
+        CreateMap<CreateMainAboutUsDto, MainAboutUs>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPageId, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPage, opt => opt.Ignore());
+
+        CreateMap<CreateMainPartnersDto, MainPartners>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPageId, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPage, opt => opt.Ignore());
+
+        CreateMap<CreateImpactStatisticDto, ImpactStatistics>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Image, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPageId, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPage, opt => opt.Ignore());
+
+        CreateMap<CreateMetricDto, Metric>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.StatisticId, opt => opt.Ignore())
+            .ForMember(dest => dest.Statistics, opt => opt.Ignore());
+
+        CreateMap<MainPageEntity, MainPageDto>();
+        CreateMap<MainAboutUs, MainAboutUsDto>();
+        CreateMap<MainPartners, MainPartnersDto>();
+        CreateMap<ImpactStatistics, ImpactStatisticDto>();
+        CreateMap<Metric, MetricDto>();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -1,0 +1,50 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
+
+namespace VictoryCenter.BLL.Queries.Admin.MainPage.GetMainPage;
+
+public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainPageDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+
+    public GetMainPageHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<MainPageDto>> Handle(GetMainPageQuery request, CancellationToken cancellationToken)
+    {
+        var mainPageEntity = await _repositoryWrapper.MainPageRepository
+            .GetFirstOrDefaultAsync(new QueryOptions<MainPageEntity>
+            {
+                Include = q => q
+                    .Include(e => e.Image)
+                    .Include(e => e.MainAboutUs)
+                    .Include(e => e.MainPartners)
+                    .Include(e => e.ImpactStatistics)
+                    .ThenInclude(s => s.Image)
+                    .Include(e => e.ImpactStatistics)
+                    .ThenInclude(s => s.Metrics),
+                AsNoTracking = true
+            });
+
+        if (mainPageEntity is null)
+        {
+            return Result.Fail<MainPageDto>(
+                ErrorMessagesConstants.NotFound(null, typeof(MainPageEntity)));
+        }
+
+        var resultDto = _mapper.Map<MainPageEntity, MainPageDto>(mainPageEntity);
+
+        return Result.Ok(resultDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -9,7 +9,6 @@ using VictoryCenter.DAL.Repositories.Options;
 using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
 
 namespace VictoryCenter.BLL.Queries.Admin.MainPage.GetMainPage;
-
 public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainPageDto>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
@@ -40,7 +39,7 @@ public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainP
         if (mainPageEntity is null)
         {
             return Result.Fail<MainPageDto>(
-                ErrorMessagesConstants.NotFound(null, typeof(MainPageEntity)));
+                ErrorMessagesConstants.NotFound());
         }
 
         var resultDto = _mapper.Map<MainPageEntity, MainPageDto>(mainPageEntity);

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/MainPage/GetMainPage/GetMainPageQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/MainPage/GetMainPage/GetMainPageQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+namespace VictoryCenter.BLL.Queries.Admin.MainPage.GetMainPage;
+
+public record GetMainPageQuery : IRequest<Result<MainPageDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Commands/CreateMainPageCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Commands/CreateMainPageCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.MainPage.Create;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Commands;
+
+public class CreateMainPageCommandValidator : AbstractValidator<CreateMainPageCommand>
+{
+    public CreateMainPageCommandValidator()
+    {
+        RuleFor(x => x.CreateMainPageDto)
+            .NotNull()
+            .SetValidator(new CreateMainPageDtoValidator());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseImpactStatisticDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseImpactStatisticDtoValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public abstract class BaseImpactStatisticDtoValidator<TDto> : AbstractValidator<TDto>
+    where TDto : BaseImpactStatisticDto
+{
+    protected BaseImpactStatisticDtoValidator()
+    {
+        RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseImpactStatisticDto.Description)))
+            .MinimumLength(MainPageConstants.ImpactStatistic.Description.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseImpactStatisticDto.Description), MainPageConstants.ImpactStatistic.Description.MinLength))
+            .MaximumLength(MainPageConstants.ImpactStatistic.Description.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseImpactStatisticDto.Description), MainPageConstants.ImpactStatistic.Description.MaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainAboutUsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainAboutUsDtoValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public abstract class BaseMainAboutUsDtoValidator<TDto> : AbstractValidator<TDto>
+    where TDto : BaseMainAboutUsDto
+{
+    protected BaseMainAboutUsDtoValidator()
+    {
+        RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainAboutUsDto.Title)))
+            .MinimumLength(MainPageConstants.Title.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MinLength))
+            .MaximumLength(MainPageConstants.Title.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MaxLength));
+
+        RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainAboutUsDto.Description)))
+            .MinimumLength(MainPageConstants.Description.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MinLength))
+            .MaximumLength(MainPageConstants.Description.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPageDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPageDtoValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public abstract class BaseMainPageDtoValidator<TDto> : AbstractValidator<TDto>
+    where TDto : BaseMainPageDto
+{
+    protected BaseMainPageDtoValidator()
+    {
+        RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageDto.Title)))
+            .MinimumLength(MainPageConstants.Title.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MinLength))
+            .MaximumLength(MainPageConstants.Title.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MaxLength));
+
+        RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageDto.Description)))
+            .MinimumLength(MainPageConstants.Description.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MinLength))
+            .MaximumLength(MainPageConstants.Description.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPartnersDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPartnersDtoValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public abstract class BaseMainPartnersDtoValidator<TDto> : AbstractValidator<TDto>
+    where TDto : BaseMainPartnersDto
+{
+    protected BaseMainPartnersDtoValidator()
+    {
+        RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPartnersDto.Title)))
+            .MinimumLength(MainPageConstants.Title.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MinLength))
+            .MaximumLength(MainPageConstants.Title.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MaxLength));
+
+        RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPartnersDto.Description)))
+            .MinimumLength(MainPageConstants.Description.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MinLength))
+            .MaximumLength(MainPageConstants.Description.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMetricDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMetricDtoValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public abstract class BaseMetricDtoValidator<TDto> : AbstractValidator<TDto>
+    where TDto : BaseMetricDto
+{
+    protected BaseMetricDtoValidator()
+    {
+        RuleFor(x => x.Value)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMetricDto.Value)))
+            .MinimumLength(MainPageConstants.Metric.Value.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMetricDto.Value), MainPageConstants.Metric.Value.MinLength))
+            .MaximumLength(MainPageConstants.Metric.Value.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMetricDto.Value), MainPageConstants.Metric.Value.MaxLength));
+
+        RuleFor(x => x.Signature)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMetricDto.Signature)))
+            .MinimumLength(MainPageConstants.Metric.Signature.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMetricDto.Signature), MainPageConstants.Metric.Signature.MinLength))
+            .MaximumLength(MainPageConstants.Metric.Signature.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMetricDto.Signature), MainPageConstants.Metric.Signature.MaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateImpactStatisticDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateImpactStatisticDtoValidator.cs
@@ -17,6 +17,7 @@ public class CreateImpactStatisticDtoValidator : BaseImpactStatisticDtoValidator
                 nameof(CreateImpactStatisticDto.Metrics), MainPageConstants.ImpactStatistic.MaxCount));
 
         RuleForEach(x => x.Metrics)
+            .NotNull()
             .SetValidator(new CreateMetricDtoValidator());
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateImpactStatisticDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateImpactStatisticDtoValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class CreateImpactStatisticDtoValidator : BaseImpactStatisticDtoValidator<CreateImpactStatisticDto>
+{
+    public CreateImpactStatisticDtoValidator()
+    {
+        RuleFor(x => x.Metrics)
+            .Cascade(CascadeMode.Stop)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateImpactStatisticDto.Metrics)))
+            .Must(m => m.Count <= MainPageConstants.ImpactStatistic.MaxCount)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(CreateImpactStatisticDto.Metrics), MainPageConstants.ImpactStatistic.MaxCount));
+
+        RuleForEach(x => x.Metrics)
+            .SetValidator(new CreateMetricDtoValidator());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainAboutUsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainAboutUsDtoValidator.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class CreateMainAboutUsDtoValidator : BaseMainAboutUsDtoValidator<CreateMainAboutUsDto>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPageDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPageDtoValidator.cs
@@ -29,6 +29,7 @@ public class CreateMainPageDtoValidator : BaseMainPageDtoValidator<CreateMainPag
                 nameof(CreateMainPageDto.ImpactStatistics), MainPageConstants.ImpactStatistic.MaxCount));
 
         RuleForEach(x => x.ImpactStatistics)
+            .NotNull()
             .SetValidator(new CreateImpactStatisticDtoValidator());
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPageDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPageDtoValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class CreateMainPageDtoValidator : BaseMainPageDtoValidator<CreateMainPageDto>
+{
+    public CreateMainPageDtoValidator()
+    {
+        When(x => x.MainAboutUs is not null, () =>
+        {
+            RuleFor(x => x.MainAboutUs!)
+                .SetValidator(new CreateMainAboutUsDtoValidator());
+        });
+
+        When(x => x.MainPartners is not null, () =>
+        {
+            RuleFor(x => x.MainPartners!)
+                .SetValidator(new CreateMainPartnersDtoValidator());
+        });
+
+        RuleFor(x => x.ImpactStatistics)
+            .Cascade(CascadeMode.Stop)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateMainPageDto.ImpactStatistics)))
+            .Must(s => s.Count <= MainPageConstants.ImpactStatistic.MaxCount)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(CreateMainPageDto.ImpactStatistics), MainPageConstants.ImpactStatistic.MaxCount));
+
+        RuleForEach(x => x.ImpactStatistics)
+            .SetValidator(new CreateImpactStatisticDtoValidator());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPartnersDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPartnersDtoValidator.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class CreateMainPartnersDtoValidator : BaseMainPartnersDtoValidator<CreateMainPartnersDto>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMetricDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMetricDtoValidator.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class CreateMetricDtoValidator : BaseMetricDtoValidator<CreateMetricDto>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/VictoryCenter.BLL.csproj
+++ b/VictoryCenter/VictoryCenter.BLL/VictoryCenter.BLL.csproj
@@ -25,4 +25,9 @@
       <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="DTOs\Admin\MainAboutUs\" />
+      <Folder Include="DTOs\Admin\MainPartners\" />
+    </ItemGroup>
+
 </Project>

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -24,6 +24,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -71,6 +72,11 @@ public interface IRepositoryWrapper
     ICompanyProfileRequisiteRepository CompanyProfileRequisiteRepository { get; }
     ICompanyProfileContactLocalizationsRepository CompanyProfileContactLocalizationsRepository { get; }
     ICompanyProfileRequisiteLocalizationsRepository CompanyProfileRequisiteLocalizationsRepository { get; }
+
+    IMainPageRepository MainPageRepository { get; }
+    IMainAboutUsRepository MainAboutUsRepository { get; }
+    IMainPartnersRepository MainPartnersRepository { get; }
+    IImpactStatisticsRepository ImpactStatisticsRepository { get; }
 
     IRepositoryBase<TEntity> GetRepository<TEntity>()
         where TEntity : class;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IImpactStatisticsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IImpactStatisticsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+
+public interface IImpactStatisticsRepository : IRepositoryBase<ImpactStatistics>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainAboutUsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainAboutUsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+
+public interface IMainAboutUsRepository : IRepositoryBase<MainAboutUs>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainPageRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainPageRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+
+public interface IMainPageRepository : IRepositoryBase<MainPageEntity>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainPartnersRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainPartnersRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+
+public interface IMainPartnersRepository : IRepositoryBase<MainPartners>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -50,8 +50,10 @@ using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgram
 using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyPrograms;
 using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
 using VictoryCenter.DAL.Repositories.Realizations.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.CompanyProfile;
+using VictoryCenter.DAL.Repositories.Realizations.MainPage;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -96,6 +98,10 @@ public class RepositoryWrapper : IRepositoryWrapper
     private ICompanyProfileRequisiteRepository? _companyProfileRequisiteRepository;
     private ICompanyProfileContactLocalizationsRepository? _companyProfileContactLocalizationsRepository;
     private ICompanyProfileRequisiteLocalizationsRepository? _companyProfileRequisiteLocalizationsRepository;
+    private IMainPageRepository? _mainPageRepository;
+    private IMainAboutUsRepository? _mainAboutUsRepository;
+    private IMainPartnersRepository? _mainPartnersRepository;
+    private IImpactStatisticsRepository? _impactStatisticsRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -165,6 +171,18 @@ public class RepositoryWrapper : IRepositoryWrapper
         _companyProfileContactLocalizationsRepository ??= new CompanyProfileContactLocalizationsRepository(_victoryCenterDbContext);
     public ICompanyProfileRequisiteLocalizationsRepository CompanyProfileRequisiteLocalizationsRepository =>
         _companyProfileRequisiteLocalizationsRepository ??= new CompanyProfileRequisiteLocalizationsRepository(_victoryCenterDbContext);
+
+    public IMainPageRepository MainPageRepository =>
+        _mainPageRepository ??= new MainPageRepository(_victoryCenterDbContext);
+
+    public IMainAboutUsRepository MainAboutUsRepository =>
+        _mainAboutUsRepository ??= new MainAboutUsRepository(_victoryCenterDbContext);
+
+    public IMainPartnersRepository MainPartnersRepository =>
+        _mainPartnersRepository ??= new MainPartnersRepository(_victoryCenterDbContext);
+
+    public IImpactStatisticsRepository ImpactStatisticsRepository =>
+        _impactStatisticsRepository ??= new ImpactStatisticsRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -54,13 +54,7 @@ using VictoryCenter.DAL.Repositories.Realizations.TeamMembers;
 using VictoryCenter.DAL.Repositories.Realizations.VisitorPages;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreSections;
-using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyPrograms;
-using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyPrograms;
-using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
-using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
-using VictoryCenter.DAL.Repositories.Realizations.CompanyProfile;
-using VictoryCenter.DAL.Repositories.Realizations.Localization.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Realizations.MainPage;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/ImpactStatisticsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/ImpactStatisticsRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.MainPage;
+
+public class ImpactStatisticsRepository : RepositoryBase<ImpactStatistics>, IImpactStatisticsRepository
+{
+    public ImpactStatisticsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainAboutUsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainAboutUsRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.MainPage;
+
+public class MainAboutUsRepository : RepositoryBase<MainAboutUs>, IMainAboutUsRepository
+{
+    public MainAboutUsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainPageRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainPageRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.MainPage;
+
+public class MainPageRepository : RepositoryBase<MainPageEntity>, IMainPageRepository
+{
+    public MainPageRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainPartnersRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainPartnersRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.MainPage;
+
+public class MainPartnersRepository : RepositoryBase<MainPartners>, IMainPartnersRepository
+{
+    public MainPartnersRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/CreateMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/CreateMainPageHandlerTests.cs
@@ -1,0 +1,421 @@
+using System.Transactions;
+using AutoMapper;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.MainPage.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Interfaces.Media;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.MainPage;
+
+public class CreateMainPageHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<IMainPageRepository> _mainPageRepositoryMock = new();
+    private readonly Mock<IImageRepository> _imageRepositoryMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<IValidator<CreateMainPageCommand>> _validatorMock = new();
+
+    public CreateMainPageHandlerTests()
+    {
+        _repositoryWrapperMock
+            .SetupGet(x => x.MainPageRepository)
+            .Returns(_mainPageRepositoryMock.Object);
+
+        _repositoryWrapperMock
+            .SetupGet(x => x.ImageRepository)
+            .Returns(_imageRepositoryMock.Object);
+
+        _repositoryWrapperMock
+            .Setup(x => x.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateMainPage_WhenRequestIsValid()
+    {
+        // Arrange
+        var command = new CreateMainPageCommand(GetValidCreateDto());
+        var createdEntity = GetMainPageEntity(10);
+        var resultDto = GetMainPageDto(10);
+
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CountAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(0);
+
+        _imageRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
+            .ReturnsAsync(new List<Image>
+            {
+                new() { Id = 5 },
+                new() { Id = 6 },
+            });
+
+        _mapperMock
+            .Setup(x => x.Map<CreateMainPageDto, DAL.Entities.MainPage>(command.CreateMainPageDto))
+            .Returns(createdEntity);
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CreateAsync(createdEntity))
+            .ReturnsAsync(createdEntity);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mainPageRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(createdEntity);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.MainPage, MainPageDto>(createdEntity))
+            .Returns(resultDto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(resultDto.Id, result.Value.Id);
+
+        _mainPageRepositoryMock.Verify(x => x.CreateAsync(createdEntity), Times.Once);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
+        _imageRepositoryMock.Verify(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()), Times.Once);
+        _validatorMock.Verify(
+            x => x.ValidateAsync(It.IsAny<ValidationContext<CreateMainPageCommand>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        // Arrange
+        var command = new CreateMainPageCommand(GetValidCreateDto());
+        SetupValidationFailure("Validation failed");
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Validation failed", result.Errors[0].Message);
+
+        _repositoryWrapperMock.Verify(x => x.BeginTransaction(), Times.Never);
+        _mainPageRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<DAL.Entities.MainPage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenMainPageAlreadyExists()
+    {
+        // Arrange
+        var command = new CreateMainPageCommand(GetValidCreateDto());
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CountAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(1);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.OnlyOneEntityOfTypeIsAllowed(nameof(DAL.Entities.MainPage)),
+            result.Errors[0].Message);
+
+        _imageRepositoryMock.Verify(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()), Times.Never);
+        _mainPageRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<DAL.Entities.MainPage>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenImageDoesNotExist()
+    {
+        // Arrange
+        var command = new CreateMainPageCommand(GetValidCreateDto());
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CountAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(0);
+
+        _imageRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
+            .ReturnsAsync(new List<Image>
+            {
+                new() { Id = 5 },
+            });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(new[] { 6L }, typeof(Image)),
+            result.Errors[0].Message);
+
+        _mainPageRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<DAL.Entities.MainPage>()), Times.Never);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenCreatedEntityCannotBeLoaded()
+    {
+        // Arrange
+        var dtoWithoutImages = GetValidCreateDto();
+        dtoWithoutImages = dtoWithoutImages with
+        {
+            ImageId = null,
+            ImpactStatistics =
+            [
+                new CreateImpactStatisticDto
+                {
+                    Description = "Impact statistic description",
+                    ImageId = null,
+                    Metrics =
+                    [
+                        new CreateMetricDto
+                        {
+                            Value = "100",
+                            Signature = "children",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var command = new CreateMainPageCommand(dtoWithoutImages);
+        var createdEntity = GetMainPageEntity(99);
+
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CountAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(0);
+
+        _mapperMock
+            .Setup(x => x.Map<CreateMainPageDto, DAL.Entities.MainPage>(command.CreateMainPageDto))
+            .Returns(createdEntity);
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CreateAsync(createdEntity))
+            .ReturnsAsync(createdEntity);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mainPageRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync((DAL.Entities.MainPage?)null);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(DAL.Entities.MainPage)),
+            result.Errors[0].Message);
+
+        _imageRepositoryMock.Verify(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        var command = new CreateMainPageCommand(GetValidCreateDto());
+        var createdEntity = GetMainPageEntity(77);
+
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CountAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(0);
+
+        _imageRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
+            .ReturnsAsync(new List<Image>
+            {
+                new() { Id = 5 },
+                new() { Id = 6 },
+            });
+
+        _mapperMock
+            .Setup(x => x.Map<CreateMainPageDto, DAL.Entities.MainPage>(command.CreateMainPageDto))
+            .Returns(createdEntity);
+
+        _mainPageRepositoryMock
+            .Setup(x => x.CreateAsync(createdEntity))
+            .ReturnsAsync(createdEntity);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(DAL.Entities.MainPage)),
+            result.Errors[0].Message);
+    }
+
+    private CreateMainPageHandler CreateHandler() => new(
+        _repositoryWrapperMock.Object,
+        _mapperMock.Object,
+        _validatorMock.Object);
+
+    private void SetupValidationSuccess()
+    {
+        _validatorMock
+            .Setup(x => x.ValidateAsync(It.IsAny<ValidationContext<CreateMainPageCommand>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+    }
+
+    private void SetupValidationFailure(string errorMessage)
+    {
+        _validatorMock
+            .Setup(x => x.ValidateAsync(It.IsAny<ValidationContext<CreateMainPageCommand>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(new[]
+            {
+                new ValidationFailure("CreateMainPageDto", errorMessage),
+            }));
+    }
+
+    private static CreateMainPageDto GetValidCreateDto() => new()
+    {
+        Title = "Main page title",
+        Description = "Main page description that is long enough",
+        ImageId = 5,
+        MainAboutUs = new CreateMainAboutUsDto
+        {
+            Title = "About us title",
+            Description = "About us description that is long enough",
+        },
+        MainPartners = new CreateMainPartnersDto
+        {
+            Title = "Partners title",
+            Description = "Partners description that is long enough",
+        },
+        ImpactStatistics =
+        [
+            new CreateImpactStatisticDto
+            {
+                Description = "Impact statistic description",
+                ImageId = 6,
+                Metrics =
+                [
+                    new CreateMetricDto
+                    {
+                        Value = "100",
+                        Signature = "children",
+                    },
+                ],
+            },
+        ],
+    };
+
+    private static DAL.Entities.MainPage GetMainPageEntity(long id) => new()
+    {
+        Id = id,
+        Title = "Main page title",
+        Description = "Main page description",
+        ImageId = 5,
+        MainAboutUs = new MainAboutUs
+        {
+            Id = 11,
+            Title = "About us title",
+            Description = "About us description",
+        },
+        MainPartners = new MainPartners
+        {
+            Id = 12,
+            Title = "Partners title",
+            Description = "Partners description",
+        },
+        ImpactStatistics =
+        [
+            new ImpactStatistics
+            {
+                Id = 13,
+                Description = "Impact statistic",
+                ImageId = 6,
+                Metrics =
+                [
+                    new Metric
+                    {
+                        Id = 14,
+                        Value = "100",
+                        Signature = "children",
+                    },
+                ],
+            },
+        ],
+    };
+
+    private static MainPageDto GetMainPageDto(long id) => new()
+    {
+        Id = id,
+        Title = "Main page title",
+        Description = "Main page description",
+        MainAboutUs = new MainAboutUsDto
+        {
+            Id = 11,
+            Title = "About us title",
+            Description = "About us description",
+        },
+        MainPartners = new MainPartnersDto
+        {
+            Id = 12,
+            Title = "Partners title",
+            Description = "Partners description",
+        },
+        ImpactStatistics =
+        [
+            new ImpactStatisticDto
+            {
+                Id = 13,
+                Description = "Impact statistic",
+                Metrics =
+                [
+                    new MetricDto
+                    {
+                        Id = 14,
+                        Value = "100",
+                        Signature = "children",
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/CreateMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/CreateMainPageHandlerTests.cs
@@ -306,7 +306,7 @@ public class CreateMainPageHandlerTests
     {
         _validatorMock
             .Setup(x => x.ValidateAsync(It.IsAny<ValidationContext<CreateMainPageCommand>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ValidationResult(new[]
+            .ThrowsAsync(new ValidationException(new[]
             {
                 new ValidationFailure("CreateMainPageDto", errorMessage),
             }));

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/GetMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/GetMainPageHandlerTests.cs
@@ -1,0 +1,84 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.Queries.Admin.MainPage.GetMainPage;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.MainPage;
+
+public class GetMainPageHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<IMainPageRepository> _mainPageRepositoryMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+
+    public GetMainPageHandlerTests()
+    {
+        _repositoryWrapperMock
+            .SetupGet(x => x.MainPageRepository)
+            .Returns(_mainPageRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnMainPage_WhenEntityExists()
+    {
+        // Arrange
+        QueryOptions<DAL.Entities.MainPage>? passedQueryOptions = null;
+
+        var entity = new DAL.Entities.MainPage
+        {
+            Id = 1,
+            Title = "Main page",
+            Description = "Main page description",
+        };
+
+        var dto = new MainPageDto
+        {
+            Id = 1,
+            Title = "Main page",
+            Description = "Main page description",
+        };
+
+        _mainPageRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .Callback<QueryOptions<DAL.Entities.MainPage>?>(options => passedQueryOptions = options)
+            .ReturnsAsync(entity);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.MainPage, MainPageDto>(entity))
+            .Returns(dto);
+
+        var handler = new GetMainPageHandler(_repositoryWrapperMock.Object, _mapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(new GetMainPageQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(dto.Id, result.Value.Id);
+        Assert.NotNull(passedQueryOptions);
+        Assert.True(passedQueryOptions!.AsNoTracking);
+        Assert.NotNull(passedQueryOptions.Include);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenEntityNotFound()
+    {
+        // Arrange
+        _mainPageRepositoryMock
+            .Setup(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync((DAL.Entities.MainPage?)null);
+
+        var handler = new GetMainPageHandler(_repositoryWrapperMock.Object, _mapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(new GetMainPageQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.NotFound(), result.Errors[0].Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateImpactStatisticDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateImpactStatisticDtoValidatorTests.cs
@@ -1,0 +1,114 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class CreateImpactStatisticDtoValidatorTests
+{
+    private readonly CreateImpactStatisticDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenDescriptionIsEmpty(string? description)
+    {
+        var dto = GetValidDto() with { Description = description! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseImpactStatisticDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with
+        {
+            Description = new string('a', MainPageConstants.ImpactStatistic.Description.MinLength - 1),
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseImpactStatisticDto.Description),
+                MainPageConstants.ImpactStatistic.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with
+        {
+            Description = new string('a', MainPageConstants.ImpactStatistic.Description.MaxLength + 1),
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseImpactStatisticDto.Description),
+                MainPageConstants.ImpactStatistic.Description.MaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMetricsIsNull()
+    {
+        var dto = GetValidDto() with { Metrics = null! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Metrics)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateImpactStatisticDto.Metrics)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMetricsCountIsTooLarge()
+    {
+        var dto = GetValidDto() with
+        {
+            Metrics = Enumerable
+                .Range(1, MainPageConstants.ImpactStatistic.MaxCount + 1)
+                .Select(_ => new CreateMetricDto { Value = "100", Signature = "kids" })
+                .ToList(),
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Metrics)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(CreateImpactStatisticDto.Metrics), MainPageConstants.ImpactStatistic.MaxCount));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenNestedMetricIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            Metrics = [new CreateMetricDto { Value = string.Empty, Signature = "kids" }],
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("Metrics[0].Value");
+    }
+
+    private static CreateImpactStatisticDto GetValidDto() => new()
+    {
+        Description = "Impact description",
+        ImageId = 1,
+        Metrics = [new CreateMetricDto { Value = "100", Signature = "kids" }],
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateImpactStatisticDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateImpactStatisticDtoValidatorTests.cs
@@ -105,6 +105,19 @@ public class CreateImpactStatisticDtoValidatorTests
         result.ShouldHaveValidationErrorFor("Metrics[0].Value");
     }
 
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMetricsContainsNullElement()
+    {
+        var dto = GetValidDto() with
+        {
+            Metrics = [null!],
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("Metrics[0]");
+    }
+
     private static CreateImpactStatisticDto GetValidDto() => new()
     {
         Description = "Impact description",

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainAboutUsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainAboutUsDtoValidatorTests.cs
@@ -1,0 +1,100 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class CreateMainAboutUsDtoValidatorTests
+{
+    private readonly CreateMainAboutUsDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenTitleIsEmpty(string? title)
+    {
+        var dto = GetValidDto() with { Title = title! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainAboutUsDto.Title)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenDescriptionIsEmpty(string? description)
+    {
+        var dto = GetValidDto() with { Description = description! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainAboutUsDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    private static CreateMainAboutUsDto GetValidDto() => new()
+    {
+        Title = "About us title",
+        Description = "About us description",
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
@@ -181,6 +181,19 @@ public class CreateMainPageDtoValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldHaveError_WhenImpactStatisticsContainsNullElement()
+    {
+        var dto = GetValidDto() with
+        {
+            ImpactStatistics = [null!],
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("ImpactStatistics[0]");
+    }
+
+    [Fact]
     public void Validate_ShouldNotHaveErrors_WhenOptionalSectionsAreNull()
     {
         var dto = GetValidDto() with

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
@@ -1,0 +1,221 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class CreateMainPageDtoValidatorTests
+{
+    private readonly CreateMainPageDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenTitleIsEmpty(string? title)
+    {
+        var dto = GetValidDto();
+        dto = dto with { Title = title! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageDto.Title)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenDescriptionIsEmpty(string? description)
+    {
+        var dto = GetValidDto() with { Description = description! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenImpactStatisticsIsNull()
+    {
+        var dto = GetValidDto() with { ImpactStatistics = null! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.ImpactStatistics)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateMainPageDto.ImpactStatistics)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenImpactStatisticsCountIsTooLarge()
+    {
+        var dto = GetValidDto() with
+        {
+            ImpactStatistics = Enumerable
+                .Range(1, MainPageConstants.ImpactStatistic.MaxCount + 1)
+                .Select(_ => GetValidImpactStatisticDto())
+                .ToList(),
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.ImpactStatistics)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(CreateMainPageDto.ImpactStatistics), MainPageConstants.ImpactStatistic.MaxCount));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainAboutUsIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainAboutUs = new CreateMainAboutUsDto
+            {
+                Title = string.Empty,
+                Description = "Valid description",
+            },
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("MainAboutUs.Title");
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainPartnersIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainPartners = new CreateMainPartnersDto
+            {
+                Title = string.Empty,
+                Description = "Valid description",
+            },
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("MainPartners.Title");
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenNestedImpactStatisticIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            ImpactStatistics =
+            [
+                new CreateImpactStatisticDto
+                {
+                    Description = string.Empty,
+                    Metrics = [new CreateMetricDto { Value = "10", Signature = "kids" }],
+                },
+            ],
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("ImpactStatistics[0].Description");
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenOptionalSectionsAreNull()
+    {
+        var dto = GetValidDto() with
+        {
+            MainAboutUs = null,
+            MainPartners = null,
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static CreateMainPageDto GetValidDto() => new()
+    {
+        Title = "Main page title",
+        Description = "Main page description",
+        ImageId = 1,
+        MainAboutUs = new CreateMainAboutUsDto
+        {
+            Title = "About us title",
+            Description = "About us description",
+        },
+        MainPartners = new CreateMainPartnersDto
+        {
+            Title = "Partners title",
+            Description = "Partners description",
+        },
+        ImpactStatistics = [GetValidImpactStatisticDto()],
+    };
+
+    private static CreateImpactStatisticDto GetValidImpactStatisticDto() => new()
+    {
+        Description = "Impact statistic description",
+        ImageId = 2,
+        Metrics = [new CreateMetricDto { Value = "100", Signature = "children" }],
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPartnersDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPartnersDtoValidatorTests.cs
@@ -1,0 +1,100 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class CreateMainPartnersDtoValidatorTests
+{
+    private readonly CreateMainPartnersDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenTitleIsEmpty(string? title)
+    {
+        var dto = GetValidDto() with { Title = title! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPartnersDto.Title)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenDescriptionIsEmpty(string? description)
+    {
+        var dto = GetValidDto() with { Description = description! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPartnersDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    private static CreateMainPartnersDto GetValidDto() => new()
+    {
+        Title = "Partners title",
+        Description = "Partners description",
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMetricDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMetricDtoValidatorTests.cs
@@ -1,0 +1,79 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class CreateMetricDtoValidatorTests
+{
+    private readonly CreateMetricDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenValueIsEmpty(string? value)
+    {
+        var dto = GetValidDto() with { Value = value! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Value)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMetricDto.Value)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenValueIsTooLong()
+    {
+        var dto = GetValidDto() with { Value = new string('a', MainPageConstants.Metric.Value.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Value)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMetricDto.Value), MainPageConstants.Metric.Value.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenSignatureIsEmpty(string? signature)
+    {
+        var dto = GetValidDto() with { Signature = signature! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Signature)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMetricDto.Signature)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenSignatureIsTooLong()
+    {
+        var dto = GetValidDto() with
+        {
+            Signature = new string('a', MainPageConstants.Metric.Signature.MaxLength + 1),
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Signature)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMetricDto.Signature), MainPageConstants.Metric.Signature.MaxLength));
+    }
+
+    private static CreateMetricDto GetValidDto() => new()
+    {
+        Value = "100",
+        Signature = "children",
+    };
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.MainPage.Create;
+using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.Queries.Admin.MainPage.GetMainPage;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class MainPageController : AuthorizedApiController
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(MainPageDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetMainPage()
+    {
+        return HandleResult(await Mediator.Send(new GetMainPageQuery()));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(MainPageDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateMainPage([FromBody] CreateMainPageDto createMainPageDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateMainPageCommand(createMainPageDto)));
+    }
+}


### PR DESCRIPTION
dev
## GitHub

* [GitHub issue](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2167)

## Summary of issue
	•	Added GET and POST endpoints for the Main Page.
	•	Implemented validation for the incoming requests.
	•	Created the necessary mapping profiles.
	•	Added tests covering the new functionality.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin can create and retrieve a single Main Page with title, description, image and structured sections (About Us, Partners, Impact Statistics with metrics).

* **Validation**
  * Added comprehensive validation for fields and collections (required, min/max lengths, max counts); ensures referenced images exist and prevents creating more than one Main Page.

* **API**
  * New endpoints to get and create Main Page content.

* **Tests**
  * Unit tests for handlers and validators covering success and multiple failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->