### PR TITLE
refactor/issue-1441: remove limitations of createing new categories

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryHandler.cs
@@ -36,18 +36,6 @@ public class CreateReportFundsExpendituresCategoryHandler
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var categoriesCount = await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.CountAsync(
-                new QueryOptions<ReportFundsExpendituresCategory>
-                {
-                    Filter = category => category.Type == request.CreateReportFundsExpendituresCategoryDto.Type
-                });
-
-            if (categoriesCount >= ReportFundsExpendituresCategoryConstants.MaxCategoriesCountPerType)
-            {
-                return Result.Fail<ReportFundsExpendituresCategoryDto>(
-                    ReportFundsExpendituresCategoryConstants.CannotCreateCategoryWhenMaximumCountReached);
-            }
-
             var duplicateCategoriesCount = await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.CountAsync(
                 new QueryOptions<ReportFundsExpendituresCategory>
                 {

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
@@ -2,12 +2,8 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class ReportFundsExpendituresCategoryConstants
 {
-    public static readonly int MaxCategoriesCountPerType = 4;
     public static readonly int NameMaxLength = 255;
     public static readonly string DuplicateCategoryName = "Category with the same name already exists";
-
-    public static readonly string CannotCreateCategoryWhenMaximumCountReached =
-        $"Cannot create category because the maximum number of categories ({MaxCategoriesCountPerType}) for this type has been reached";
 
     public static readonly string CantDeleteCategoryWhileAssociatedWithAnyRecord =
         "Can't delete category while associated with any funds and expenditures record";

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
@@ -54,7 +54,7 @@ public class CreateReportFundsExpendituresCategoryTests
     public async Task Handle_ShouldCreateCategory()
     {
         // Arrange
-        SetupDependencies(categoriesCount: 0, duplicateCategoriesCount: 0, saveResult: 1);
+        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
         var handler = new CreateReportFundsExpendituresCategoryHandler(
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
@@ -95,36 +95,10 @@ public class CreateReportFundsExpendituresCategoryTests
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenMaximumCountReached()
-    {
-        // Arrange
-        SetupDependencies(
-            categoriesCount: ReportFundsExpendituresCategoryConstants.MaxCategoriesCountPerType,
-            duplicateCategoriesCount: 0,
-            saveResult: 1);
-
-        var handler = new CreateReportFundsExpendituresCategoryHandler(
-            _mapperMock.Object,
-            _repositoryWrapperMock.Object,
-            _validator);
-
-        // Act
-        var result = await handler.Handle(
-            new CreateReportFundsExpendituresCategoryCommand(_createDto),
-            CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        Assert.Equal(
-            ReportFundsExpendituresCategoryConstants.CannotCreateCategoryWhenMaximumCountReached,
-            result.Errors[0].Message);
-    }
-
-    [Fact]
     public async Task Handle_ShouldFail_WhenDuplicateCategoryExists()
     {
         // Arrange
-        SetupDependencies(categoriesCount: 0, duplicateCategoriesCount: 1, saveResult: 1);
+        SetupDependencies(duplicateCategoriesCount: 1, saveResult: 1);
 
         var handler = new CreateReportFundsExpendituresCategoryHandler(
             _mapperMock.Object,
@@ -145,7 +119,7 @@ public class CreateReportFundsExpendituresCategoryTests
     public async Task Handle_ShouldFail_WhenSaveChangesFails()
     {
         // Arrange
-        SetupDependencies(categoriesCount: 0, duplicateCategoriesCount: 0, saveResult: 0);
+        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 0);
 
         var handler = new CreateReportFundsExpendituresCategoryHandler(
             _mapperMock.Object,
@@ -168,7 +142,7 @@ public class CreateReportFundsExpendituresCategoryTests
     public async Task Handle_ShouldFail_WhenDbUpdateExceptionOccurs()
     {
         // Arrange
-        SetupDependencies(categoriesCount: 0, duplicateCategoriesCount: 0, saveResult: 1);
+        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
         _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync())
             .ThrowsAsync(new DbUpdateException());
 
@@ -189,14 +163,13 @@ public class CreateReportFundsExpendituresCategoryTests
             result.Errors[0].Message);
     }
 
-    private void SetupDependencies(int categoriesCount, int duplicateCategoriesCount, int saveResult)
+    private void SetupDependencies(int duplicateCategoriesCount, int saveResult)
     {
         _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportFundsExpendituresCategoriesRepository)
             .Returns(_categoriesRepositoryMock.Object);
 
         _categoriesRepositoryMock
-            .SetupSequence(repository => repository.CountAsync(It.IsAny<QueryOptions<ReportFundsExpendituresCategory>>()))
-            .ReturnsAsync(categoriesCount)
+            .Setup(repository => repository.CountAsync(It.IsAny<QueryOptions<ReportFundsExpendituresCategory>>()))
             .ReturnsAsync(duplicateCategoriesCount);
 
         _categoriesRepositoryMock


### PR DESCRIPTION
## GitHub Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1441


## Summary of issue

The report funds and expenditures category creation was incorrectly limited to a maximum of 4 categories per type. This constraint was not aligned with actual business requirements and prevented admins from creating additional categories beyond that hardcoded threshold

## Summary of change

Removed the max-4-categories-per-type restriction from the funds and expenditures category creation flow:
 - Deleted MaxCategoriesCountPerType and CannotCreateCategoryWhenMaximumCountReached constants from ReportFundsExpendituresCategoryConstants
 - Removed the category count check and the associated CountAsync call in CreateReportFundsExpendituresCategoryHandler 
 - Removed the Handle ShouldFail WhenMaximumCountReached unit test and simplified SetupDependencies accordingly Testing approach 
 - Existing unit tests updated and passing
 
## Testing approach

Manually verified that creating more than 4 categories of the same type now succeeds
<img width="147" height="225" alt="image" src="https://github.com/user-attachments/assets/2da63092-0ac1-42d1-ac6b-b57b778f37f6" />



## CHECK LIST
- [x]  СI passed
- [ ]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions
