### PR TITLE
Feature/issue-1327: Implement translation status for PDF Section

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
@@ -4,6 +4,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.PdfSection;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -44,7 +45,8 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
             var pdfSection = await _repositoryWrapper.PdfSectionRepository.GetFirstOrDefaultAsync(
                 new QueryOptions<DAL.Entities.PdfSection>
                 {
-                    AsNoTracking = false
+                    AsNoTracking = false,
+                    Include = ps => ps.Include(ps => ps.Localizations)
                 });
 
             if (pdfSection == null)
@@ -60,6 +62,8 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
             {
                 pdfSection.Title = normalizedTitle;
                 pdfSection.Description = normalizedDescription;
+
+                SetLocalizationsToOutdated(pdfSection);
 
                 if (await _repositoryWrapper.SaveChangesAsync() <= 0)
                 {
@@ -101,5 +105,13 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
         }
 
         return trimmed;
+    }
+
+    private static void SetLocalizationsToOutdated(DAL.Entities.PdfSection pdfSection)
+    {
+        foreach (var loc in pdfSection.Localizations)
+        {
+            loc.TranslationStatus = TranslationStatus.Outdated;
+        }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfSection/Update/UpdatePdfSectionHandler.cs
@@ -109,6 +109,11 @@ public class UpdatePdfSectionHandler : IRequestHandler<UpdatePdfSectionCommand, 
 
     private static void SetLocalizationsToOutdated(DAL.Entities.PdfSection pdfSection)
     {
+        if (pdfSection.Localizations == null)
+        {
+            return;
+        }
+
         foreach (var loc in pdfSection.Localizations)
         {
             loc.TranslationStatus = TranslationStatus.Outdated;

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfSection/PdfSectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfSection/PdfSectionDto.cs
@@ -1,7 +1,10 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.PdfSection;
+
 namespace VictoryCenter.BLL.DTOs.Admin.PdfSection;
 
 public class PdfSectionDto
 {
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    public IEnumerable<PdfSectionLocalizationDto> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionHandler.cs
@@ -1,6 +1,8 @@
 using FluentResults;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.PdfSection;
 using VictoryCenter.BLL.DTOs.Admin.PdfSection;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -23,7 +25,11 @@ public class GetPdfSectionHandler
         CancellationToken cancellationToken)
     {
         var section = await _repositoryWrapper.PdfSectionRepository.GetFirstOrDefaultAsync(
-            new QueryOptions<PdfSectionEntity> { AsNoTracking = true });
+            new QueryOptions<PdfSectionEntity>
+            {
+                AsNoTracking = true,
+                Include = ps => ps.Include(ps => ps.Localizations).ThenInclude(l => l.Language)
+            });
 
         if (section == null)
         {
@@ -34,6 +40,13 @@ public class GetPdfSectionHandler
         {
             Title = section.Title,
             Description = section.Description,
+            Localizations = section.Localizations.Select(l => new PdfSectionLocalizationDto
+            {
+                LanguageId = l.LanguageId,
+                Title = l.Title,
+                Description = l.Description,
+                TranslationStatus = l.TranslationStatus,
+            }).ToList()
         };
 
         return Result.Ok(dto);

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfSection/Get/GetPdfSectionHandler.cs
@@ -40,13 +40,13 @@ public class GetPdfSectionHandler
         {
             Title = section.Title,
             Description = section.Description,
-            Localizations = section.Localizations.Select(l => new PdfSectionLocalizationDto
+            Localizations = [.. section.Localizations.Select(l => new PdfSectionLocalizationDto
             {
                 LanguageId = l.LanguageId,
                 Title = l.Title,
                 Description = l.Description,
                 TranslationStatus = l.TranslationStatus,
-            }).ToList()
+            })]
         };
 
         return Result.Ok(dto);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSection/GetPdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSection/GetPdfSectionHandlerTests.cs
@@ -78,4 +78,72 @@ public class GetPdfSectionHandlerTests
         Assert.Equal(_pdfSection.Title, result.Value.Title);
         Assert.Equal(_pdfSection.Description, result.Value.Description);
     }
+
+    [Fact]
+    public async Task Handle_SectionWithLocalizations_ReturnsDtoWithLocalizations()
+    {
+        // Arrange
+        var sectionWithLocalizations = new PdfSection
+        {
+            Id = 1,
+            Title = "Тестова секція",
+            Description = "Опис тестової секції",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Localizations =
+            [
+                new()
+            {
+                LanguageId = 1,
+                Title = "Test section",
+                Description = "Test description",
+                TranslationStatus = DAL.Enums.TranslationStatus.Relevant,
+                Language = new() { Id = 1, Code = "en", Name = "English" }
+            },
+            ]
+        };
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(sectionWithLocalizations);
+
+        var handler = new GetPdfSectionHandler(_mockRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new GetPdfSectionQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Localizations);
+        Assert.Single(result.Value.Localizations);
+        var loc = result.Value.Localizations.First();
+        Assert.Equal(1, loc.LanguageId);
+        Assert.Equal("Test section", loc.Title);
+        Assert.Equal("Test description", loc.Description);
+    }
+
+    [Fact]
+    public async Task Handle_SectionWithNoLocalizations_ReturnsDtoWithEmptyLocalizations()
+    {
+        // Arrange
+        var sectionWithNoLocalizations = new PdfSection
+        {
+            Id = 1,
+            Title = "Тестова секція",
+            Description = "Опис тестової секції",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Localizations = []
+        };
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(sectionWithNoLocalizations);
+
+        var handler = new GetPdfSectionHandler(_mockRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new GetPdfSectionQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Localizations);
+        Assert.Empty(result.Value.Localizations);
+    }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSection/UpdatePdfSectionHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfSection/UpdatePdfSectionHandlerTests.cs
@@ -305,4 +305,73 @@ public class UpdatePdfSectionHandlerTests
         Assert.NotNull(result.Value);
         Assert.Equal(description160Chars, result.Value.Description);
     }
+
+    [Fact]
+    public async Task Handle_SectionWithNullLocalizations_DoesNotThrow()
+    {
+        // Arrange
+        var sectionWithNullLocalizations = new PdfSection
+        {
+            Id = 1,
+            Title = "Стара назва",
+            Description = "Старий опис",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Localizations = null!
+        };
+
+        var updateDto = new PdfSectionDto { Title = "Нова назва", Description = "Новий опис" };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(sectionWithNullLocalizations);
+        _mockRepo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_SectionWithLocalizations_SetsAllLocalizationsToOutdated()
+    {
+        // Arrange
+        var sectionWithLocalizations = new PdfSection
+        {
+            Id = 1,
+            Title = "Стара назва",
+            Description = "Старий опис",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Localizations =
+            [
+                new() { TranslationStatus = DAL.Enums.TranslationStatus.Relevant },
+            new() { TranslationStatus = DAL.Enums.TranslationStatus.Relevant },
+        ]
+        };
+
+        var updateDto = new PdfSectionDto { Title = "Нова назва", Description = "Новий опис" };
+        var command = new UpdatePdfSectionCommand(updateDto);
+
+        _mockRepo.Setup(r => r.PdfSectionRepository.CountAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(1);
+        _mockRepo.Setup(r => r.PdfSectionRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PdfSection>>()))
+                 .ReturnsAsync(sectionWithLocalizations);
+        _mockRepo.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var handler = new UpdatePdfSectionHandler(_mockRepo.Object, _validator);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.All(
+            sectionWithLocalizations.Localizations,
+            loc => Assert.Equal(DAL.Enums.TranslationStatus.Outdated, loc.TranslationStatus));
+    }
 }


### PR DESCRIPTION
## GitHub Ticket

* [Ticket 1327](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1327)

## Summary of issue

This is implementation of translation status indicators for the PDF section. It provides the localization data required by the admin panel to display accurate translation status badges.

## Summary of change

- Extended PdfSectionDto with a Localizations collection to expose translation data via the GET /PdfSection/pdf-section endpoint
- Updated GetPdfSectionHandler to eager-load localizations and their languages, and map them to PdfSectionLocalizationDto including TranslationStatus
- Updated UpdatePdfSectionHandler to eager-load localizations and set their TranslationStatus to Outdated when the base Ukrainian content is modified

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF sections now track translation status and mark associated translations as outdated when content is updated.
  * Added localization information display for PDF sections, showing translation details by language and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->