### PR TITLE
Feature/issue-1838: [Reports] Add bulk-delete for Report Funds/Expenditures records

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
+
+public record BulkDeleteReportFundsExpendituresRecordCommand(IEnumerable<long> Ids)
+    : IRequest<Result<long[]>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommandHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommandHandler.cs
@@ -1,0 +1,75 @@
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
+
+public class BulkDeleteReportFundsExpendituresRecordCommandHandler
+    : IRequestHandler<BulkDeleteReportFundsExpendituresRecordCommand, Result<long[]>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<BulkDeleteReportFundsExpendituresRecordCommand> _validator;
+
+    public BulkDeleteReportFundsExpendituresRecordCommandHandler(
+        IValidator<BulkDeleteReportFundsExpendituresRecordCommand> validator, IRepositoryWrapper repositoryWrapper)
+    {
+        _validator = validator;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<long[]>> Handle(
+        BulkDeleteReportFundsExpendituresRecordCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var entitiesToDelete = (await _repositoryWrapper
+                .ReportFundsExpendituresRecordsRepository
+                .GetAllAsync(new QueryOptions<ReportFundsExpendituresRecord>
+                {
+                    Filter = record => request.Ids.Contains(record.Id)
+                })).ToList();
+
+            var existingRecordIds = entitiesToDelete.Select(e => e.Id);
+
+            var nonExistingRecordIds = request.Ids.Except(existingRecordIds).ToList();
+
+            if (nonExistingRecordIds.Any())
+            {
+                return Result.Fail(ErrorMessagesConstants.NotFound(
+                    nonExistingRecordIds,
+                    typeof(ReportFundsExpendituresRecord)));
+            }
+
+            _repositoryWrapper
+                .ReportFundsExpendituresRecordsRepository
+                .DeleteRange(entitiesToDelete);
+
+            if (await _repositoryWrapper.SaveChangesAsync() == 0)
+            {
+                return Result.Fail(
+                    ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportFundsExpendituresRecord)));
+            }
+
+            return Result.Ok(request.Ids.ToArray());
+        }
+        catch (ValidationException validationException)
+        {
+            return Result.Fail(
+                validationException.Errors.Select(error => error.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail(
+                ErrorMessagesConstants.FailedToDeleteEntitiesInDatabase(
+                    typeof(ReportFundsExpendituresRecord)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresRecordConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresRecordConstants.cs
@@ -23,4 +23,6 @@ public static class ReportFundsExpendituresRecordConstants
 
     public static readonly string CategoryAlreadyHasRecord =
         "Record for this category already exists";
+
+    public static readonly int MaxNumberOfRecordsPerBulkDelete = 100;
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordCommandValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Validators.ReportFundsExpendituresRecords;
+
+public class BulkDeleteReportFundsExpendituresRecordCommandValidator
+    : AbstractValidator<BulkDeleteReportFundsExpendituresRecordCommand>
+{
+    public BulkDeleteReportFundsExpendituresRecordCommandValidator()
+    {
+        RuleForEach(e => e.Ids)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(ReportFundsExpendituresRecord.Id)));
+
+        RuleFor(e => e.Ids)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(BulkDeleteReportFundsExpendituresRecordCommand.Ids)))
+            .Must(e => e.Count() <= ReportFundsExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete)
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(BulkDeleteReportFundsExpendituresRecordCommand.Ids),
+                ReportFundsExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete))
+            .Must(e => e.Distinct().Count() == e.Count())
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(BulkDeleteReportFundsExpendituresRecordCommand.Ids)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.ReportFundsExpendituresRecords.BulkDelete;
+
+public class BulkDeleteReportFundsExpendituresRecordTests : BaseTestClass
+{
+    public BulkDeleteReportFundsExpendituresRecordTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task BulkDelete_ShouldDeleteRecords()
+    {
+        var category = new ReportFundsExpendituresCategory
+        {
+            Name = "Category",
+            Type = VictoryCenter.DAL.Enums.ReportFundsExpendituresType.Income,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var category2 = new ReportFundsExpendituresCategory
+        {
+            Name = "Category2",
+            Type = VictoryCenter.DAL.Enums.ReportFundsExpendituresType.Expense,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.ReportFundsExpendituresCategories.AddRangeAsync(category, category2);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var record1 = new ReportFundsExpendituresRecord
+        {
+            CategoryId = category.Id,
+            Type = VictoryCenter.DAL.Enums.ReportFundsExpendituresType.Income,
+            ReportingYear = 2025,
+            AmountUah = 300m,
+            AmountUsd = 6m,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var record2 = new ReportFundsExpendituresRecord
+        {
+            CategoryId = category2.Id,
+            Type = VictoryCenter.DAL.Enums.ReportFundsExpendituresType.Expense,
+            ReportingYear = 2026,
+            AmountUah = 400m,
+            AmountUsd = 8m,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.ReportFundsExpendituresRecords.AddRangeAsync(record1, record2);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var idsToDelete = new List<long> { record1.Id, record2.Id };
+        var response = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/ReportFundsExpendituresRecords/bulk-delete", idsToDelete);
+        response.EnsureSuccessStatusCode();
+
+        var remainingRecords = await Fixture.DbContext.ReportFundsExpendituresRecords
+            .Where(entity => idsToDelete.Contains(entity.Id))
+            .ToListAsync();
+
+        Assert.Empty(remainingRecords);
+    }
+
+    [Theory]
+    [InlineData(1111, 22222)]
+    [InlineData(2131231, 3424324)]
+    public async Task BulkDelete_ShouldNotDeleteRecords_NotFound(long id1, long id2)
+    {
+        var idsToDelete = new List<long> { id1, id2 };
+
+        var response = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/ReportFundsExpendituresRecords/bulk-delete", idsToDelete);
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordTests.cs
@@ -1,0 +1,220 @@
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Validators.ReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpendituresRecords;
+
+public class BulkDeleteReportFundsExpendituresRecordTests
+{
+    private readonly Mock<IReportFundsExpendituresRecordsRepository> _recordsRepositoryMock;
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly IValidator<BulkDeleteReportFundsExpendituresRecordCommand> _validator;
+
+    public BulkDeleteReportFundsExpendituresRecordTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _recordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
+        _validator = new BulkDeleteReportFundsExpendituresRecordCommandValidator();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteRecords()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var entities = ids.Select(id => new ReportFundsExpendituresRecord { Id = id }).ToList();
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(ids);
+        SetupDependencies(entities, 1);
+
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(ids, result.Value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Handle_ShouldFail_WhenIdIsInvalid(long invalidId)
+    {
+        // Arrange
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(new[] { invalidId });
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.PropertyMustBePositive(nameof(ReportFundsExpendituresRecord.Id)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenIdsAreNotUnique()
+    {
+        // Arrange
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(new[] { 1L, 1L });
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.CollectionMustContainUniqueValues(
+                nameof(BulkDeleteReportFundsExpendituresRecordCommand.Ids)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenIdsAreEmpty()
+    {
+        // Arrange
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(Array.Empty<long>());
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(BulkDeleteReportFundsExpendituresRecordCommand.Ids)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenIdsExceedMaximumCount()
+    {
+        // Arrange
+        var maxCount = ReportFundsExpendituresRecordConstants.MaxNumberOfRecordsPerBulkDelete;
+        var ids = Enumerable.Range(1, maxCount + 1).Select(i => (long)i).ToArray();
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(ids);
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.CollectionCannotContainMoreThan(
+                nameof(BulkDeleteReportFundsExpendituresRecordCommand.Ids), maxCount),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenEntitiesNotFound()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var existingIds = new List<long> { 1, 2 };
+        var entities = existingIds.Select(id => new ReportFundsExpendituresRecord { Id = id }).ToList();
+        var nonExistingIds = new List<long> { 3 };
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(ids);
+        SetupDependencies(entities, 0);
+
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(nonExistingIds, typeof(ReportFundsExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenSaveChangesFails()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var entities = ids.Select(id => new ReportFundsExpendituresRecord { Id = id }).ToList();
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(ids);
+        SetupDependencies(entities, 0);
+
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportFundsExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        var ids = new long[] { 1, 2, 3 };
+        var entities = ids.Select(id => new ReportFundsExpendituresRecord { Id = id }).ToList();
+        var command = new BulkDeleteReportFundsExpendituresRecordCommand(ids);
+
+        _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportFundsExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+
+        _recordsRepositoryMock.Setup(repository =>
+                repository.GetAllAsync(It.IsAny<QueryOptions<ReportFundsExpendituresRecord>>() ))
+            .ReturnsAsync(entities);
+
+        _recordsRepositoryMock.Setup(repository =>
+            repository.DeleteRange(It.IsAny<IEnumerable<ReportFundsExpendituresRecord>>()));
+
+        _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
+            _validator, _repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntitiesInDatabase(typeof(ReportFundsExpendituresRecord)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies(IEnumerable<ReportFundsExpendituresRecord> returnedEntities, int saveResult)
+    {
+        _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportFundsExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+
+        _recordsRepositoryMock.Setup(repository =>
+                repository.GetAllAsync(It.IsAny<QueryOptions<ReportFundsExpendituresRecord>>() ))
+            .ReturnsAsync(returnedEntities);
+
+        _recordsRepositoryMock.Setup(repository =>
+            repository.DeleteRange(It.IsAny<IEnumerable<ReportFundsExpendituresRecord>>()));
+
+        _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportFundsExpendituresRecordsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportFundsExpendituresRecordsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Create;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Delete;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Update;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresRecords;
 using VictoryCenter.BLL.Queries.Admin.ReportFundsExpendituresRecords.GetAll;
 using VictoryCenter.BLL.Queries.Admin.ReportFundsExpendituresRecords.GetSummary;
@@ -46,6 +47,15 @@ public class ReportFundsExpendituresRecordsController : AuthorizedApiController
     {
         return HandleResult(await Mediator.Send(
             new UpdateReportFundsExpendituresRecordCommand(updateReportFundsExpendituresRecordDto, id)));
+    }
+
+    [HttpPost("bulk-delete")]
+    [ProducesResponseType(typeof(long[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> BulkDeleteReportFundsExpendituresRecords([FromBody] IEnumerable<long> ids)
+    {
+        return HandleResult(await Mediator.Send(new BulkDeleteReportFundsExpendituresRecordCommand(ids)));
     }
 
     [HttpDelete("{id:long}")]


### PR DESCRIPTION
## GitHub Ticket
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1838

## Summary of issue

Admins need ability to delete multiple Report Funds/Expenditures records in a single action (bulk delete).

## Summary of change

•	Added BulkDeleteReportFundsExpendituresRecordCommand and handler to perform bulk deletion.
•	Added FluentValidation validator BulkDeleteReportFundsExpendituresRecordCommandValidator.
•	Added MaxNumberOfRecordsPerBulkDelete constant to ReportFundsExpendituresRecordConstants.
•	Exposed POST /api/ReportFundsExpendituresRecords/bulk-delete endpoint in ReportFundsExpendituresRecordsController.
•	Implemented deletion logic consistent with existing bulk-delete pattern used for program expenditures (checks for missing ids, deletes entities, handles DB errors).
Tests:
•	Unit tests for command handler covering success and all validation/error scenarios.
•	Integration tests for controller endpoint covering success and NotFound scenarios.

## Testing approach

Build succeeded locally after changes; run unit and integration tests to confirm.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk delete functionality for report funds expenditure records, supporting up to 100 records per operation. Includes validation to confirm all IDs are positive and unique, with verification that all requested records exist before deletion. Provides detailed error responses for validation failures and missing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->