### PR TITLE
Feature/issue 2234 [Reports] Program expenses - Delete single program expense record backend

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Delete;
+
+public record DeleteReportProgramExpendituresRecordCommand(long ReportProgramExpendituresRecordId)
+    : IRequest<Result<long>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordHandler.cs
@@ -1,0 +1,71 @@
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Delete;
+
+public class DeleteReportProgramExpendituresRecordHandler
+    : IRequestHandler<DeleteReportProgramExpendituresRecordCommand, Result<long>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<DeleteReportProgramExpendituresRecordCommand> _validator;
+
+    public DeleteReportProgramExpendituresRecordHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IValidator<DeleteReportProgramExpendituresRecordCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+    }
+
+    public async Task<Result<long>> Handle(
+        DeleteReportProgramExpendituresRecordCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var recordToBeDeleted = await _repositoryWrapper
+                .ReportProgramExpendituresRecordsRepository.GetFirstOrDefaultAsync(
+                    new QueryOptions<ReportProgramExpendituresRecord>
+                    {
+                        Filter = record => record.Id == request.ReportProgramExpendituresRecordId
+                    });
+
+            if (recordToBeDeleted is null)
+            {
+                return Result.Fail(
+                    ErrorMessagesConstants.NotFound(
+                        request.ReportProgramExpendituresRecordId,
+                        typeof(ReportProgramExpendituresRecord)));
+            }
+
+            _repositoryWrapper.ReportProgramExpendituresRecordsRepository.Delete(recordToBeDeleted);
+
+            if (await _repositoryWrapper.SaveChangesAsync() == 0)
+            {
+                return Result.Fail(
+                    ErrorMessagesConstants.FailedToDeleteEntity(typeof(ReportProgramExpendituresRecord)));
+            }
+
+            return Result.Ok(request.ReportProgramExpendituresRecordId);
+        }
+        catch (ValidationException validationException)
+        {
+            return Result.Fail(
+                validationException.Errors.Select(error => error.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail(
+                ErrorMessagesConstants.FailedToDeleteEntityInDatabase(
+                    typeof(ReportProgramExpendituresRecord)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Delete;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
+
+public class DeleteReportProgramExpendituresRecordCommandValidator
+    : AbstractValidator<DeleteReportProgramExpendituresRecordCommand>
+{
+    public DeleteReportProgramExpendituresRecordCommandValidator()
+    {
+        RuleFor(x => x.ReportProgramExpendituresRecordId)
+            .NotNull()
+            .MustBeValidId(nameof(ReportProgramExpendituresRecord.Id));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordCommandValidator.cs
@@ -10,7 +10,6 @@ public class DeleteReportProgramExpendituresRecordCommandValidator
     public DeleteReportProgramExpendituresRecordCommandValidator()
     {
         RuleFor(x => x.ReportProgramExpendituresRecordId)
-            .NotNull()
             .MustBeValidId(nameof(ReportProgramExpendituresRecord.Id));
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.ReportProgramExpendituresRecords.Delete;
+
+public class DeleteReportProgramExpendituresRecordTests : BaseTestClass
+{
+    private ReportProgramExpendituresRecord _validReportProgramExpendituresRecord = null!;
+
+    public DeleteReportProgramExpendituresRecordTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _validReportProgramExpendituresRecord = await CreateValidReportProgramExpendituresRecordInDatabaseAsync();
+    }
+
+    [Fact]
+    public async Task Delete_ShouldDeleteRecord_WhenRecordExists()
+    {
+        var response = await Fixture.HttpClient.DeleteAsync(
+            $"/api/ReportProgramExpendituresRecords/{_validReportProgramExpendituresRecord.Id}");
+
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        var responseContentToLongConversionResult = long.TryParse(responseContent, out var responseId);
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(responseContentToLongConversionResult);
+        Assert.Equal(_validReportProgramExpendituresRecord.Id, responseId);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldFail_WhenRecordDoesNotExist()
+    {
+        const long invalidId = 99999;
+        var response = await Fixture.HttpClient.DeleteAsync(
+            $"/api/ReportProgramExpendituresRecords/{invalidId}");
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task<ReportProgramExpendituresRecord> CreateValidReportProgramExpendituresRecordInDatabaseAsync()
+    {
+        var programCategory = new HippotherapyProgramCategory
+        {
+            Name = "Some program category",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        Fixture.DbContext.HippotherapyProgramCategories.Add(programCategory);
+
+        var record = new ReportProgramExpendituresRecord
+        {
+            CreatedAt = DateTimeOffset.UtcNow,
+            ReportingYear = 2016,
+            AmountUah = 100,
+            AmountUsd = 100,
+            HippotherapyProgramCategory = programCategory
+        };
+        Fixture.DbContext.ReportProgramExpendituresRecords.Add(record);
+
+        await Fixture.DbContext.SaveChangesAsync();
+
+        return record;
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordTests.cs
@@ -1,0 +1,143 @@
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Delete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportProgramExpendituresRecords;
+
+public class DeleteReportProgramExpendituresRecordTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IReportProgramExpendituresRecordsRepository> _recordsRepositoryMock;
+    private readonly IValidator<DeleteReportProgramExpendituresRecordCommand> _validator;
+
+    private readonly ReportProgramExpendituresRecord _record = new()
+    {
+        Id = 1,
+        HippotherapyProgramCategoryId = 1,
+        ReportingYear = 2025,
+        AmountUah = 100,
+        AmountUsd = 20
+    };
+
+    public DeleteReportProgramExpendituresRecordTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _recordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
+        _validator = new DeleteReportProgramExpendituresRecordCommandValidator();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteRecord()
+    {
+        // Arrange
+        SetupDependencies(_record, saveResult: 1);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportProgramExpendituresRecordCommand(_record.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_record.Id, result.Value);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        // Arrange
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportProgramExpendituresRecordCommand(0),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.PropertyMustBePositive(nameof(ReportProgramExpendituresRecord.Id)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenRecordNotFound()
+    {
+        // Arrange
+        SetupDependencies(null, saveResult: 1);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportProgramExpendituresRecordCommand(999),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(999, typeof(ReportProgramExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesFails()
+    {
+        // Arrange
+        SetupDependencies(_record, saveResult: 0);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportProgramExpendituresRecordCommand(_record.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntity(typeof(ReportProgramExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        SetupDependencies(_record, saveResult: 1);
+        _repositoryWrapperMock
+            .Setup(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException("Database error"));
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportProgramExpendituresRecordCommand(_record.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(ReportProgramExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies(ReportProgramExpendituresRecord? record, int saveResult)
+    {
+        _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+
+        _recordsRepositoryMock
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(record);
+
+        _recordsRepositoryMock.Setup(repository => repository.Delete(It.IsAny<ReportProgramExpendituresRecord>()));
+        _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Create;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Delete;
 using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -16,5 +17,14 @@ public class ReportProgramExpendituresRecordsController : AuthorizedApiControlle
     {
         return HandleResult(await Mediator.Send(
             new CreateReportProgramExpendituresRecordCommand(createReportProgramExpendituresRecordDto)));
+    }
+
+    [HttpDelete("{id:long}")]
+    [ProducesResponseType(typeof(long), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeleteReportProgramExpenditureRecordAsync([FromRoute] long id)
+    {
+        return HandleResult(await Mediator.Send(new DeleteReportProgramExpendituresRecordCommand(id)));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
@@ -23,7 +23,7 @@ public class ReportProgramExpendituresRecordsController : AuthorizedApiControlle
     [ProducesResponseType(typeof(long), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> DeleteReportProgramExpenditureRecordAsync([FromRoute] long id)
+    public async Task<IActionResult> DeleteReportProgramExpendituresRecordAsync([FromRoute] long id)
     {
         return HandleResult(await Mediator.Send(new DeleteReportProgramExpendituresRecordCommand(id)));
     }


### PR DESCRIPTION
dev
## Github

* [Github issue](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2234)

## Summary of issue
- Added a DELETE endpoint to delete a single program expense
- Implemented validation for the incoming requests
- Added tests that cover new features

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints for creating and deleting program expenditure records with automatic validation of monetary amounts and reporting year ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->