### PR TITLE
Feature/issue 2235 [Reports] Program expenses - Bulk deletion of program expense records backend

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
+
+public record BulkDeleteReportProgramExpendituresRecordCommand(IEnumerable<long> Ids)
+    : IRequest<Result<long[]>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommandHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommandHandler.cs
@@ -30,8 +30,6 @@ public class BulkDeleteReportProgramExpendituresRecordCommandHandler
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            using var transaction = _repositoryWrapper.BeginTransaction();
-
             var entitiesToDelete = (await _repositoryWrapper
                 .ReportProgramExpendituresRecordsRepository
                 .GetAllAsync(new QueryOptions<ReportProgramExpendituresRecord>
@@ -59,8 +57,6 @@ public class BulkDeleteReportProgramExpendituresRecordCommandHandler
                 return Result.Fail(
                     ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportProgramExpendituresRecord)));
             }
-
-            transaction.Complete();
 
             return Result.Ok(request.Ids.ToArray());
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommandHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommandHandler.cs
@@ -1,0 +1,80 @@
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
+
+public class BulkDeleteReportProgramExpendituresRecordCommandHandler
+    : IRequestHandler<BulkDeleteReportProgramExpendituresRecordCommand, Result<long[]>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<BulkDeleteReportProgramExpendituresRecordCommand> _validator;
+
+    public BulkDeleteReportProgramExpendituresRecordCommandHandler(
+        IValidator<BulkDeleteReportProgramExpendituresRecordCommand> validator, IRepositoryWrapper repositoryWrapper)
+    {
+        _validator = validator;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<long[]>> Handle(
+        BulkDeleteReportProgramExpendituresRecordCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            using var transaction = _repositoryWrapper.BeginTransaction();
+
+            var existingRecordIds = await _repositoryWrapper
+                .ReportProgramExpendituresRecordsRepository
+                .GetAllProjectedAsync(
+                    record => record.Id,
+                    new QueryOptions<ReportProgramExpendituresRecord>
+                    {
+                        Filter = record => request.Ids.Contains(record.Id),
+                        AsNoTracking = true
+                    });
+
+            var nonExistingRecordIds = request.Ids.Except(existingRecordIds).ToList();
+
+            if (nonExistingRecordIds.Count > 0)
+            {
+                return Result.Fail(ErrorMessagesConstants.NotFound(
+                    nonExistingRecordIds,
+                    typeof(ReportProgramExpendituresRecord)));
+            }
+
+            var deletedEntityCount = await _repositoryWrapper
+                .ReportProgramExpendituresRecordsRepository
+                .BulkDeleteAsync(record => request.Ids.Contains(record.Id));
+
+            if (deletedEntityCount != request.Ids.Count())
+            {
+                return Result.Fail(
+                    ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportProgramExpendituresRecord)));
+            }
+
+            transaction.Complete();
+
+            return Result.Ok(request.Ids.ToArray());
+        }
+        catch (ValidationException validationException)
+        {
+            return Result.Fail(
+                validationException.Errors.Select(error => error.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail(
+                ErrorMessagesConstants.FailedToDeleteEntitiesInDatabase(
+                    typeof(ReportProgramExpendituresRecord)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommandHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordCommandHandler.cs
@@ -32,30 +32,29 @@ public class BulkDeleteReportProgramExpendituresRecordCommandHandler
 
             using var transaction = _repositoryWrapper.BeginTransaction();
 
-            var existingRecordIds = await _repositoryWrapper
+            var entitiesToDelete = (await _repositoryWrapper
                 .ReportProgramExpendituresRecordsRepository
-                .GetAllProjectedAsync(
-                    record => record.Id,
-                    new QueryOptions<ReportProgramExpendituresRecord>
-                    {
-                        Filter = record => request.Ids.Contains(record.Id),
-                        AsNoTracking = true
-                    });
+                .GetAllAsync(new QueryOptions<ReportProgramExpendituresRecord>
+                {
+                    Filter = record => request.Ids.Contains(record.Id)
+                })).ToList();
+
+            var existingRecordIds = entitiesToDelete.Select(e => e.Id);
 
             var nonExistingRecordIds = request.Ids.Except(existingRecordIds).ToList();
 
-            if (nonExistingRecordIds.Count > 0)
+            if (nonExistingRecordIds.Any())
             {
                 return Result.Fail(ErrorMessagesConstants.NotFound(
                     nonExistingRecordIds,
                     typeof(ReportProgramExpendituresRecord)));
             }
 
-            var deletedEntityCount = await _repositoryWrapper
+            _repositoryWrapper
                 .ReportProgramExpendituresRecordsRepository
-                .BulkDeleteAsync(record => request.Ids.Contains(record.Id));
+                .DeleteRange(entitiesToDelete);
 
-            if (deletedEntityCount != request.Ids.Count())
+            if (await _repositoryWrapper.SaveChangesAsync() == 0)
             {
                 return Result.Fail(
                     ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportProgramExpendituresRecord)));

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -1,3 +1,5 @@
+using VictoryCenter.DAL.Enums;
+
 namespace VictoryCenter.BLL.Constants;
 
 public static class ErrorMessagesConstants
@@ -74,6 +76,20 @@ public static class ErrorMessagesConstants
         ArgumentNullException.ThrowIfNull(entityType);
 
         return $"Failed to delete {entityType.Name}";
+    }
+
+    public static string FailedToDeleteEntities(Type entityType)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+
+        return $"Failed to delete {entityType.Name} entities  in the database";
+    }
+
+    public static string FailedToDeleteEntitiesInDatabase(Type entityType)
+    {
+        ArgumentNullException.ThrowIfNull(entityType);
+
+        return $"Failed to delete {entityType.Name} entities in the database";
     }
 
     public static string FailedToDeleteEntityInDatabase(Type entityType)
@@ -157,7 +173,7 @@ public static class ErrorMessagesConstants
         return $"{property} must be a valid value";
     }
 
-    public static string PropertyNotAllowedForContentType(string property, DAL.Enums.ContentType contentType)
+    public static string PropertyNotAllowedForContentType(string property, ContentType contentType)
     {
         return $"{property} is not allowed for content type {contentType}";
     }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -82,7 +82,7 @@ public static class ErrorMessagesConstants
     {
         ArgumentNullException.ThrowIfNull(entityType);
 
-        return $"Failed to delete {entityType.Name} entities  in the database";
+        return $"Failed to delete {entityType.Name} entities";
     }
 
     public static string FailedToDeleteEntitiesInDatabase(Type entityType)

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportProgramExpendituresRecordConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportProgramExpendituresRecordConstants.cs
@@ -18,6 +18,8 @@ public static class ReportProgramExpendituresRecordConstants
     public static readonly string AmountFormat =
         $"a number with up to {AmountDigitsBeforeDecimalPoint} digits before the decimal separator and up to {AmountDigitsAfterDecimalPoint} after";
 
+    public static readonly int MaxNumberOfRecordsPerBulkDelete = 100;
+
     public static string ProgramCategoryAlreadyHasRecordForSpecifiedYear(long programCategoryId, int year)
     {
         return $"A record for the {programCategoryId} program category already exists for the year {year}.";

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.DAL.Entities;
 
 namespace VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
@@ -13,6 +14,17 @@ public class BulkDeleteReportProgramExpendituresRecordCommandValidator
             .MustBeValidId(nameof(ReportProgramExpendituresRecord.Id));
 
         RuleFor(e => e.Ids)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)))
+            .WithMessage(
+                ErrorMessagesConstants.CollectionCannotBeEmpty(
+                    nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)))
+            .Must(e =>
+                e.Count() <= ReportProgramExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids),
+                ReportProgramExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete))
             .MustHaveUniqueIds(nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidator.cs
@@ -17,9 +17,6 @@ public class BulkDeleteReportProgramExpendituresRecordCommandValidator
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
                 nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)))
-            .WithMessage(
-                ErrorMessagesConstants.CollectionCannotBeEmpty(
-                    nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)))
             .Must(e =>
                 e.Count() <= ReportProgramExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete)
             .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
+
+public class BulkDeleteReportProgramExpendituresRecordCommandValidator
+    : AbstractValidator<BulkDeleteReportProgramExpendituresRecordCommand>
+{
+    public BulkDeleteReportProgramExpendituresRecordCommandValidator()
+    {
+        RuleForEach(e => e.Ids)
+            .MustBeValidId(nameof(ReportProgramExpendituresRecord.Id));
+
+        RuleFor(e => e.Ids)
+            .MustHaveUniqueIds(nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/ReportProgramExpendituresRecordsValidationExtensions.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportProgramExpendituresRecords/ReportProgramExpendituresRecordsValidationExtensions.cs
@@ -46,4 +46,16 @@ public static class ReportProgramExpendituresRecordsValidationExtensions
                 property,
                 ReportProgramExpendituresRecordConstants.ReportingYearMaxValue));
     }
+
+    public static IRuleBuilderOptions<T, IEnumerable<long>> MustHaveUniqueIds<T>(
+        this IRuleBuilder<T, IEnumerable<long>> ruleBuilder,
+        string collection)
+    {
+        return ruleBuilder.Must(e =>
+            {
+                var enumerable = e as long[] ?? e.ToArray();
+                return enumerable.Count() == enumerable.Distinct().Count();
+            })
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(collection));
+    }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
@@ -29,6 +29,8 @@ public interface IRepositoryBase<T>
 
     void DeleteRange(IEnumerable<T> entities);
 
+    Task<bool> ExistsAsync(Expression<Func<T, bool>> filter);
+
     Task<TKey?> MaxAsync<TKey>(Expression<Func<T, TKey>> selector, Expression<Func<T, bool>>? filter = null)
         where TKey : struct;
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
@@ -9,7 +9,15 @@ public interface IRepositoryBase<T>
 {
     Task<IEnumerable<T>> GetAllAsync(QueryOptions<T>? queryOptions = null);
 
+    Task<IEnumerable<TResult>> GetAllProjectedAsync<TResult>(
+        Expression<Func<T, TResult>> selector,
+        QueryOptions<T>? queryOptions = null);
+
     Task<T?> GetFirstOrDefaultAsync(QueryOptions<T>? queryOptions = null);
+
+    Task<TResult?> GetFirstOrDefaultProjectedAsync<TResult>(
+        Expression<Func<T, TResult>> selector,
+        QueryOptions<T>? queryOptions = null);
 
     Task<T> CreateAsync(T entity);
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryBase.cs
@@ -37,6 +37,8 @@ public interface IRepositoryBase<T>
 
     void DeleteRange(IEnumerable<T> entities);
 
+    Task<int> BulkDeleteAsync(Expression<Func<T, bool>> filter);
+
     Task<bool> ExistsAsync(Expression<Func<T, bool>> filter);
 
     Task<TKey?> MaxAsync<TKey>(Expression<Func<T, TKey>> selector, Expression<Func<T, bool>>? filter = null)

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryBase.cs
@@ -30,6 +30,22 @@ public class RepositoryBase<T> : IRepositoryBase<T>
         return await query.ToListAsync();
     }
 
+    public async Task<IEnumerable<TResult>> GetAllProjectedAsync<TResult>(
+        Expression<Func<T, TResult>> selector,
+        QueryOptions<T>? queryOptions = null)
+    {
+        IQueryable<T> query = DbContext.Set<T>();
+
+        if (queryOptions != null)
+        {
+            query = ApplyQueryOptions(query, queryOptions);
+        }
+
+        var projectedQuery = ApplySelect(query, selector);
+
+        return await projectedQuery.ToListAsync();
+    }
+
     public async Task<T?> GetFirstOrDefaultAsync(QueryOptions<T>? queryOptions = null)
     {
         IQueryable<T> query = DbContext.Set<T>();
@@ -42,6 +58,24 @@ public class RepositoryBase<T> : IRepositoryBase<T>
         }
 
         return await query.FirstOrDefaultAsync();
+    }
+
+    public async Task<TResult?> GetFirstOrDefaultProjectedAsync<TResult>(
+        Expression<Func<T, TResult>> selector,
+        QueryOptions<T>? queryOptions = null)
+    {
+        IQueryable<T> query = DbContext.Set<T>();
+
+        if (queryOptions != null)
+        {
+            query = ApplyTracking(query, queryOptions.AsNoTracking);
+            query = ApplyInclude(query, queryOptions.Include);
+            query = ApplyFilter(query, queryOptions.Filter);
+        }
+
+        var projectedQuery = ApplySelect(query, selector);
+
+        return await projectedQuery.FirstOrDefaultAsync();
     }
 
     public async Task<T> CreateAsync(T entity)
@@ -163,9 +197,14 @@ public class RepositoryBase<T> : IRepositoryBase<T>
         return query;
     }
 
-    static private IQueryable<T> ApplyTracking(IQueryable<T> query, bool asNoTracking)
+    private static IQueryable<T> ApplyTracking(IQueryable<T> query, bool asNoTracking)
     {
         return asNoTracking ? query.AsNoTracking() : query;
+    }
+
+    private static IQueryable<TResult> ApplySelect<TResult>(IQueryable<T> query, Expression<Func<T, TResult>> selector)
+    {
+        return query.Select(selector);
     }
 
     private static IQueryable<T> ApplyQueryOptions(IQueryable<T> query, QueryOptions<T> queryOptions)

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryBase.cs
@@ -89,6 +89,11 @@ public class RepositoryBase<T> : IRepositoryBase<T>
         DbContext.Set<T>().RemoveRange(entities);
     }
 
+    public async Task<bool> ExistsAsync(Expression<Func<T, bool>> filter)
+    {
+        return await DbContext.Set<T>().AnyAsync(filter);
+    }
+
     public async Task<TKey?> MaxAsync<TKey>(
         Expression<Func<T, TKey>> selector,
         Expression<Func<T, bool>>? filter = null)

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryBase.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryBase.cs
@@ -123,6 +123,11 @@ public class RepositoryBase<T> : IRepositoryBase<T>
         DbContext.Set<T>().RemoveRange(entities);
     }
 
+    public async Task<int> BulkDeleteAsync(Expression<Func<T, bool>> filter)
+    {
+        return await DbContext.Set<T>().Where(filter).ExecuteDeleteAsync();
+    }
+
     public async Task<bool> ExistsAsync(Expression<Func<T, bool>> filter)
     {
         return await DbContext.Set<T>().AnyAsync(filter);

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -27,7 +27,7 @@ public class BulkDeleteReportProgramExpendituresRecordTests : BaseTestClass
             Name = "Hippotherapy category",
             CreatedAt = DateTimeOffset.UtcNow
         };
-        await Fixture.DbContext.HippotherapyProgramCategories.AddAsync(category);
+        await Fixture.DbContext.HippotherapyProgramCategories.AddRangeAsync(category, category2);
         await Fixture.DbContext.SaveChangesAsync();
 
         var record1 = new ReportProgramExpendituresRecord

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.DAL.Entities;
 using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
 
@@ -10,65 +14,64 @@ public class BulkDeleteReportProgramExpendituresRecordTests : BaseTestClass
     {
     }
 
-    // [Fact]
-    // public async Task BulkDelete_ShouldDeleteRecords()
-    // {
-    //     var category = new HippotherapyProgramCategory
-    //     {
-    //         Name = "Hippotherapy category",
-    //         CreatedAt = DateTimeOffset.UtcNow
-    //     };
-    //     var category2 = new HippotherapyProgramCategory
-    //     {
-    //         Name = "Hippotherapy category",
-    //         CreatedAt = DateTimeOffset.UtcNow
-    //     };
-    //     await Fixture.DbContext.HippotherapyProgramCategories.AddAsync(category);
-    //     await Fixture.DbContext.SaveChangesAsync();
-    //
-    //     var record1 = new ReportProgramExpendituresRecord
-    //     {
-    //         HippotherapyProgramCategoryId = category.Id,
-    //         ReportingYear = 2025,
-    //         AmountUah = 300m,
-    //         AmountUsd = 6m,
-    //         CreatedAt = DateTimeOffset.UtcNow
-    //     };
-    //     var record2 = new ReportProgramExpendituresRecord
-    //     {
-    //         HippotherapyProgramCategoryId = category2.Id,
-    //         ReportingYear = 2026,
-    //         AmountUah = 400m,
-    //         AmountUsd = 8m,
-    //         CreatedAt = DateTimeOffset.UtcNow
-    //     };
-    //     await Fixture.DbContext.ReportProgramExpendituresRecords.AddRangeAsync(record1, record2);
-    //     await Fixture.DbContext.SaveChangesAsync();
-    //
-    //     var idsToDelete = new List<long> { record1.Id, record2.Id };
-    //
-    //     HttpResponseMessage response = await Fixture.HttpClient.PostAsJsonAsync(
-    //         "/api/ReportProgramExpendituresRecords/bulk-delete", idsToDelete);
-    //     response.EnsureSuccessStatusCode();
-    //
-    //     var remainingRecords = await Fixture.DbContext.ReportProgramExpendituresRecords
-    //         .Where(entity => idsToDelete.Contains(entity.Id))
-    //         .ToListAsync();
-    //
-    //     Assert.Empty(remainingRecords);
-    // }
-    //
-    // [Theory]
-    // [InlineData(-1, -2)]
-    // [InlineData(0, 0)]
-    // public async Task BulkDelete_ShouldNotDeleteRecords_NotFound(long id1, long id2)
-    // {
-    //     var idsToDelete = new List<long> { id1, id2 };
-    //
-    //     HttpResponseMessage response = await Fixture.HttpClient.PostAsJsonAsync(
-    //         "/api/ReportProgramExpendituresRecords/bulk-delete", idsToDelete);
-    //
-    //     Assert.False(response.IsSuccessStatusCode);
-    //     Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    // }
+    [Fact]
+    public async Task BulkDelete_ShouldDeleteRecords()
+    {
+        var category = new HippotherapyProgramCategory
+        {
+            Name = "Hippotherapy category",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var category2 = new HippotherapyProgramCategory
+        {
+            Name = "Hippotherapy category",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.HippotherapyProgramCategories.AddAsync(category);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var record1 = new ReportProgramExpendituresRecord
+        {
+            HippotherapyProgramCategoryId = category.Id,
+            ReportingYear = 2025,
+            AmountUah = 300m,
+            AmountUsd = 6m,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var record2 = new ReportProgramExpendituresRecord
+        {
+            HippotherapyProgramCategoryId = category2.Id,
+            ReportingYear = 2026,
+            AmountUah = 400m,
+            AmountUsd = 8m,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.ReportProgramExpendituresRecords.AddRangeAsync(record1, record2);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var idsToDelete = new List<long> { record1.Id, record2.Id };
+        var response = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/ReportProgramExpendituresRecords/bulk-delete", idsToDelete);
+        response.EnsureSuccessStatusCode();
+
+        var remainingRecords = await Fixture.DbContext.ReportProgramExpendituresRecords
+            .Where(entity => idsToDelete.Contains(entity.Id))
+            .ToListAsync();
+
+        Assert.Empty(remainingRecords);
+    }
+
+    [Theory]
+    [InlineData(1111, 22222)]
+    [InlineData(2131231, 3424324)]
+    public async Task BulkDelete_ShouldNotDeleteRecords_NotFound(long id1, long id2)
+    {
+        var idsToDelete = new List<long> { id1, id2 };
+
+        var response = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/ReportProgramExpendituresRecords/bulk-delete", idsToDelete);
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/BulkDelete/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -1,0 +1,74 @@
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.ReportProgramExpendituresRecords.BulkDelete;
+
+public class BulkDeleteReportProgramExpendituresRecordTests : BaseTestClass
+{
+    public BulkDeleteReportProgramExpendituresRecordTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    // [Fact]
+    // public async Task BulkDelete_ShouldDeleteRecords()
+    // {
+    //     var category = new HippotherapyProgramCategory
+    //     {
+    //         Name = "Hippotherapy category",
+    //         CreatedAt = DateTimeOffset.UtcNow
+    //     };
+    //     var category2 = new HippotherapyProgramCategory
+    //     {
+    //         Name = "Hippotherapy category",
+    //         CreatedAt = DateTimeOffset.UtcNow
+    //     };
+    //     await Fixture.DbContext.HippotherapyProgramCategories.AddAsync(category);
+    //     await Fixture.DbContext.SaveChangesAsync();
+    //
+    //     var record1 = new ReportProgramExpendituresRecord
+    //     {
+    //         HippotherapyProgramCategoryId = category.Id,
+    //         ReportingYear = 2025,
+    //         AmountUah = 300m,
+    //         AmountUsd = 6m,
+    //         CreatedAt = DateTimeOffset.UtcNow
+    //     };
+    //     var record2 = new ReportProgramExpendituresRecord
+    //     {
+    //         HippotherapyProgramCategoryId = category2.Id,
+    //         ReportingYear = 2026,
+    //         AmountUah = 400m,
+    //         AmountUsd = 8m,
+    //         CreatedAt = DateTimeOffset.UtcNow
+    //     };
+    //     await Fixture.DbContext.ReportProgramExpendituresRecords.AddRangeAsync(record1, record2);
+    //     await Fixture.DbContext.SaveChangesAsync();
+    //
+    //     var idsToDelete = new List<long> { record1.Id, record2.Id };
+    //
+    //     HttpResponseMessage response = await Fixture.HttpClient.PostAsJsonAsync(
+    //         "/api/ReportProgramExpendituresRecords/bulk-delete", idsToDelete);
+    //     response.EnsureSuccessStatusCode();
+    //
+    //     var remainingRecords = await Fixture.DbContext.ReportProgramExpendituresRecords
+    //         .Where(entity => idsToDelete.Contains(entity.Id))
+    //         .ToListAsync();
+    //
+    //     Assert.Empty(remainingRecords);
+    // }
+    //
+    // [Theory]
+    // [InlineData(-1, -2)]
+    // [InlineData(0, 0)]
+    // public async Task BulkDelete_ShouldNotDeleteRecords_NotFound(long id1, long id2)
+    // {
+    //     var idsToDelete = new List<long> { id1, id2 };
+    //
+    //     HttpResponseMessage response = await Fixture.HttpClient.PostAsJsonAsync(
+    //         "/api/ReportProgramExpendituresRecords/bulk-delete", idsToDelete);
+    //
+    //     Assert.False(response.IsSuccessStatusCode);
+    //     Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    // }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -1,4 +1,3 @@
-using System.Linq.Expressions;
 using System.Transactions;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
@@ -31,8 +30,9 @@ public class BulkDeleteReportProgramExpendituresRecordTests
     {
         // Arrange
         var ids = new long[] { 1, 2, 3 };
+        var entities = ids.Select(id => new ReportProgramExpendituresRecord { Id = id }).ToList();
         var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
-        SetupDependencies(ids.ToList(), 3);
+        SetupDependencies(entities, 1);
 
         var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
             _validator, _repositoryWrapperMock.Object);
@@ -90,9 +90,10 @@ public class BulkDeleteReportProgramExpendituresRecordTests
         // Arrange
         var ids = new long[] { 1, 2, 3 };
         var existingIds = new List<long> { 1, 2 };
+        var entities = existingIds.Select(id => new ReportProgramExpendituresRecord { Id = id }).ToList();
         var nonExistingIds = new List<long> { 3 };
         var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
-        SetupDependencies(existingIds, 0);
+        SetupDependencies(entities, 0);
 
         var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
             _validator, _repositoryWrapperMock.Object);
@@ -108,12 +109,13 @@ public class BulkDeleteReportProgramExpendituresRecordTests
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenDeletedCountDoesNotMatch()
+    public async Task Handle_ShouldFail_WhenSaveChangesFails()
     {
         // Arrange
         var ids = new long[] { 1, 2, 3 };
+        var entities = ids.Select(id => new ReportProgramExpendituresRecord { Id = id }).ToList();
         var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
-        SetupDependencies(ids.ToList(), 2);
+        SetupDependencies(entities, 0);
 
         var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
             _validator, _repositoryWrapperMock.Object);
@@ -133,6 +135,7 @@ public class BulkDeleteReportProgramExpendituresRecordTests
     {
         // Arrange
         var ids = new long[] { 1, 2, 3 };
+        var entities = ids.Select(id => new ReportProgramExpendituresRecord { Id = id }).ToList();
         var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
 
         _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
@@ -142,13 +145,13 @@ public class BulkDeleteReportProgramExpendituresRecordTests
             .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
 
         _recordsRepositoryMock.Setup(repository =>
-                repository.GetAllProjectedAsync(
-                    It.IsAny<Expression<Func<ReportProgramExpendituresRecord, long>>>(),
-                    It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
-            .ReturnsAsync(ids.ToList());
+                repository.GetAllAsync(It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(entities);
 
         _recordsRepositoryMock.Setup(repository =>
-                repository.BulkDeleteAsync(It.IsAny<Expression<Func<ReportProgramExpendituresRecord, bool>>>()))
+            repository.DeleteRange(It.IsAny<IEnumerable<ReportProgramExpendituresRecord>>()));
+
+        _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync())
             .ThrowsAsync(new DbUpdateException());
 
         var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
@@ -164,7 +167,7 @@ public class BulkDeleteReportProgramExpendituresRecordTests
             result.Errors[0].Message);
     }
 
-    private void SetupDependencies(List<long> returnedProjectionIds, int deletedCount)
+    private void SetupDependencies(IEnumerable<ReportProgramExpendituresRecord> returnedEntities, int saveResult)
     {
         _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
             .Returns(_recordsRepositoryMock.Object);
@@ -173,13 +176,12 @@ public class BulkDeleteReportProgramExpendituresRecordTests
             .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
 
         _recordsRepositoryMock.Setup(repository =>
-                repository.GetAllProjectedAsync(
-                    It.IsAny<Expression<Func<ReportProgramExpendituresRecord, long>>>(),
-                    It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
-            .ReturnsAsync(returnedProjectionIds);
+                repository.GetAllAsync(It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(returnedEntities);
 
         _recordsRepositoryMock.Setup(repository =>
-                repository.BulkDeleteAsync(It.IsAny<Expression<Func<ReportProgramExpendituresRecord, bool>>>()))
-            .ReturnsAsync(deletedCount);
+            repository.DeleteRange(It.IsAny<IEnumerable<ReportProgramExpendituresRecord>>()));
+
+        _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -85,6 +85,46 @@ public class BulkDeleteReportProgramExpendituresRecordTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenIdsAreEmpty()
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(Array.Empty<long>());
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenIdsExceedMaximumCount()
+    {
+        // Arrange
+        var maxCount = ReportProgramExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete;
+        var ids = Enumerable.Range(1, maxCount + 1).Select(i => (long)i).ToArray();
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids), maxCount),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
     public async Task Handle_ShouldFail_WhenEntitiesNotFound()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -1,0 +1,185 @@
+using System.Linq.Expressions;
+using System.Transactions;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportProgramExpendituresRecords;
+
+public class BulkDeleteReportProgramExpendituresRecordTests
+{
+    private readonly Mock<IReportProgramExpendituresRecordsRepository> _recordsRepositoryMock;
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly IValidator<BulkDeleteReportProgramExpendituresRecordCommand> _validator;
+
+    public BulkDeleteReportProgramExpendituresRecordTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _recordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
+        _validator = new BulkDeleteReportProgramExpendituresRecordCommandValidator();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteRecords()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
+        SetupDependencies(ids.ToList(), 3);
+
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(ids, result.Value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Handle_ShouldFail_WhenIdIsInvalid(long invalidId)
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand([invalidId]);
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.PropertyMustBePositive(nameof(ReportProgramExpendituresRecord.Id)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenIdsAreNotUnique()
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand([1, 1]);
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenEntitiesNotFound()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var existingIds = new List<long> { 1, 2 };
+        var nonExistingIds = new List<long> { 3 };
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
+        SetupDependencies(existingIds, 0);
+
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(nonExistingIds, typeof(ReportProgramExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDeletedCountDoesNotMatch()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
+        SetupDependencies(ids.ToList(), 2);
+
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportProgramExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
+
+        _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+
+        _repositoryWrapperMock.Setup(wrapper => wrapper.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+
+        _recordsRepositoryMock.Setup(repository =>
+                repository.GetAllProjectedAsync(
+                    It.IsAny<Expression<Func<ReportProgramExpendituresRecord, long>>>(),
+                    It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(ids.ToList());
+
+        _recordsRepositoryMock.Setup(repository =>
+                repository.BulkDeleteAsync(It.IsAny<Expression<Func<ReportProgramExpendituresRecord, bool>>>()))
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = new BulkDeleteReportProgramExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntitiesInDatabase(typeof(ReportProgramExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies(List<long> returnedProjectionIds, int deletedCount)
+    {
+        _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+
+        _repositoryWrapperMock.Setup(wrapper => wrapper.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
+
+        _recordsRepositoryMock.Setup(repository =>
+                repository.GetAllProjectedAsync(
+                    It.IsAny<Expression<Func<ReportProgramExpendituresRecord, long>>>(),
+                    It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(returnedProjectionIds);
+
+        _recordsRepositoryMock.Setup(repository =>
+                repository.BulkDeleteAsync(It.IsAny<Expression<Func<ReportProgramExpendituresRecord, bool>>>()))
+            .ReturnsAsync(deletedCount);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordTests.cs
@@ -1,4 +1,3 @@
-using System.Transactions;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Moq;
@@ -181,9 +180,6 @@ public class BulkDeleteReportProgramExpendituresRecordTests
         _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
             .Returns(_recordsRepositoryMock.Object);
 
-        _repositoryWrapperMock.Setup(wrapper => wrapper.BeginTransaction())
-            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
-
         _recordsRepositoryMock.Setup(repository =>
                 repository.GetAllAsync(It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))
             .ReturnsAsync(entities);
@@ -211,9 +207,6 @@ public class BulkDeleteReportProgramExpendituresRecordTests
     {
         _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
             .Returns(_recordsRepositoryMock.Object);
-
-        _repositoryWrapperMock.Setup(wrapper => wrapper.BeginTransaction())
-            .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
 
         _recordsRepositoryMock.Setup(repository =>
                 repository.GetAllAsync(It.IsAny<QueryOptions<ReportProgramExpendituresRecord>>()))

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportProgramExpendituresRecords/BulkDeleteReportProgramExpendituresRecordCommandValidatorTests.cs
@@ -1,0 +1,93 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.ReportProgramExpendituresRecords;
+
+public class BulkDeleteReportProgramExpendituresRecordCommandValidatorTests
+{
+    private readonly BulkDeleteReportProgramExpendituresRecordCommandValidator _validator;
+
+    public BulkDeleteReportProgramExpendituresRecordCommandValidatorTests()
+    {
+        _validator = new BulkDeleteReportProgramExpendituresRecordCommandValidator();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIdsAreEmpty()
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(Array.Empty<long>());
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Ids)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIdsContainInvalidId()
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(new[] { 1L, 0L });
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Ids)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(ReportProgramExpendituresRecord.Id)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIdsAreNotUnique()
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(new[] { 1L, 1L });
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Ids)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIdsExceedMaximumCount()
+    {
+        // Arrange
+        var maxCount = ReportProgramExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete;
+        var ids = Enumerable.Range(1, maxCount + 1).Select(i => (long)i).ToArray();
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(ids);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Ids)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(BulkDeleteReportProgramExpendituresRecordCommand.Ids),
+                maxCount));
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        // Arrange
+        var command = new BulkDeleteReportProgramExpendituresRecordCommand(new[] { 1L, 2L, 3L });
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportProgramExpendituresRecords/ReportProgramExpendituresRecordsValidationExtensionsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportProgramExpendituresRecords/ReportProgramExpendituresRecordsValidationExtensionsTests.cs
@@ -86,10 +86,27 @@ public class ReportProgramExpendituresRecordsValidationExtensionsTests
         {
             Amount = 100.50m,
             Id = 1,
-            Year = ReportProgramExpendituresRecordConstants.ReportingYearMinValue
+            Year = ReportProgramExpendituresRecordConstants.ReportingYearMinValue,
+            Ids = [1, 2, 3]
         };
         var result = _validator.TestValidate(model);
         result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenIdsAreNotUnique()
+    {
+        var model = new DummyModel
+        {
+            Amount = 100.50m,
+            Id = 1,
+            Year = ReportProgramExpendituresRecordConstants.ReportingYearMinValue,
+            Ids = [1, 1, 1]
+        };
+
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Ids)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(DummyModel.Ids)));
     }
 
     private class DummyModel
@@ -97,6 +114,7 @@ public class ReportProgramExpendituresRecordsValidationExtensionsTests
         public decimal Amount { get; set; }
         public long Id { get; set; }
         public int Year { get; set; }
+        public IEnumerable<long> Ids { get; set; } = [];
     }
 
     private class DummyValidator : AbstractValidator<DummyModel>
@@ -106,6 +124,7 @@ public class ReportProgramExpendituresRecordsValidationExtensionsTests
             RuleFor(x => x.Amount).MustBeValidAmountOfMoney(nameof(DummyModel.Amount));
             RuleFor(x => x.Id).MustBeValidId(nameof(DummyModel.Id));
             RuleFor(x => x.Year).MustBeValidReportingYear(nameof(DummyModel.Year));
+            RuleFor(x => x.Ids).MustHaveUniqueIds(nameof(DummyModel.Ids));
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
@@ -24,7 +24,7 @@ public class ReportProgramExpendituresRecordsController : AuthorizedApiControlle
     [ProducesResponseType(typeof(long[]), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> BulkDeleteReportProgramExpenditureRecordsAsync([FromBody] IEnumerable<long> ids)
+    public async Task<IActionResult> BulkDeleteReportProgramExpendituresRecordsAsync([FromBody] IEnumerable<long> ids)
     {
         return HandleResult(await Mediator.Send(new BulkDeleteReportProgramExpendituresRecordCommand(ids)));
     }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.BulkDelete;
 using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Create;
 using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
 using VictoryCenter.WebAPI.Controllers.Common;
@@ -16,5 +17,14 @@ public class ReportProgramExpendituresRecordsController : AuthorizedApiControlle
     {
         return HandleResult(await Mediator.Send(
             new CreateReportProgramExpendituresRecordCommand(createReportProgramExpendituresRecordDto)));
+    }
+
+    [HttpPost("bulk-delete")]
+    [ProducesResponseType(typeof(long[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> BulkDeleteReportProgramExpenditureRecordsAsync([FromBody] IEnumerable<long> ids)
+    {
+        return HandleResult(await Mediator.Send(new BulkDeleteReportProgramExpendituresRecordCommand(ids)));
     }
 }


### PR DESCRIPTION
dev
## Github

* [Github issue](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2235)

- Added a POST endpoint for bulk deletion of program expense records
- Implemented validation for the incoming requests
- Added tests that cover new features

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bulk-delete admin endpoint for Report Program Expenditures Records with a 100-item limit.

* **Validation**
  * IDs must be present, positive, unique, and within the configured limit; detailed validation errors returned.

* **Error Handling**
  * Clear failure responses for missing records, failed deletions, and database errors.

* **Tests**
  * New unit and integration tests covering successful deletion and multiple failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->