### PR TITLE
Feature/issue-1380: Implement updating pdf file name

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfReports.Update;
+
+public record UpdatePdfReportCommand(long Id, string Name)
+    : IRequest<Result<PdfReportDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
@@ -30,31 +30,31 @@ public class UpdatePdfReportHandler : IRequestHandler<UpdatePdfReportCommand, Re
     }
 
     public async Task<Result<PdfReportDto>> Handle(
-        UpdatePdfReportCommand request,
-        CancellationToken cancellationToken)
+    UpdatePdfReportCommand request,
+    CancellationToken cancellationToken)
     {
         try
         {
-            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var normalizedRequest = request with { Name = NormalizeText(request.Name) };
+            await _validator.ValidateAndThrowAsync(normalizedRequest, cancellationToken);
 
             var pdfReport = await _repositoryWrapper.PdfReportRepository.GetFirstOrDefaultAsync(
                 new QueryOptions<PdfReport>
                 {
-                    Filter = pr => pr.Id == request.Id,
+                    Filter = pr => pr.Id == normalizedRequest.Id,
                     AsNoTracking = false
                 });
 
             if (pdfReport == null)
             {
-                return Result.Fail<PdfReportDto>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
+                return Result.Fail<PdfReportDto>(ErrorMessagesConstants.NotFound(normalizedRequest.Id, typeof(PdfReport)));
             }
 
-            var normalizedName = NormalizeText(request.Name);
-            var hasChanges = pdfReport.Name != normalizedName;
+            var hasChanges = pdfReport.Name != normalizedRequest.Name;
 
             if (hasChanges)
             {
-                pdfReport.Name = normalizedName;
+                pdfReport.Name = normalizedRequest.Name;
 
                 if (await _repositoryWrapper.SaveChangesAsync() <= 0)
                 {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.PdfReports.Update;
+
+public class UpdatePdfReportHandler : IRequestHandler<UpdatePdfReportCommand, Result<PdfReportDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<UpdatePdfReportCommand> _validator;
+    private readonly IMapper _mapper;
+    private static readonly Regex MultipleSpaces = new(@" {2,}", RegexOptions.Compiled);
+
+    public UpdatePdfReportHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IValidator<UpdatePdfReportCommand> validator,
+        IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<PdfReportDto>> Handle(
+        UpdatePdfReportCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var pdfReport = await _repositoryWrapper.PdfReportRepository.GetFirstOrDefaultAsync(
+                new QueryOptions<PdfReport>
+                {
+                    Filter = pr => pr.Id == request.Id,
+                    AsNoTracking = false
+                });
+
+            if (pdfReport == null)
+            {
+                return Result.Fail<PdfReportDto>(ErrorMessagesConstants.NotFound(request.Id, typeof(PdfReport)));
+            }
+
+            var normalizedName = NormalizeText(request.Name);
+            var hasChanges = pdfReport.Name != normalizedName;
+
+            if (hasChanges)
+            {
+                pdfReport.Name = normalizedName;
+
+                if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+                {
+                    return Result.Fail<PdfReportDto>(
+                        ErrorMessagesConstants.FailedToUpdateEntity(typeof(PdfReport)));
+                }
+            }
+
+            var dto = _mapper.Map<PdfReportDto>(pdfReport);
+            return Result.Ok(dto);
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<PdfReportDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<PdfReportDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(PdfReport)));
+        }
+    }
+
+    private static string NormalizeText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        return MultipleSpaces.Replace(text.Trim(), " ");
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
@@ -17,7 +17,7 @@ public class UpdatePdfReportHandler : IRequestHandler<UpdatePdfReportCommand, Re
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<UpdatePdfReportCommand> _validator;
     private readonly IMapper _mapper;
-    private static readonly Regex MultipleSpaces = new(@" {2,}", RegexOptions.Compiled);
+    private static readonly Regex MultipleSpaces = new(@" {2,}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     public UpdatePdfReportHandler(
         IRepositoryWrapper repositoryWrapper,

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Update/UpdatePdfReportHandler.cs
@@ -17,7 +17,7 @@ public class UpdatePdfReportHandler : IRequestHandler<UpdatePdfReportCommand, Re
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<UpdatePdfReportCommand> _validator;
     private readonly IMapper _mapper;
-    private static readonly Regex MultipleSpaces = new(@" {2,}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+    private static readonly Regex ExcessiveWhitespace = new(@"\s+", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     public UpdatePdfReportHandler(
         IRepositoryWrapper repositoryWrapper,
@@ -84,6 +84,6 @@ public class UpdatePdfReportHandler : IRequestHandler<UpdatePdfReportCommand, Re
             return string.Empty;
         }
 
-        return MultipleSpaces.Replace(text.Trim(), " ");
+        return ExcessiveWhitespace.Replace(text.Trim(), " ");
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/PdfReportConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/PdfReportConstants.cs
@@ -24,4 +24,10 @@ public static class PdfReportConstants
     public static readonly string FailedToSavePdf = "Failed to save PDF file";
     public static readonly string FailedToReadPdf = "Failed to read PDF file";
     public static readonly string FailedToDeletePdf = "Failed to delete PDF file";
+
+    public static readonly int NameMinLength = 2;
+    public static readonly int NameMaxLength = 50;
+    public static readonly string NameMinLengthErrorMessage = "Не менше 2 символів";
+    public static readonly string NameMaxLengthErrorMessage = "Не більше 50 символів";
+    public static readonly string NameRequiredErrorMessage = "Поле обов'язкове";
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/UpdatePdfReportRequestDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/UpdatePdfReportRequestDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.PdfReports;
+
+public record UpdatePdfReportRequestDto
+{
+    public required string Name { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/UpdatePdfReportValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/UpdatePdfReportValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Update;
+using VictoryCenter.BLL.Constants;
+
+namespace VictoryCenter.BLL.Validators.PdfReports;
+
+public class UpdatePdfReportValidator : AbstractValidator<UpdatePdfReportCommand>
+{
+    public UpdatePdfReportValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan(nameof(UpdatePdfReportCommand.Id), 0));
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage(PdfReportConstants.NameRequiredErrorMessage)
+            .MinimumLength(PdfReportConstants.NameMinLength)
+            .WithMessage(PdfReportConstants.NameMinLengthErrorMessage)
+            .MaximumLength(PdfReportConstants.NameMaxLength)
+            .WithMessage(PdfReportConstants.NameMaxLengthErrorMessage);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Update/UpdatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Update/UpdatePdfReportTests.cs
@@ -1,0 +1,246 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.Update;
+
+public class UpdatePdfReportTests : BaseTestClass
+{
+    public UpdatePdfReportTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_ValidRequest_ShouldUpdateNameAndReturnDto()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("original-name.pdf");
+        var newName = "Updated Report Name";
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = newName });
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfReportDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(result);
+        Assert.Equal(newName, result.Name);
+        Assert.Equal(created.Id, result.Id);
+
+        var dbRecord = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.Id == created.Id);
+        Assert.NotNull(dbRecord);
+        Assert.Equal(newName, dbRecord.Name);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_SameName_ShouldReturnDtoWithoutChanges()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("same-name.pdf");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = created.Name });
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfReportDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(result);
+        Assert.Equal(created.Name, result.Name);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_NameWithLeadingAndTrailingSpaces_ShouldTrimAndSave()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("trim-test.pdf");
+        var nameWithSpaces = "  Trimmed Name  ";
+        var expectedName = "Trimmed Name";
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = nameWithSpaces });
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfReportDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(result);
+        Assert.Equal(expectedName, result.Name);
+
+        var dbRecord = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.Id == created.Id);
+        Assert.NotNull(dbRecord);
+        Assert.Equal(expectedName, dbRecord.Name);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_NameWithMultipleSpaces_ShouldNormalizeAndSave()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("spaces-test.pdf");
+        var nameWithMultipleSpaces = "Report   With    Multiple    Spaces";
+        var expectedName = "Report With Multiple Spaces";
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = nameWithMultipleSpaces });
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PdfReportDto>(responseString, JsonOptions);
+
+        // Assert
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.NotNull(result);
+        Assert.Equal(expectedName, result.Name);
+
+        var dbRecord = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.Id == created.Id);
+        Assert.NotNull(dbRecord);
+        Assert.Equal(expectedName, dbRecord.Name);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_NotExistingId_ShouldReturnNotFound()
+    {
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            "api/PdfReports/999999",
+            new UpdatePdfReportRequestDto { Name = "Some Name" });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_EmptyName_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("empty-name-test.pdf");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = "" });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_WhitespaceOnlyName_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("whitespace-test.pdf");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = "   " });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var dbRecord = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.Id == created.Id);
+        Assert.NotNull(dbRecord);
+        Assert.NotEqual(string.Empty, dbRecord.Name);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_NameTooShort_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("short-name-test.pdf");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = "A" });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_NameTooShortAfterNormalization_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("short-after-norm-test.pdf");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = "A  " });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var dbRecord = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.Id == created.Id);
+        Assert.NotNull(dbRecord);
+        Assert.NotEqual("A", dbRecord.Name);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_NameTooLong_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var created = await CreatePdfReportAsync("long-name-test.pdf");
+        var tooLongName = new string('a', PdfReportConstants.NameMaxLength + 1);
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"api/PdfReports/{created.Id}",
+            new UpdatePdfReportRequestDto { Name = tooLongName });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePdfReport_InvalidId_ShouldReturnBadRequest()
+    {
+        // Act
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            "api/PdfReports/-1",
+            new UpdatePdfReportRequestDto { Name = "Valid Name" });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private async Task<PdfReportDto> CreatePdfReportAsync(string fileName = "test-report.pdf")
+    {
+        using var form = CreatePdfFormData(fileName: fileName);
+        var response = await Fixture.HttpClient.PostAsync("api/PdfReports", form);
+        response.EnsureSuccessStatusCode();
+        var responseString = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<PdfReportDto>(responseString, JsonOptions)!;
+    }
+
+    private static MultipartFormDataContent CreatePdfFormData(
+        byte[] content = null!,
+        string fileName = "test-report.pdf",
+        string contentType = "application/pdf")
+    {
+        var pdfContent = content ?? new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34 };
+        var form = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(pdfContent);
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+        form.Add(fileContent, "File", fileName);
+        return form;
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/UpdatePdfReportHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/UpdatePdfReportHandlerTests.cs
@@ -1,0 +1,435 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Validators.PdfReports;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
+
+public class UpdatePdfReportHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly IValidator<UpdatePdfReportCommand> _validator;
+    private readonly PdfReport _testPdfReport;
+    private readonly PdfReportDto _testPdfReportDto;
+
+    public UpdatePdfReportHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+        _validator = new UpdatePdfReportValidator();
+
+        _testPdfReport = new PdfReport
+        {
+            Id = 1,
+            Name = "Old Report Name",
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _testPdfReportDto = new PdfReportDto
+        {
+            Id = 1,
+            Name = "Old Report Name",
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_WithNameChange_ShouldUpdateAndReturnDto()
+    {
+        // Arrange
+        var newName = "New Report Name";
+        var command = new UpdatePdfReportCommand(1, newName);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var updatedDto = new PdfReportDto
+        {
+            Id = 1,
+            Name = newName,
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _mockMapper
+            .Setup(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()))
+            .Returns(updatedDto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(newName, result.Value.Name);
+        Assert.Equal(1, result.Value.Id);
+
+        _mockRepositoryWrapper.Verify(
+            x => x.SaveChangesAsync(),
+            Times.Once);
+        _mockMapper.Verify(
+            x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_NoNameChange_ShouldNotSaveAndReturnDto()
+    {
+        // Arrange
+        var command = new UpdatePdfReportCommand(1, _testPdfReport.Name);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockMapper
+            .Setup(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()))
+            .Returns(_testPdfReportDto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_testPdfReport.Name, result.Value.Name);
+
+        _mockRepositoryWrapper.Verify(
+            x => x.SaveChangesAsync(),
+            Times.Never);
+        _mockMapper.Verify(
+            x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_WithMultipleSpaces_ShouldNormalizeAndUpdate()
+    {
+        // Arrange
+        var nameWithMultipleSpaces = "Report   With    Multiple    Spaces";
+        var normalizedName = "Report With Multiple Spaces";
+        var command = new UpdatePdfReportCommand(1, nameWithMultipleSpaces);
+
+        var testReport = new PdfReport
+        {
+            Id = 1,
+            Name = "Old Name",
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(testReport);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var updatedDto = new PdfReportDto
+        {
+            Id = 1,
+            Name = normalizedName,
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _mockMapper
+            .Setup(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()))
+            .Returns(updatedDto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(normalizedName, result.Value.Name);
+        Assert.DoesNotContain("   ", result.Value.Name);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_WithWhitespace_ShouldTrimAndUpdate()
+    {
+        // Arrange
+        var nameWithWhitespace = "  Report Name  ";
+        var trimmedName = "Report Name";
+        var command = new UpdatePdfReportCommand(1, nameWithWhitespace);
+
+        var testReport = new PdfReport
+        {
+            Id = 1,
+            Name = "Old Name",
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(testReport);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var updatedDto = new PdfReportDto
+        {
+            Id = 1,
+            Name = trimmedName,
+            BlobName = "blob-name-123.pdf",
+            FileSizeBytes = 1024000,
+            Priority = 1,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        _mockMapper
+            .Setup(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()))
+            .Returns(updatedDto);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(trimmedName, result.Value.Name);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceOnlyName_ReturnsValidationError()
+    {
+        var command = new UpdatePdfReportCommand(1, "   ");
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            PdfReportConstants.NameRequiredErrorMessage,
+            result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ReportNotFound_ReturnsFailResult()
+    {
+        // Arrange
+        var command = new UpdatePdfReportCommand(999, "New Name");
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync((PdfReport?)null);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(999, typeof(PdfReport)),
+            result.Errors.Select(e => e.Message));
+
+        _mockRepositoryWrapper.Verify(
+            x => x.SaveChangesAsync(),
+            Times.Never);
+        _mockMapper.Verify(
+            x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesReturnsZero_ReturnsFailResult()
+    {
+        // Arrange
+        var newName = "New Report Name";
+        var command = new UpdatePdfReportCommand(1, newName);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(0);
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(PdfReport)),
+            result.Errors.Select(e => e.Message));
+
+        _mockRepositoryWrapper.Verify(
+            x => x.SaveChangesAsync(),
+            Times.Once);
+        _mockMapper.Verify(
+            x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DbUpdateException_ReturnsFailResult()
+    {
+        // Arrange
+        var newName = "New Report Name";
+        var command = new UpdatePdfReportCommand(1, newName);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReport);
+
+        _mockRepositoryWrapper
+            .Setup(x => x.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(PdfReport)),
+            result.Errors.Select(e => e.Message));
+
+        _mockMapper.Verify(
+            x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidId_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new UpdatePdfReportCommand(-1, "New Name");
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyName_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new UpdatePdfReportCommand(1, "");
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NameTooShort_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new UpdatePdfReportCommand(1, "A");
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NameTooShortAfterNormalization_ReturnsValidationError()
+    {
+        // Arrange
+        var command = new UpdatePdfReportCommand(1, " A  ");
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            PdfReportConstants.NameMinLengthErrorMessage,
+            result.Errors.Select(e => e.Message));
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NameTooLongAfterNormalization_ReturnsValidationError()
+    {
+        // Arrange
+        var longName = new string('a', PdfReportConstants.NameMaxLength + 1);
+        var command = new UpdatePdfReportCommand(1, longName);
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(
+            PdfReportConstants.NameMaxLengthErrorMessage,
+            result.Errors.Select(e => e.Message));
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfReport>>()),
+            Times.Never);
+    }
+
+    private UpdatePdfReportHandler CreateHandler() =>
+        new(_mockRepositoryWrapper.Object, _validator, _mockMapper.Object);
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
+using VictoryCenter.BLL.Commands.Admin.PdfReports.Update;
 using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.DTOs.Common;
@@ -41,6 +42,15 @@ public class PdfReportsController : AuthorizedApiController
         }
 
         return File(result.Value, "application/pdf", fileDownloadName: null);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(PdfReportDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdatePdfReport(long id, [FromBody] UpdatePdfReportRequestDto request)
+    {
+        return HandleResult(await Mediator.Send(new UpdatePdfReportCommand(id, request.Name)));
     }
 
     [HttpDelete("{id}")]


### PR DESCRIPTION
## GitHub ticket

* [Ticket 1380](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1380)

## Summary of issue

Admins had no way to rename the display name of an uploaded PDF file after it was uploaded.

## Summary of change

Implemented the UpdatePdfReport endpoint (PUT /api/admin/pdf-reports/{id}) that allows admins to rename the display name of an uploaded PDF file. The handler validates the new name (2–50 characters, required), normalizes it (trims leading/trailing spaces, collapses consecutive spaces into one), and persists the change only if the name actually differs from the current value.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now update PDF report names via a new update endpoint.
  * Added validation for PDF report names to ensure they contain 2-50 characters and are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->