### PR TITLE
Fix/issue 2099 - Added ability to localizing History

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationCommand.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.History.Create;
+
+public record CreateHistoryLocalizationCommand(CreateHistorySectionLocalizationDto CreateHistorySectionLocalizationDto)
+    : IRequest<Result<HistorySectionLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
@@ -57,7 +57,8 @@ public class CreateHistoryLocalizationHandler : IRequestHandler<CreateHistoryLoc
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
-                return Result.Fail<HistorySectionLocalizationDto>("Failed to save in Database");
+                return Result.Fail<HistorySectionLocalizationDto>(ErrorMessagesConstants.
+                FailedToCreateEntityInDatabase(typeof(HistorySectionLocalizationDto)));
             }
 
             var createdLocalizations = await _repositoryWrapper.HistorySectionContentLocalizationsRepository

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
@@ -71,7 +71,7 @@ public class CreateHistoryLocalizationHandler : IRequestHandler<CreateHistoryLoc
             var result = new HistorySectionLocalizationDto
             {
                 EntityId = section.Id,
-                Contents = _mapper.Map<List<HistorySectionContentLocalizationDto>>(contentLocalizations)
+                Contents = _mapper.Map<List<HistorySectionContentLocalizationDto>>(createdLocalizations)
             };
 
             return Result.Ok(result);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
@@ -1,0 +1,101 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.History.Create;
+
+public class CreateHistoryLocalizationHandler : IRequestHandler<CreateHistoryLocalizationCommand, Result<HistorySectionLocalizationDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<HistorySectionContent, HistorySectionContentLocalization> _contentLocalizationService;
+    private readonly IValidator<CreateHistoryLocalizationCommand> _validator;
+    public CreateHistoryLocalizationHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILocalizationService<HistorySectionContent, HistorySectionContentLocalization> contentLocalizationService, IValidator<CreateHistoryLocalizationCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _contentLocalizationService = contentLocalizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<HistorySectionLocalizationDto>> Handle(CreateHistoryLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var section = await _repositoryWrapper.HistorySectionsRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<HistorySection>
+                {
+                    Filter = x => x.Id == request.CreateHistorySectionLocalizationDto.EntityId,
+                    Include = x => x.Include(x => x.Contents)
+                });
+            if (section is null)
+            {
+                return Result.Fail<HistorySectionLocalizationDto>(ErrorMessagesConstants.NotFound(request.CreateHistorySectionLocalizationDto.EntityId, typeof(HistorySection)));
+            }
+
+            var contentTypesById = section.Contents.ToDictionary(c => c.Id, c => c.ContentType);
+
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(
+                request.CreateHistorySectionLocalizationDto.Contents,
+                contentTypesById);
+
+            var contentDtos = request.CreateHistorySectionLocalizationDto.Contents.ToList();
+            var contentLocalizations = _mapper.Map<List<HistorySectionContentLocalization>>(contentDtos);
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations, false);
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<HistorySectionLocalizationDto>("Failed to save in Database");
+            }
+
+            var createdLocalizations = await _repositoryWrapper.HistorySectionContentLocalizationsRepository
+                .GetAllAsync(new QueryOptions<HistorySectionContentLocalization>
+                {
+                    Filter = l => contentLocalizations.Select(c => c.EntityId).Contains(l.EntityId) &&
+                                  contentLocalizations.Select(c => c.LanguageId).Contains(l.LanguageId),
+                    Include = q => q.Include(l => l.Language)
+                });
+
+            var result = new HistorySectionLocalizationDto
+            {
+                EntityId = section.Id,
+                Contents = _mapper.Map<List<HistorySectionContentLocalizationDto>>(contentLocalizations)
+            };
+
+            return Result.Ok(result);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(HistorySectionLocalizationDto)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(ErrorMessagesConstants.
+                FailedToCreateEntityInDatabase(typeof(HistorySectionLocalizationDto)));
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(ex.Message);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/Localization/HistoryLocalizationConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/Localization/HistoryLocalizationConstants.cs
@@ -1,0 +1,10 @@
+namespace VictoryCenter.BLL.Constants.Localization;
+
+public class HistoryLocalizationConstants
+{
+    public static readonly int ContentTitleMinLength = 5;
+    public static readonly int ContentTitleMaxLength = 60;
+
+    public static readonly int ContentDescriptionMinLength = 10;
+    public static readonly int ContentDescriptionMaxLength = 600;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/Create/CreateHistorySectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/Create/CreateHistorySectionContentLocalizationDto.cs
@@ -1,0 +1,13 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+
+public record CreateHistorySectionContentLocalizationDto : ILocalizationIdentity, IHistoryContentLocalization
+{
+    public long EntityId { get; init; }
+
+    public long LanguageId { get; init; }
+
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/Create/CreateHistorySectionLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/Create/CreateHistorySectionLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+
+public record CreateHistorySectionLocalizationDto
+{
+    public long EntityId { get; set; }
+    public List<CreateHistorySectionContentLocalizationDto> Contents { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/Create/IHistoryContentLocalization.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/Create/IHistoryContentLocalization.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+
+public interface IHistoryContentLocalization
+{
+    long EntityId { get; }
+    string? Title { get; }
+    string? Description { get; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/HistorySectionContentLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/HistorySectionContentLocalizationDto.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.History;
+
+public record HistorySectionContentLocalizationDto
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public TranslationStatus TranslationStatus { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/HistorySectionLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/History/HistorySectionLocalizationDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.History;
+
+public record HistorySectionLocalizationDto
+{
+    public long EntityId { get; init; }
+    public ICollection<HistorySectionContentLocalizationDto> Contents { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/HistorySectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/HistorySectionContentLocalizationValidationHelper.cs
@@ -1,0 +1,96 @@
+using FluentValidation;
+using FluentValidation.Results;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Helpers;
+
+public class HistorySectionContentLocalizationValidationHelper
+{
+    public static void ValidateHistoryContents<TContent>(
+        IEnumerable<TContent> localizationContents,
+        IReadOnlyDictionary<long, ContentType> contentTypesById)
+        where TContent : IHistoryContentLocalization
+    {
+        var allowedTypes = new HashSet<ContentType> { ContentType.Title, ContentType.Description };
+
+        foreach (var content in localizationContents)
+        {
+            if (!contentTypesById.TryGetValue(content.EntityId, out var contentType))
+            {
+                throw new ValidationException(
+                [
+                    new ValidationFailure("EntityId", ErrorMessagesConstants.NotFound(content.EntityId, typeof(HistorySectionContent)))
+                ]);
+            }
+
+            if (!allowedTypes.Contains(contentType))
+            {
+                throw new ValidationException(
+                [
+                    new ValidationFailure(
+                        "ContentType",
+                        $"Content {content.EntityId} has type {contentType}, which is not allowed for history localization. Only Title and Description are allowed.")
+                ]);
+            }
+
+            ValidateContentLocalizationByType(content, contentType);
+        }
+    }
+
+    private static void ValidateContentLocalizationByType(
+        IHistoryContentLocalization content,
+        ContentType contentType)
+    {
+        var hasTitle = HasValue(content.Title);
+        var hasDescription = HasValue(content.Description);
+
+        switch (contentType)
+        {
+            case ContentType.Title:
+                RequireField(nameof(content.Title), hasTitle);
+                ForbidField(nameof(content.Description), hasDescription, contentType);
+                break;
+            case ContentType.Description:
+                RequireField(nameof(content.Description), hasDescription);
+                ForbidField(nameof(content.Title), hasTitle, contentType);
+                break;
+            default:
+                throw new ValidationException(
+                [
+                    new ValidationFailure(
+                        nameof(contentType),
+                        ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(contentType)))
+                ]);
+        }
+    }
+
+    private static void RequireField(string fieldName, bool hasValue)
+    {
+        if (!hasValue)
+        {
+            throw new ValidationException(
+            [
+                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyIsRequired(fieldName))
+            ]);
+        }
+    }
+
+    private static void ForbidField(string fieldName, bool hasValue, ContentType contentType)
+    {
+        if (hasValue)
+        {
+            throw new ValidationException(
+            [
+                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyNotAllowedForContentType(fieldName, contentType))
+            ]);
+        }
+    }
+
+    private static bool HasValue(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/HistorySectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/HistorySectionContentLocalizationValidationHelper.cs
@@ -36,26 +36,26 @@ public class HistorySectionContentLocalizationValidationHelper
                 ]);
             }
 
-            ValidateContentLocalizationByType(content, contentType);
+            ValidateContentLocalizationByTypes(content, contentType);
         }
     }
 
-    private static void ValidateContentLocalizationByType(
+    private static void ValidateContentLocalizationByTypes(
         IHistoryContentLocalization content,
         ContentType contentType)
     {
-        var hasTitle = HasValue(content.Title);
-        var hasDescription = HasValue(content.Description);
+        var hasTitle = ProgramSectionContentLocalizationValidationHelper.HasValue(content.Title);
+        var hasDescription = ProgramSectionContentLocalizationValidationHelper.HasValue(content.Description);
 
         switch (contentType)
         {
             case ContentType.Title:
-                RequireField(nameof(content.Title), hasTitle);
-                ForbidField(nameof(content.Description), hasDescription, contentType);
+                ProgramSectionContentLocalizationValidationHelper.RequireField(nameof(content.Title), hasTitle);
+                ProgramSectionContentLocalizationValidationHelper.ForbidField(nameof(content.Description), hasDescription, contentType);
                 break;
             case ContentType.Description:
-                RequireField(nameof(content.Description), hasDescription);
-                ForbidField(nameof(content.Title), hasTitle, contentType);
+                ProgramSectionContentLocalizationValidationHelper.RequireField(nameof(content.Description), hasDescription);
+                ProgramSectionContentLocalizationValidationHelper.ForbidField(nameof(content.Title), hasTitle, contentType);
                 break;
             default:
                 throw new ValidationException(
@@ -65,32 +65,5 @@ public class HistorySectionContentLocalizationValidationHelper
                         ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(contentType)))
                 ]);
         }
-    }
-
-    private static void RequireField(string fieldName, bool hasValue)
-    {
-        if (!hasValue)
-        {
-            throw new ValidationException(
-            [
-                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyIsRequired(fieldName))
-            ]);
-        }
-    }
-
-    private static void ForbidField(string fieldName, bool hasValue, ContentType contentType)
-    {
-        if (hasValue)
-        {
-            throw new ValidationException(
-            [
-                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyNotAllowedForContentType(fieldName, contentType))
-            ]);
-        }
-    }
-
-    private static bool HasValue(string? value)
-    {
-        return !string.IsNullOrWhiteSpace(value);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionContentLocalizationValidationHelper.cs
@@ -166,6 +166,33 @@ public static class ProgramSectionContentLocalizationValidationHelper
         }
     }
 
+    public static void RequireField(string fieldName, bool hasValue)
+    {
+        if (!hasValue)
+        {
+            throw new ValidationException(
+            [
+                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyIsRequired(fieldName))
+            ]);
+        }
+    }
+
+    public static void ForbidField(string fieldName, bool hasValue, ContentType contentType)
+    {
+        if (hasValue)
+        {
+            throw new ValidationException(
+            [
+                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyNotAllowedForContentType(fieldName, contentType))
+            ]);
+        }
+    }
+
+    public static bool HasValue(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
     private static void ValidateContentLocalizationByType(
         BaseHippotherapyProgramSectionContentLocalizationDto content,
         ContentType contentType)
@@ -221,32 +248,5 @@ public static class ProgramSectionContentLocalizationValidationHelper
                         ErrorMessagesConstants.PropertyMustBeValidEnum(nameof(contentType)))
                 ]);
         }
-    }
-
-    private static void RequireField(string fieldName, bool hasValue)
-    {
-        if (!hasValue)
-        {
-            throw new ValidationException(
-            [
-                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyIsRequired(fieldName))
-            ]);
-        }
-    }
-
-    private static void ForbidField(string fieldName, bool hasValue, ContentType contentType)
-    {
-        if (hasValue)
-        {
-            throw new ValidationException(
-            [
-                new ValidationFailure(fieldName, ErrorMessagesConstants.PropertyNotAllowedForContentType(fieldName, contentType))
-            ]);
-        }
-    }
-
-    private static bool HasValue(string? value)
-    {
-        return !string.IsNullOrWhiteSpace(value);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/History/HistoryLocalizationProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/History/HistoryLocalizationProfile.cs
@@ -1,0 +1,19 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Mapping.Localization.History;
+
+public class HistoryLocalizationProfile : Profile
+{
+    public HistoryLocalizationProfile()
+    {
+        CreateMap<CreateHistorySectionContentLocalizationDto, HistorySectionContentLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<HistorySectionContentLocalization, HistorySectionContentLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/CreateHistorySectionContentLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/CreateHistorySectionContentLocalizationValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+
+namespace VictoryCenter.BLL.Validators.Localization.History;
+
+public class CreateHistorySectionContentLocalizationValidator : AbstractValidator<CreateHistorySectionContentLocalizationDto>
+{
+    public CreateHistorySectionContentLocalizationValidator()
+    {
+        RuleFor(x => x.Title)
+            .MinimumLength(ProgramSectionContentLocalizationConstants.TitleMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
+                ProgramSectionContentLocalizationConstants.TitleMinLength))
+            .MaximumLength(ProgramSectionContentLocalizationConstants.TitleMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
+                ProgramSectionContentLocalizationConstants.TitleMaxLength))
+            .When(x => !string.IsNullOrWhiteSpace(x.Title));
+        RuleFor(x => x.Description)
+            .MinimumLength(ProgramSectionContentLocalizationConstants.DescriptionMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Description),
+                ProgramSectionContentLocalizationConstants.DescriptionMinLength))
+            .MaximumLength(ProgramSectionContentLocalizationConstants.DescriptionMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Description),
+                ProgramSectionContentLocalizationConstants.DescriptionMaxLength))
+            .When(x => !string.IsNullOrWhiteSpace(x.Description));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/CreateHistorySectionContentLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/CreateHistorySectionContentLocalizationValidator.cs
@@ -1,7 +1,6 @@
 using FluentValidation;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Constants.Localization;
-using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Common;
 using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
 
 namespace VictoryCenter.BLL.Validators.Localization.History;
@@ -11,24 +10,24 @@ public class CreateHistorySectionContentLocalizationValidator : AbstractValidato
     public CreateHistorySectionContentLocalizationValidator()
     {
         RuleFor(x => x.Title)
-            .MinimumLength(ProgramSectionContentLocalizationConstants.TitleMinLength)
+            .MinimumLength(HistoryLocalizationConstants.ContentTitleMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
-                ProgramSectionContentLocalizationConstants.TitleMinLength))
-            .MaximumLength(ProgramSectionContentLocalizationConstants.TitleMaxLength)
+                nameof(CreateHistorySectionContentLocalizationDto.Title),
+                HistoryLocalizationConstants.ContentTitleMinLength))
+            .MaximumLength(HistoryLocalizationConstants.ContentTitleMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Title),
-                ProgramSectionContentLocalizationConstants.TitleMaxLength))
+                nameof(CreateHistorySectionContentLocalizationDto.Title),
+                HistoryLocalizationConstants.ContentTitleMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Title));
         RuleFor(x => x.Description)
-            .MinimumLength(ProgramSectionContentLocalizationConstants.DescriptionMinLength)
+            .MinimumLength(HistoryLocalizationConstants.ContentDescriptionMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Description),
-                ProgramSectionContentLocalizationConstants.DescriptionMinLength))
-            .MaximumLength(ProgramSectionContentLocalizationConstants.DescriptionMaxLength)
+                nameof(CreateHistorySectionContentLocalizationDto.Description),
+                HistoryLocalizationConstants.ContentDescriptionMinLength))
+            .MaximumLength(HistoryLocalizationConstants.ContentDescriptionMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseHippotherapyProgramSectionContentLocalizationDto.Description),
-                ProgramSectionContentLocalizationConstants.DescriptionMaxLength))
+                nameof(CreateHistorySectionContentLocalizationDto.Description),
+                HistoryLocalizationConstants.ContentDescriptionMaxLength))
             .When(x => !string.IsNullOrWhiteSpace(x.Description));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/CreateHistorySectionLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/CreateHistorySectionLocalizationValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Create;
+namespace VictoryCenter.BLL.Validators.Localization.History;
+
+public class CreateHistorySectionLocalizationValidator : AbstractValidator<CreateHistoryLocalizationCommand>
+{
+    public CreateHistorySectionLocalizationValidator(CreateHistorySectionContentLocalizationValidator contentValidator)
+    {
+        RuleForEach(x => x.CreateHistorySectionLocalizationDto.Contents)
+            .SetValidator(contentValidator)
+            .When(x => x.CreateHistorySectionLocalizationDto.Contents != null);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/HistorySectionContentLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/HistorySectionContentLocalizationConfig.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class HistorySectionContentLocalizationConfig : EntityLocalizationConfig<HistorySectionContentLocalization, HistorySectionContent>
+{
+    public override void Configure(EntityTypeBuilder<HistorySectionContentLocalization> entity)
+    {
+        base.Configure(entity);
+
+        entity.Property(e => e.Title)
+            .HasMaxLength(60)
+            .IsRequired(false);
+
+        entity.Property(e => e.Description)
+            .HasMaxLength(600)
+            .IsRequired(false);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -116,6 +116,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<HistorySectionContent> HistorySectionContents { get; set; }
 
+    public DbSet<HistorySectionContentLocalization> HistorySectionContentLocalizations { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/VictoryCenter/VictoryCenter.DAL/Entities/HistoryContents/HistorySectionContent.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/HistoryContents/HistorySectionContent.cs
@@ -1,9 +1,11 @@
 using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.DAL.Entities.HistoryContents;
 
-public abstract class HistorySectionContent : IEntity
+public abstract class HistorySectionContent : IEntity, ITranslatedEntity<HistorySectionContentLocalization>
 {
     public long Id { get; set; }
 
@@ -14,4 +16,6 @@ public abstract class HistorySectionContent : IEntity
     public int Order { get; set; }
 
     public HistorySection Section { get; set; } = null!;
+
+    public ICollection<HistorySectionContentLocalization> Localizations { get; set; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/HistorySectionContentLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/HistorySectionContentLocalization.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Entities.HistoryContents;
+
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class HistorySectionContentLocalization : LocalizationBase<HistorySectionContent>
+{
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260504074542_AddLocalizationForHistory.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260504074542_AddLocalizationForHistory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504074542_AddLocalizationForHistory")]
+    partial class AddLocalizationForHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260504074542_AddLocalizationForHistory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260504074542_AddLocalizationForHistory.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLocalizationForHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "HistorySectionContentLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(60)", maxLength: 60, nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(600)", maxLength: 600, nullable: true),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_HistorySectionContentLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_HistorySectionContentLocalizations_HistorySectionContents_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "HistorySectionContents",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_HistorySectionContentLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HistorySectionContentLocalizations_LanguageId",
+                table: "HistorySectionContentLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "HistorySectionContentLocalizations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -29,6 +29,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.VisitorPages;
 using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreSections;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -88,6 +89,7 @@ public interface IRepositoryWrapper
     IMetricLocalizationsRepository MetricLocalizationsRepository { get; }
     IHistorySectionsRepository HistorySectionsRepository { get; }
     IHistorySectionContentsRepository HistorySectionContentsRepository { get; }
+    IHistorySectionContentLocalizationsRepository HistorySectionContentLocalizationsRepository { get; }
 
     IRepositoryBase<TEntity> GetRepository<TEntity>()
         where TEntity : class;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/History/IHistorySectionContentLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/History/IHistorySectionContentLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
+
+public interface IHistorySectionContentLocalizationsRepository : IRepositoryBase<HistorySectionContentLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -62,6 +62,8 @@ using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreContents;
 using VictoryCenter.DAL.Repositories.Realizations.WhoWeAreSections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.MainPage;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.MainPage;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.History;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -116,6 +118,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IMetricLocalizationsRepository? _metricLocalizationsRepository;
     private IHistorySectionsRepository? _historySectionsRepository;
     private IHistorySectionContentsRepository? _historySectionContentsRepository;
+    private IHistorySectionContentLocalizationsRepository? _historySectionContentLocalizationsRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -270,6 +273,9 @@ public class RepositoryWrapper : IRepositoryWrapper
         _historySectionsRepository ??= new HistorySectionsRepository(_victoryCenterDbContext);
     public IHistorySectionContentsRepository HistorySectionContentsRepository =>
         _historySectionContentsRepository ??= new HistorySectionContentsRepository(_victoryCenterDbContext);
+
+    public IHistorySectionContentLocalizationsRepository HistorySectionContentLocalizationsRepository =>
+        _historySectionContentLocalizationsRepository ??= new HistorySectionContentLocalizationsRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/History/HistorySectionContentLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/History/HistorySectionContentLocalizationsRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.History;
+
+public class HistorySectionContentLocalizationsRepository : RepositoryBase<HistorySectionContentLocalization>, IHistorySectionContentLocalizationsRepository
+{
+    public HistorySectionContentLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HistorySectionContentLocalizationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/HistorySectionContentLocalizationHelperTests.cs
@@ -1,0 +1,150 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.HelperTests;
+
+public class HistorySectionContentLocalizationHelperTests
+{
+    [Fact]
+    public void ValidateHistoryContents_WithValidData()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 10, Title = "History Title", Description = null },
+            new() { EntityId = 11, Title = null, Description = "History Description" }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 10, ContentType.Title },
+            { 11, ContentType.Description }
+        };
+
+        var ex = Record.Exception(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ValidateHistoryContents_InvalidContentId_ThrowsNotFoundValidationException()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 99 }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>();
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Contains(
+            ErrorMessagesConstants.NotFound(99, typeof(HistorySectionContent)).Split(' ')[0],
+            ex.Message);
+    }
+
+    [Fact]
+    public void ValidateHistoryContents_UnsupportedContentType_ThrowsValidationException()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 10, Title = "Some Title" }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 10, ContentType.Image }
+        };
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Contains("which is not allowed for history localization", ex.Message);
+        Assert.Contains("Only Title and Description are allowed", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateHistoryContents_TitleType_WithoutTitle_ThrowsValidationException()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 10, Title = "" }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 10, ContentType.Title }
+        };
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Contains(ErrorMessagesConstants.PropertyIsRequired("Title"), ex.Message);
+    }
+
+    [Fact]
+    public void ValidateHistoryContents_TitleType_WithForbiddenDescription_ThrowsValidationException()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 10, Title = "Valid Title", Description = "Forbidden Description" }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 10, ContentType.Title }
+        };
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Contains(
+            ErrorMessagesConstants.PropertyNotAllowedForContentType("Description", ContentType.Title),
+            ex.Message);
+    }
+
+    [Fact]
+    public void ValidateHistoryContents_DescriptionType_WithoutDescription_ThrowsValidationException()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 11, Description = null }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 11, ContentType.Description }
+        };
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Contains(ErrorMessagesConstants.PropertyIsRequired("Description"), ex.Message);
+    }
+
+    [Fact]
+    public void ValidateHistoryContents_DescriptionType_WithForbiddenTitle_ThrowsValidationException()
+    {
+        var contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new() { EntityId = 11, Description = "Valid Description", Title = "Forbidden Title" }
+        };
+
+        var contentTypesById = new Dictionary<long, ContentType>
+        {
+            { 11, ContentType.Description }
+        };
+
+        var ex = Assert.Throws<ValidationException>(() =>
+            HistorySectionContentLocalizationValidationHelper.ValidateHistoryContents(contents, contentTypesById));
+
+        Assert.Contains(
+            ErrorMessagesConstants.PropertyNotAllowedForContentType("Title", ContentType.Description),
+            ex.Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/CreateHistorySectionContentLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/CreateHistorySectionContentLocalizationHandlerTests.cs
@@ -1,0 +1,276 @@
+using AutoMapper;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.History;
+
+public class CreateHistorySectionContentLocalizationHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<ILocalizationService<HistorySectionContent, HistorySectionContentLocalization>> _localizationServiceMock;
+    private readonly Mock<IValidator<CreateHistoryLocalizationCommand>> _validatorMock;
+    private readonly CreateHistoryLocalizationHandler _handler;
+
+    private static readonly List<CreateHistorySectionContentLocalizationDto> _testContentLocalizationDto = new()
+    {
+        new CreateHistorySectionContentLocalizationDto
+        {
+            EntityId = 3,
+            LanguageId = 2,
+            Title = "Test Title",
+        },
+        new CreateHistorySectionContentLocalizationDto
+        {
+            EntityId = 2,
+            LanguageId = 2,
+            Description = "Test Description 2",
+        }
+    };
+    private readonly CreateHistorySectionLocalizationDto _testSectionLocalizationDto = new()
+    {
+        EntityId = 1,
+        Contents = _testContentLocalizationDto
+    };
+    private readonly CreateHistorySectionLocalizationDto _failedFortest = new()
+    {
+        EntityId = 3,
+        Contents = new List<CreateHistorySectionContentLocalizationDto>
+        {
+            new ()
+            {
+                EntityId = 3,
+                LanguageId = 2,
+                Title = "For failed Test Title",
+            },
+            new ()
+            {
+                EntityId = 2,
+                LanguageId = 3,
+                Description = "For failed Test Description 2",
+            }
+        }
+    };
+
+    private readonly HistorySection _section = new()
+    {
+        Id = 1,
+        Template = HistorySectionTemplate.TextOnly,
+        Order = 1,
+        CreatedAt = DateTimeOffset.UtcNow,
+        Contents = new List<HistorySectionContent>()
+        {
+            new TitleHistoryContent
+            {
+                Id = 3,
+                SectionId = 1,
+                ContentType = ContentType.Title,
+                Order = 1,
+                Title = "Оригінальний текст",
+            },
+            new DescriptionHistoryContent
+            {
+                Id = 2,
+                SectionId = 1,
+                ContentType = ContentType.Description,
+                Order = 1,
+                Description = "Оригінальний опис",
+            }
+        }
+    };
+    public CreateHistorySectionContentLocalizationHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _mapperMock = new Mock<IMapper>();
+        _localizationServiceMock = new Mock<ILocalizationService<HistorySectionContent, HistorySectionContentLocalization>>();
+        _validatorMock = new Mock<IValidator<CreateHistoryLocalizationCommand>>();
+        _handler = new CreateHistoryLocalizationHandler(_repositoryWrapperMock.Object, _mapperMock.Object, _localizationServiceMock.Object, _validatorMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateLocalizationForHistory_Successfully()
+    {
+        SetupDependencies();
+
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailWhenSectionNotFoundInDatabase()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ThrowsAsync(new KeyNotFoundException(ErrorMessagesConstants.NotFound(_testSectionLocalizationDto.EntityId, typeof(HistorySection))));
+
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .ThrowsAsync(new KeyNotFoundException(ErrorMessagesConstants.NotFound(2, typeof(HistorySectionContentLocalization))));
+
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenValidationExceptionThrowsWhileTrackEntityLocalizationAsync()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .ThrowsAsync(new ValidationException(new[] { new ValidationFailure("test", "Bulk localization supports only one LanguageId.") }));
+
+        var command = new CreateHistoryLocalizationCommand(_failedFortest);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenInvalidOperationExceptionThrown()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenFailedToCreateEntityInDatabase()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenDbUpdateExceptionThrown()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ThrowsAsync(new DbUpdateException());
+
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenUnexpectedExceptionThrown()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ThrowsAsync(new Exception("Unexpected error"));
+        var command = new CreateHistoryLocalizationCommand(_testSectionLocalizationDto);
+        var result = await _handler.Handle(command, CancellationToken.None);
+        Assert.True(result.IsFailed);
+    }
+
+    private void SetupDependencies()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository
+            .GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(_section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        _repositoryWrapperMock.Setup(r => r.HistorySectionContentLocalizationsRepository
+        .GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
+        .ReturnsAsync(new List<HistorySectionContentLocalization>());
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<CreateHistorySectionContentLocalizationDto>>()))
+            .Returns(new List<HistorySectionContentLocalization>());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/History/CreateHistorySectionContentLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/History/CreateHistorySectionContentLocalizationValidatorTests.cs
@@ -1,0 +1,145 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+using VictoryCenter.BLL.Validators.Localization.History;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.History;
+
+public class CreateHistorySectionContentLocalizationValidatorTests
+{
+    private readonly CreateHistorySectionContentLocalizationValidator _validator;
+
+    public CreateHistorySectionContentLocalizationValidatorTests()
+    {
+        _validator = new CreateHistorySectionContentLocalizationValidator();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WhenTitleIsNullOrEmpty_ShouldNotHaveValidationError(string title)
+    {
+        // Arrange
+        var model = new CreateHistorySectionContentLocalizationDto { Title = title };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public void Validate_WhenTitleIsValid_ShouldNotHaveValidationError()
+    {
+        // Arrange
+        var validTitle = new string('a', HistoryLocalizationConstants.ContentTitleMinLength + 1);
+        var model = new CreateHistorySectionContentLocalizationDto { Title = validTitle };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public void Validate_WhenTitleIsTooShort_ShouldHaveValidationError()
+    {
+        // Arrange
+        var invalidTitle = new string('a', Math.Max(1, HistoryLocalizationConstants.ContentTitleMinLength - 1));
+        var model = new CreateHistorySectionContentLocalizationDto { Title = invalidTitle };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                  nameof(CreateHistorySectionContentLocalizationDto.Title),
+                  HistoryLocalizationConstants.ContentTitleMinLength));
+    }
+
+    [Fact]
+    public void Validate_WhenTitleIsTooLong_ShouldHaveValidationError()
+    {
+        // Arrange
+        var invalidTitle = new string('a', HistoryLocalizationConstants.ContentTitleMaxLength + 1);
+        var model = new CreateHistorySectionContentLocalizationDto { Title = invalidTitle };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                  nameof(CreateHistorySectionContentLocalizationDto.Title),
+                  HistoryLocalizationConstants.ContentTitleMaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WhenDescriptionIsNullOrEmpty_ShouldNotHaveValidationError(string description)
+    {
+        // Arrange
+        var model = new CreateHistorySectionContentLocalizationDto { Description = description };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_WhenDescriptionIsValid_ShouldNotHaveValidationError()
+    {
+        // Arrange
+        var validDescription = new string('a', HistoryLocalizationConstants.ContentDescriptionMinLength + 1);
+        var model = new CreateHistorySectionContentLocalizationDto { Description = validDescription };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_WhenDescriptionIsTooShort_ShouldHaveValidationError()
+    {
+        // Arrange
+        var invalidDescription = new string('a', Math.Max(1, HistoryLocalizationConstants.ContentDescriptionMinLength - 1));
+        var model = new CreateHistorySectionContentLocalizationDto { Description = invalidDescription };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                  nameof(CreateHistorySectionContentLocalizationDto.Description),
+                  HistoryLocalizationConstants.ContentDescriptionMinLength));
+    }
+
+    [Fact]
+    public void Validate_WhenDescriptionIsTooLong_ShouldHaveValidationError()
+    {
+        // Arrange
+        var invalidDescription = new string('a', HistoryLocalizationConstants.ContentDescriptionMaxLength + 1);
+        var model = new CreateHistorySectionContentLocalizationDto { Description = invalidDescription };
+
+        // Act
+        var result = _validator.TestValidate(model);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                  nameof(CreateHistorySectionContentLocalizationDto.Description),
+                  HistoryLocalizationConstants.ContentDescriptionMaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HistoryLocalizationController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HistoryLocalizationController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Create;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Create;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin.Localization;
+
+public class HistoryLocalizationController : AuthorizedApiController
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(HistorySectionLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateHistoryLocalization([FromBody] CreateHistorySectionLocalizationDto createHistorySectionLocalizationDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateHistoryLocalizationCommand(createHistorySectionLocalizationDto)));
+    }
+}


### PR DESCRIPTION
## Github tickets

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2468) - Sub issue
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2099) - Main issue


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can create/manage localized history sections (titles and descriptions) via a new API endpoint.
* **Validation**
  * Enforced rules for title/description presence, allowed content types, and min/max lengths.
* **Database**
  * Storage and retrieval added for history content localizations; responses include localized items with translation status.
* **Tests**
  * Unit tests covering successful creation and multiple failure scenarios for localization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->