### PR TITLE
Fix/issue 2264 - [Visitor][Donate] '404 - Not found' error returns on Donate page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/CompanyProfile/Get/GetCompanyProfileHandler.cs
@@ -2,7 +2,8 @@ using AutoMapper;
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
+using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -38,8 +39,26 @@ public class GetCompanyProfileHandler : IRequestHandler<GetCompanyProfileQuery, 
 
         if (entity is null)
         {
-            return Result.Fail<CompanyProfileDto>(
-                ErrorMessagesConstants.NotFound());
+            return Result.Ok(new CompanyProfileDto
+            {
+                Contacts = new CompanyProfileContactsDto
+                {
+                    Phone = string.Empty,
+                    Address = string.Empty,
+                    Email = string.Empty,
+                    CorrespondenceEmail = string.Empty,
+                    Motto = string.Empty,
+                    Localizations = []
+                },
+                Requisites = new CompanyProfileRequisiteDto
+                {
+                    Recipient = string.Empty,
+                    Edrpou = string.Empty,
+                    Address = string.Empty,
+                    Localizations = []
+                },
+                SocialLinks = []
+            });
         }
 
         return Result.Ok(_mapper.Map<CompanyProfileDto>(entity));

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/FaqQuestions/GetPublished/GetPublishedFaqQuestionsBySlugHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/FaqQuestions/GetPublished/GetPublishedFaqQuestionsBySlugHandler.cs
@@ -2,7 +2,6 @@ using AutoMapper;
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Public.FaqQuestions;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
@@ -29,18 +28,20 @@ public class GetPublishedFaqQuestionsBySlugHandler
     {
         var queryOptions = new QueryOptions<FaqPlacement>
         {
-            Include = placement => placement.Include(pt => pt.Question).ThenInclude(fq => fq.Localizations).ThenInclude(l => l.Language),
-            Filter = placement => placement.Page.Slug == request.Slug && placement.Question.Status == Status.Published,
+            Include = placement => placement
+                .Include(pt => pt.Question)
+                .ThenInclude(fq => fq.Localizations)
+                .ThenInclude(l => l.Language),
+            Filter = placement => placement.Page.Slug == request.Slug
+                && placement.Question.Status == Status.Published,
             OrderByASC = placement => placement.Priority
         };
 
         var publishedFaqFromVisitorPage = await _repositoryWrapper.FaqPlacementsRepository.GetAllAsync(queryOptions);
-        if (!publishedFaqFromVisitorPage.Any())
-        {
-            return Result.Fail<List<PublishedFaqQuestionDto>>(FaqConstants.PageNotFoundOrContainsNoFaqQuestions);
-        }
 
-        var publishedFaqDtos = _mapper.Map<List<PublishedFaqQuestionDto>>(publishedFaqFromVisitorPage.Select(p => p.Question));
+        var publishedFaqDtos = _mapper.Map<List<PublishedFaqQuestionDto>>(
+            publishedFaqFromVisitorPage.Select(p => p.Question));
+
         return Result.Ok(publishedFaqDtos);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/GetCompanyProfileHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/CompanyProfile/GetCompanyProfileHandlerTests.cs
@@ -1,6 +1,5 @@
 using AutoMapper;
 using Moq;
-using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileContacts;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfileRequisites;
 using VictoryCenter.BLL.DTOs.Admin.CompanyProfiles;
@@ -90,7 +89,7 @@ public class GetCompanyProfileHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenProfileNotFound()
+    public async Task Handle_ShouldReturnEmptyDto_WhenProfileNotFound()
     {
         // Arrange
         _companyProfileRepositoryMock
@@ -99,13 +98,25 @@ public class GetCompanyProfileHandlerTests
 
         var handler = new GetCompanyProfileHandler(_repositoryWrapperMock.Object, _mapperMock.Object);
 
-        // Act
         var result = await handler.Handle(new GetCompanyProfileQuery(), CancellationToken.None);
 
-        // Assert
-        Assert.False(result.IsSuccess);
-        Assert.Equal(
-            ErrorMessagesConstants.NotFound(),
-            result.Errors[0].Message);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+
+        Assert.NotNull(result.Value.Contacts);
+        Assert.Equal(string.Empty, result.Value.Contacts.Phone);
+        Assert.Equal(string.Empty, result.Value.Contacts.Address);
+        Assert.Equal(string.Empty, result.Value.Contacts.Email);
+        Assert.Equal(string.Empty, result.Value.Contacts.CorrespondenceEmail);
+        Assert.Equal(string.Empty, result.Value.Contacts.Motto);
+        Assert.Empty(result.Value.Contacts.Localizations);
+
+        Assert.NotNull(result.Value.Requisites);
+        Assert.Equal(string.Empty, result.Value.Requisites.Recipient);
+        Assert.Equal(string.Empty, result.Value.Requisites.Edrpou);
+        Assert.Equal(string.Empty, result.Value.Requisites.Address);
+        Assert.Empty(result.Value.Requisites.Localizations);
+
+        Assert.Empty(result.Value.SocialLinks);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/FaqQuestions/GetPublishedFaqQuestionsBySlugTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/FaqQuestions/GetPublishedFaqQuestionsBySlugTests.cs
@@ -1,6 +1,5 @@
 using AutoMapper;
 using Moq;
-using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Public.FaqQuestions;
 using VictoryCenter.BLL.Queries.Public.FaqQuestions.GetPublished;
 using VictoryCenter.DAL.Entities;
@@ -85,21 +84,19 @@ public class GetPublishedFaqQuestionsBySlugTests
     }
 
     [Fact]
-    public async Task Handle_PageDoesNotExistOrIsEmpty_ShouldReturnFailure()
+    public async Task Handle_PageDoesNotExistOrIsEmpty_ShouldReturnOkWithEmptyList()
     {
-        // Arrange
         SetupRepository([]);
         SetupMapper();
         var handler = new GetPublishedFaqQuestionsBySlugHandler(_mockMapper.Object, _mockRepoWrapper.Object);
         var query = new GetPublishedFaqQuestionsBySlugQuery("another-test-slug");
 
-        // Act
         var result = await handler.Handle(query, CancellationToken.None);
 
-        // Assert
         Assert.NotNull(result);
-        Assert.True(result.IsFailed);
-        Assert.Equal(FaqConstants.PageNotFoundOrContainsNoFaqQuestions, result.Errors[0].Message);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Empty(result.Value);
     }
 
     private void SetupRepository(List<FaqPlacement> entities)


### PR DESCRIPTION
dev
## Github Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2264

## Summary of issue

The Donate page triggers public API requests that return `404 Not Found` when related content is missing in the database (e.g., FAQ/Company Profile data not seeded yet). Because the UI treats these responses as errors, a “404 - Not found” message is displayed on the Donate page. Expected behavior is that public GET endpoints return `200 OK` with an empty payload (empty list or empty DTO), allowing the page to render without errors even when no data exists yet.

## Summary of change
Fix public GET behavior for empty data scenarios to avoid returning `404 Not Found` on visitor pages.

- Updated `GetPublishedFaqQuestionsBySlugHandler`:
  - when no published FAQ items are found for a page slug, handler now returns `Result.Ok([])` instead of `Result.Fail(...)`.
- Updated `GetCompanyProfileHandler`:
  - when company profile is absent, handler now returns `Result.Ok(empty CompanyProfileDto)` instead of `Result.Fail(NotFound)`.
  - returned DTO contains initialized empty values:
    - `Contacts` with empty strings and empty localizations
    - `Requisites` with empty strings and empty localizations
    - `SocialLinks = []`

As a result, public endpoints now return `200 OK` with an empty payload shape instead of being converted to `404` by `BaseApiController.HandleResult`.

## Testing approach

Unit tests updated:

- `GetPublishedFaqQuestionsBySlugTests`
  - empty data case now expects:
    - `result.IsSuccess == true`
    - `result.Value` is empty list

- `GetCompanyProfileHandlerTests`
  - missing profile case now expects:
    - `result.IsSuccess == true`
    - returned DTO is not null
    - `Contacts` / `Requisites` are initialized with empty string fields
    - all collections are empty

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions