### PR TITLE
Refactor/issue 2301: Update totals calculating and change allowed year values in Funds and Expenditures Tab

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresRecordConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresRecordConstants.cs
@@ -2,9 +2,6 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class ReportFundsExpendituresRecordConstants
 {
-    public static readonly int ReportingYearMinValue = 2010;
-    public static readonly int ReportingYearMaxValue = 2050;
-
     public static readonly decimal AmountMinValue = 0m;
 
     public static readonly int AmountDigitsBeforeDecimalPoint = 11;
@@ -23,4 +20,6 @@ public static class ReportFundsExpendituresRecordConstants
 
     public static readonly string CategoryAlreadyHasRecord =
         "Record for this category already exists";
+    public static int ReportingYearMinValue => System.DateTime.UtcNow.Year - 1;
+    public static int ReportingYearMaxValue => System.DateTime.UtcNow.Year + 1;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresRecordConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresRecordConstants.cs
@@ -4,7 +4,7 @@ public static class ReportFundsExpendituresRecordConstants
 {
     public static readonly decimal AmountMinValue = 0m;
 
-    public static readonly int AmountDigitsBeforeDecimalPoint = 11;
+    public static readonly int AmountDigitsBeforeDecimalPoint = 9;
     public static readonly int AmountDigitsAfterDecimalPoint = 2;
 
     public static readonly int AmountPrecision =
@@ -20,6 +20,4 @@ public static class ReportFundsExpendituresRecordConstants
 
     public static readonly string CategoryAlreadyHasRecord =
         "Record for this category already exists";
-    public static int ReportingYearMinValue => System.DateTime.UtcNow.Year - 1;
-    public static int ReportingYearMaxValue => System.DateTime.UtcNow.Year + 1;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordValidator.cs
@@ -9,8 +9,13 @@ public class CreateReportFundsExpendituresRecordValidator
     : AbstractValidator<CreateReportFundsExpendituresRecordCommand>
 {
     public CreateReportFundsExpendituresRecordValidator(
-        BaseReportFundsExpendituresRecordValidator baseRecordValidator)
+        BaseReportFundsExpendituresRecordValidator baseRecordValidator,
+        TimeProvider timeProvider)
     {
+        var currentYear = timeProvider.GetUtcNow().Year;
+        var minReportingYear = currentYear - 1;
+        var maxReportingYear = currentYear + 1;
+
         RuleFor(command => command.CreateReportFundsExpendituresRecordDto)
             .NotNull()
             .SetValidator(baseRecordValidator);
@@ -23,14 +28,14 @@ public class CreateReportFundsExpendituresRecordValidator
                 .WithMessage(ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(ReportFundsExpendituresRecordDto.Type)));
 
             dto.RuleFor(recordDto => recordDto.ReportingYear)
-                .GreaterThanOrEqualTo(ReportFundsExpendituresRecordConstants.ReportingYearMinValue)
+                .GreaterThanOrEqualTo(minReportingYear)
                 .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN(
                     nameof(ReportFundsExpendituresRecordDto.ReportingYear),
-                    ReportFundsExpendituresRecordConstants.ReportingYearMinValue))
-                .LessThanOrEqualTo(ReportFundsExpendituresRecordConstants.ReportingYearMaxValue)
+                    minReportingYear))
+                .LessThanOrEqualTo(maxReportingYear)
                 .WithMessage(ErrorMessagesConstants.PropertyMustBeLessThanOrEqualToN(
                     nameof(ReportFundsExpendituresRecordDto.ReportingYear),
-                    ReportFundsExpendituresRecordConstants.ReportingYearMaxValue));
+                    maxReportingYear));
         });
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportFundsExpendituresRecords/ReportFundsExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportFundsExpendituresRecords/ReportFundsExpendituresRecordsRepository.cs
@@ -34,9 +34,9 @@ public class ReportFundsExpendituresRecordsRepository
             expenditureSummary.CategoriesCount);
     }
 
-    private Task<Dictionary<ReportFundsExpendituresType, TypeSummary>> BuildSummaryByTypeAsync()
+    private async Task<Dictionary<ReportFundsExpendituresType, TypeSummary>> BuildSummaryByTypeAsync()
     {
-        return DbContext.ReportFundsExpendituresRecords
+        var rawSummaries = await DbContext.ReportFundsExpendituresRecords
             .AsNoTracking()
             .GroupBy(record => record.Type)
             .Select(group => new
@@ -46,8 +46,13 @@ public class ReportFundsExpendituresRecordsRepository
                 UsdTotal = group.Sum(record => record.AmountUsd),
                 CategoriesCount = group.Select(record => record.CategoryId).Distinct().Count(),
             })
-            .ToDictionaryAsync(
-                summary => summary.Type,
-                summary => new TypeSummary(summary.UahTotal, summary.UsdTotal, summary.CategoriesCount));
+            .ToListAsync();
+
+        return rawSummaries.ToDictionary(
+            summary => summary.Type,
+            summary => new TypeSummary(
+                Math.Round(summary.UahTotal, 0, MidpointRounding.AwayFromZero),
+                Math.Round(summary.UsdTotal, 0, MidpointRounding.AwayFromZero),
+                summary.CategoriesCount));
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresRecords/GetSummary/GetReportFundsExpendituresSummaryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresRecords/GetSummary/GetReportFundsExpendituresSummaryTests.cs
@@ -39,8 +39,8 @@ public class GetReportFundsExpendituresSummaryTests : BaseTestClass
                 CategoryId = incomeCategory.Id,
                 Type = ReportFundsExpendituresType.Income,
                 ReportingYear = 2025,
-                AmountUah = 1000m,
-                AmountUsd = 20m,
+                AmountUah = 1000.45m,
+                AmountUsd = 20.49m,
                 CreatedAt = DateTimeOffset.UtcNow
             },
             new ReportFundsExpendituresRecord
@@ -48,8 +48,8 @@ public class GetReportFundsExpendituresSummaryTests : BaseTestClass
                 CategoryId = expenseCategory.Id,
                 Type = ReportFundsExpendituresType.Expense,
                 ReportingYear = 2025,
-                AmountUah = 500m,
-                AmountUsd = 10m,
+                AmountUah = 500.5m,
+                AmountUsd = 10.5m,
                 CreatedAt = DateTimeOffset.UtcNow
             });
         await Fixture.DbContext.SaveChangesAsync();
@@ -62,9 +62,13 @@ public class GetReportFundsExpendituresSummaryTests : BaseTestClass
             JsonConvert.DeserializeObject<ReportFundsExpendituresSummaryDto>(responseString);
 
         Assert.NotNull(responseContent);
+
         Assert.Equal(1000m, responseContent.IncomeUahTotal);
+
         Assert.Equal(20m, responseContent.IncomeUsdTotal);
-        Assert.Equal(500m, responseContent.ExpenditureUahTotal);
-        Assert.Equal(10m, responseContent.ExpenditureUsdTotal);
+
+        Assert.Equal(501m, responseContent.ExpenditureUahTotal);
+
+        Assert.Equal(11m, responseContent.ExpenditureUsdTotal);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordTests.cs
@@ -27,7 +27,7 @@ public class CreateReportFundsExpendituresRecordTests
     {
         CategoryId = 1,
         Type = ReportFundsExpendituresType.Income,
-        ReportingYear = ReportFundsExpendituresRecordConstants.ReportingYearMinValue,
+        ReportingYear = TimeProvider.System.GetUtcNow().Year,
         AmountUah = 100.50m,
         AmountUsd = 25.25m
     };
@@ -44,7 +44,7 @@ public class CreateReportFundsExpendituresRecordTests
         Id = 1,
         CategoryId = 1,
         Type = ReportFundsExpendituresType.Income,
-        ReportingYear = ReportFundsExpendituresRecordConstants.ReportingYearMinValue,
+        ReportingYear = TimeProvider.System.GetUtcNow().Year,
         AmountUah = 100.50m,
         AmountUsd = 25.25m
     };
@@ -54,7 +54,7 @@ public class CreateReportFundsExpendituresRecordTests
         Id = 1,
         CategoryId = 1,
         Type = ReportFundsExpendituresType.Income,
-        ReportingYear = ReportFundsExpendituresRecordConstants.ReportingYearMinValue,
+        ReportingYear = TimeProvider.System.GetUtcNow().Year,
         AmountUah = 100.50m,
         AmountUsd = 25.25m
     };
@@ -65,7 +65,9 @@ public class CreateReportFundsExpendituresRecordTests
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _recordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
         _categoriesRepositoryMock = new Mock<IReportFundsExpendituresCategoriesRepository>();
-        _validator = new CreateReportFundsExpendituresRecordValidator(new BaseReportFundsExpendituresRecordValidator());
+        _validator = new CreateReportFundsExpendituresRecordValidator(
+            new BaseReportFundsExpendituresRecordValidator(),
+            TimeProvider.System);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/GetReportFundsExpendituresSummaryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/GetReportFundsExpendituresSummaryTests.cs
@@ -25,7 +25,7 @@ public class GetReportFundsExpendituresSummaryTests
 
         _recordsRepositoryMock
             .Setup(repository => repository.GetSummaryAsync())
-            .ReturnsAsync((1000m, 250m, 4, 500m, 120m, 3));
+            .ReturnsAsync((1000m, 250m, 4, 501m, 120m, 3));
 
         var handler = new GetReportFundsExpendituresSummaryHandler(_repositoryWrapperMock.Object);
 
@@ -37,7 +37,7 @@ public class GetReportFundsExpendituresSummaryTests
         Assert.Equal(1000m, result.Value.IncomeUahTotal);
         Assert.Equal(250m, result.Value.IncomeUsdTotal);
         Assert.Equal(4, result.Value.IncomeCategoriesCount);
-        Assert.Equal(500m, result.Value.ExpenditureUahTotal);
+        Assert.Equal(501m, result.Value.ExpenditureUahTotal);
         Assert.Equal(120m, result.Value.ExpenditureUsdTotal);
         Assert.Equal(3, result.Value.ExpenditureCategoriesCount);
     }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordValidatorTests.cs
@@ -10,11 +10,15 @@ namespace VictoryCenter.UnitTests.ValidatorsTests.ReportFundsExpendituresRecords
 public class CreateReportFundsExpendituresRecordValidatorTests
 {
     private readonly CreateReportFundsExpendituresRecordValidator _validator;
+    private readonly int _currentYear;
 
     public CreateReportFundsExpendituresRecordValidatorTests()
     {
+        var timeProvider = TimeProvider.System;
+        _currentYear = timeProvider.GetUtcNow().Year;
         _validator = new CreateReportFundsExpendituresRecordValidator(
-            new BaseReportFundsExpendituresRecordValidator());
+            new BaseReportFundsExpendituresRecordValidator(),
+            timeProvider);
     }
 
     [Fact]
@@ -66,10 +70,7 @@ public class CreateReportFundsExpendituresRecordValidatorTests
     public void Validate_ShouldHaveError_WhenReportingYearIsLessThanMin()
     {
         // Arrange
-        var dto = GetValidDto() with
-        {
-            ReportingYear = ReportFundsExpendituresRecordConstants.ReportingYearMinValue - 1
-        };
+        var dto = GetValidDto() with { ReportingYear = _currentYear - 2 };
         var command = new CreateReportFundsExpendituresRecordCommand(dto);
 
         // Act
@@ -79,17 +80,14 @@ public class CreateReportFundsExpendituresRecordValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.CreateReportFundsExpendituresRecordDto.ReportingYear)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN(
                 nameof(ReportFundsExpendituresRecordDto.ReportingYear),
-                ReportFundsExpendituresRecordConstants.ReportingYearMinValue));
+                _currentYear - 1));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenReportingYearIsGreaterThanMax()
     {
         // Arrange
-        var dto = GetValidDto() with
-        {
-            ReportingYear = ReportFundsExpendituresRecordConstants.ReportingYearMaxValue + 1
-        };
+        var dto = GetValidDto() with { ReportingYear = _currentYear + 2 };
         var command = new CreateReportFundsExpendituresRecordCommand(dto);
 
         // Act
@@ -99,7 +97,7 @@ public class CreateReportFundsExpendituresRecordValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.CreateReportFundsExpendituresRecordDto.ReportingYear)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeLessThanOrEqualToN(
                 nameof(ReportFundsExpendituresRecordDto.ReportingYear),
-                ReportFundsExpendituresRecordConstants.ReportingYearMaxValue));
+                _currentYear + 1));
     }
 
     [Fact]
@@ -115,12 +113,12 @@ public class CreateReportFundsExpendituresRecordValidatorTests
         result.ShouldNotHaveAnyValidationErrors();
     }
 
-    private static CreateReportFundsExpendituresRecordDto GetValidDto() => new()
+    private CreateReportFundsExpendituresRecordDto GetValidDto() => new()
     {
         CategoryId = 1,
         AmountUah = 100.25m,
         AmountUsd = 50.50m,
         Type = ReportFundsExpendituresType.Income,
-        ReportingYear = ReportFundsExpendituresRecordConstants.ReportingYearMinValue
+        ReportingYear = _currentYear
     };
 }


### PR DESCRIPTION
dev

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2301

## Summary of issue

•	Summary totals (UAH and USD) returned from the funds and expenditures summary endpoint were not rounded
•	The ReportingYear field on funds and expenditures records had a fixed hardcoded range (2010–2050), which allowed creating records for years far in the future or distant past with no meaningful business constraint.

## Summary of change

•	BuildSummaryByTypeAsync() - materialized DB group results into memory and applied Math.Round(..., 0, MidpointRounding.AwayFromZero) to UahTotal and UsdTotal, rounding to the nearest integer using standard mathematical rules (e.g. 213.5 → 214, 1234.45 → 1234).
•	ReportFundsExpendituresRecordConstants - replaced ReportingYearMinValue and ReportingYearMaxValue static readonly fields (hardcoded 2010/2050) with computed properties ReportingYearFrom and ReportingYearTo that return DateTime.UtcNow.Year - 1 and DateTime.UtcNow.Year + 1 respectively, creating a 3-year sliding window (previous, current, next year).

## Testing approach

•	GetReportFundsExpendituresSummaryTests - updated mocked GetSummaryAsync() return values to reflect integer-rounded totals.
•	GetReportFundsExpendituresSummaryTests - updated seeded record amounts to include fractional values (for exmaple 1000.45, 500.5) and updated assertions to expect integer-rounded results (e.g. 1000, 501, 11), verifying end-to-end rounding behavior through the API.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reporting year bounds to dynamically reflect the current year (previous year through next year) instead of using fixed ranges.
  * Modified financial totals to round to whole numbers using standard rounding rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->