### PR TITLE
Fix/issue-2231: add image versioning support with UpdatedAt field

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Images/Update/UpdateImageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Images/Update/UpdateImageHandler.cs
@@ -52,6 +52,7 @@ public class UpdateImageHandler : IRequestHandler<UpdateImageCommand, Result<Ima
 
             var previousType = imageEntity.MimeType;
             imageEntity.MimeType = request.UpdateImageDto.MimeType!;
+            imageEntity.UpdatedAt = DateTimeOffset.UtcNow;
 
             _repositoryWrapper.ImageRepository.Update(imageEntity);
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Images/Update/UpdateImageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Images/Update/UpdateImageHandler.cs
@@ -18,18 +18,21 @@ public class UpdateImageHandler : IRequestHandler<UpdateImageCommand, Result<Ima
     private readonly IBlobService _blobService;
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly TimeProvider _timeProvider;
     private readonly IValidator<UpdateImageCommand> _validator;
 
     public UpdateImageHandler(
         IMapper mapper,
         IRepositoryWrapper repositoryWrapper,
         IValidator<UpdateImageCommand> validator,
-        IBlobService blobService)
+        IBlobService blobService,
+        TimeProvider timeProvider)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
         _blobService = blobService;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Result<ImageDto>> Handle(UpdateImageCommand request, CancellationToken cancellationToken)
@@ -52,7 +55,7 @@ public class UpdateImageHandler : IRequestHandler<UpdateImageCommand, Result<Ima
 
             var previousType = imageEntity.MimeType;
             imageEntity.MimeType = request.UpdateImageDto.MimeType!;
-            imageEntity.UpdatedAt = DateTimeOffset.UtcNow;
+            imageEntity.UpdatedAt = _timeProvider.GetUtcNow();
 
             _repositoryWrapper.ImageRepository.Update(imageEntity);
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Common/ImageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Common/ImageDto.cs
@@ -7,4 +7,5 @@ public record ImageDto
     public string Url { get; init; } = null!;
     public string MimeType { get; init; } = null!;
     public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ImageConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ImageConfig.cs
@@ -26,6 +26,9 @@ public class ImageConfig : IEntityTypeConfiguration<Image>
         entity.Property(e => e.CreatedAt)
             .IsRequired();
 
+        entity.Property(e => e.UpdatedAt)
+            .IsRequired();
+
         entity.Ignore(e => e.Url);
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Image.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Image.cs
@@ -11,4 +11,6 @@ public class Image : BaseEntity
     public string? Url { get; set; }
 
     public string MimeType { get; set; } = null!;
+
+    public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260418174750_AddUpdatedAtToImage.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260418174750_AddUpdatedAtToImage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418174750_AddUpdatedAtToImage")]
+    partial class AddUpdatedAtToImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260418174750_AddUpdatedAtToImage.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260418174750_AddUpdatedAtToImage.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUpdatedAtToImage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                schema: "media",
+                table: "Images",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.Sql(@"UPDATE media.""Images"" SET ""UpdatedAt"" = ""CreatedAt""");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                schema: "media",
+                table: "Images");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Images/UpdateImage.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Images/UpdateImage.cs
@@ -19,6 +19,7 @@ public class UpdateImageHandlerTests
     private readonly Mock<IMapper> _mockMapper;
     private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
     private readonly Mock<IBlobService> _mockBlobService;
+    private readonly Mock<TimeProvider> _mockTimeProvider;
     private readonly IValidator<UpdateImageCommand> _validator;
 
     private readonly UpdateImageDto _testUpdateImageDto = new()
@@ -35,13 +36,16 @@ public class UpdateImageHandlerTests
         CreatedAt = new DateTimeOffset(2025, 7, 16, 14, 30, 0, TimeZoneInfo.Utc.BaseUtcOffset)
     };
 
+    private static readonly DateTimeOffset TestNow = new(2025, 7, 16, 14, 30, 0, TimeSpan.Zero);
+
     private readonly ImageDto _testImageDto = new()
     {
         Id = 1,
         BlobName = "testblob.png",
         MimeType = "image/png",
         Url = "dGVzdA==",
-        CreatedAt = DateTimeOffset.UtcNow
+        CreatedAt = TestNow,
+        UpdatedAt = TestNow
     };
 
     public UpdateImageHandlerTests()
@@ -49,6 +53,8 @@ public class UpdateImageHandlerTests
         _mockMapper = new Mock<IMapper>();
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
         _mockBlobService = new Mock<IBlobService>();
+        _mockTimeProvider = new Mock<TimeProvider>();
+        _mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(TestNow);
         _validator = new UpdateImageValidator();
     }
 
@@ -84,7 +90,8 @@ public class UpdateImageHandlerTests
             _mockMapper.Object,
             _mockRepositoryWrapper.Object,
             _validator,
-            _mockBlobService.Object);
+            _mockBlobService.Object,
+            _mockTimeProvider.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -120,7 +127,8 @@ public class UpdateImageHandlerTests
             _mockMapper.Object,
             _mockRepositoryWrapper.Object,
             _validator,
-            _mockBlobService.Object);
+            _mockBlobService.Object,
+            _mockTimeProvider.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -160,7 +168,8 @@ public class UpdateImageHandlerTests
             _mockMapper.Object,
             _mockRepositoryWrapper.Object,
             _validator,
-            _mockBlobService.Object);
+            _mockBlobService.Object,
+            _mockTimeProvider.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -134,6 +134,7 @@ public static class ServicesConfiguration
                 AllowAutoRedirect = false
             });
 
+        services.AddSingleton<TimeProvider>(TimeProvider.System);
         services.AddSingleton<ITokenService, TokenService>();
         services.AddSingleton<ISlugHelper>(new SlugHelperForNonAsciiLanguages(new SlugHelperConfiguration
         {


### PR DESCRIPTION
## Github ticker

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2231)

*  [Related  frontend PR](https://github.com/ita-social-projects/VictoryCenter-Client/pull/348)


## Description

Added versioning support for images to enable cache invalidation on the client.

## Summary of change

	•	Added UpdatedAt field to the image entity.
	•	Added UpdatedAt to ImageDto.
	•	Created and applied a database migration.
	•	During the migration, a backfill was performed to populate UpdatedAt for existing records.




## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images now track update timestamps. The `UpdatedAt` field is automatically set whenever an image is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->