### PR TITLE
Feature/issue-2469: [Reports] Implement category localization CRUD

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryLocalizationCommand.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Create;
+
+public record CreateReportFundsExpendituresCategoryLocalizationCommand(
+    CreateReportFundsExpendituresCategoryLocalizationDto CreateReportFundsExpendituresCategoryLocalizationDto)
+    : IRequest<Result<ReportFundsExpendituresCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryLocalizationHandler.cs
@@ -1,0 +1,62 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Create;
+
+public class CreateReportFundsExpendituresCategoryLocalizationHandler
+    : IRequestHandler<CreateReportFundsExpendituresCategoryLocalizationCommand, Result<ReportFundsExpendituresCategoryLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization> _localizationService;
+    private readonly IValidator<CreateReportFundsExpendituresCategoryLocalizationCommand> _validator;
+
+    public CreateReportFundsExpendituresCategoryLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization> localizationService,
+        IValidator<CreateReportFundsExpendituresCategoryLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<ReportFundsExpendituresCategoryLocalizationDto>> Handle(
+        CreateReportFundsExpendituresCategoryLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var entity = _mapper.Map<ReportFundsExpendituresCategoryLocalization>(request.CreateReportFundsExpendituresCategoryLocalizationDto);
+            var result = await _localizationService.CreateEntityLocalizationAsync(entity);
+            var responseDto = _mapper.Map<ReportFundsExpendituresCategoryLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToCreateEntity(typeof(ReportFundsExpendituresCategoryLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(ReportFundsExpendituresCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryLocalizationCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Delete;
+
+public record DeleteReportFundsExpendituresCategoryLocalizationCommand(long EntityId, long LanguageId)
+    : IRequest<Result<DeleteReportFundsExpendituresCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryLocalizationHandler.cs
@@ -1,0 +1,47 @@
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Delete;
+
+public class DeleteReportFundsExpendituresCategoryLocalizationHandler
+    : IRequestHandler<DeleteReportFundsExpendituresCategoryLocalizationCommand, Result<DeleteReportFundsExpendituresCategoryLocalizationDto>>
+{
+    private readonly ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization> _localizationService;
+
+    public DeleteReportFundsExpendituresCategoryLocalizationHandler(
+        ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization> localizationService)
+    {
+        _localizationService = localizationService;
+    }
+
+    public async Task<Result<DeleteReportFundsExpendituresCategoryLocalizationDto>> Handle(
+        DeleteReportFundsExpendituresCategoryLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (entityId, languageId) = await _localizationService.DeleteEntityLocalizationAsync(request.EntityId, request.LanguageId);
+            return Result.Ok(new DeleteReportFundsExpendituresCategoryLocalizationDto { EntityId = entityId, LanguageId = languageId });
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<DeleteReportFundsExpendituresCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<DeleteReportFundsExpendituresCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToDeleteEntity(typeof(ReportFundsExpendituresCategoryLocalization)));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<DeleteReportFundsExpendituresCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(ReportFundsExpendituresCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryLocalizationCommand.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Update;
+
+public record UpdateReportFundsExpendituresCategoryLocalizationCommand(
+    UpdateReportFundsExpendituresCategoryLocalizationDto UpdateReportFundsExpendituresCategoryLocalizationDto,
+    long EntityId,
+    long LanguageId)
+    : IRequest<Result<ReportFundsExpendituresCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryLocalizationHandler.cs
@@ -1,0 +1,64 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Update;
+
+public class UpdateReportFundsExpendituresCategoryLocalizationHandler
+    : IRequestHandler<UpdateReportFundsExpendituresCategoryLocalizationCommand, Result<ReportFundsExpendituresCategoryLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization> _localizationService;
+    private readonly IValidator<UpdateReportFundsExpendituresCategoryLocalizationCommand> _validator;
+
+    public UpdateReportFundsExpendituresCategoryLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization> localizationService,
+        IValidator<UpdateReportFundsExpendituresCategoryLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<ReportFundsExpendituresCategoryLocalizationDto>> Handle(
+        UpdateReportFundsExpendituresCategoryLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var entity = _mapper.Map<ReportFundsExpendituresCategoryLocalization>(request.UpdateReportFundsExpendituresCategoryLocalizationDto);
+            entity.EntityId = request.EntityId;
+            entity.LanguageId = request.LanguageId;
+            var result = await _localizationService.UpdateEntityLocalizationAsync(entity);
+            var responseDto = _mapper.Map<ReportFundsExpendituresCategoryLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(ReportFundsExpendituresCategoryLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<ReportFundsExpendituresCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(ReportFundsExpendituresCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/Localization/ReportFundsExpendituresCategoryLocalizationConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/Localization/ReportFundsExpendituresCategoryLocalizationConstants.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.Constants.Localization;
+
+public static class ReportFundsExpendituresCategoryLocalizationConstants
+{
+    public static readonly int NameMinLength = 5;
+    public static readonly int NameMaxLength = 200;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryLocalizationDto.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+public class CreateReportFundsExpendituresCategoryLocalizationDto
+    : UpdateReportFundsExpendituresCategoryLocalizationDto, ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/DeleteReportFundsExpendituresCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/DeleteReportFundsExpendituresCategoryLocalizationDto.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+public class DeleteReportFundsExpendituresCategoryLocalizationDto : ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryLocalizationDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+public class ReportFundsExpendituresCategoryLocalizationDto
+{
+    public long EntityId { get; init; }
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+    public string Name { get; set; } = null!;
+    public TranslationStatus TranslationStatus { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryLocalizationDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+public class UpdateReportFundsExpendituresCategoryLocalizationDto
+{
+    public string Name { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryLocalizationProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryLocalizationProfile.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Mapping.Localization.ReportFundsExpendituresCategories;
+
+public class ReportFundsExpendituresCategoryLocalizationProfile : Profile
+{
+    public ReportFundsExpendituresCategoryLocalizationProfile()
+    {
+        CreateMap<CreateReportFundsExpendituresCategoryLocalizationDto, ReportFundsExpendituresCategoryLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateReportFundsExpendituresCategoryLocalizationDto, ReportFundsExpendituresCategoryLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+
+        CreateMap<ReportFundsExpendituresCategoryLocalization, ReportFundsExpendituresCategoryLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresCategories/GetByEntityId/GetReportFundsExpendituresCategoryLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresCategories/GetByEntityId/GetReportFundsExpendituresCategoryLocalizationByEntityIdHandler.cs
@@ -1,0 +1,39 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresCategories.GetByEntityId;
+
+public class GetReportFundsExpendituresCategoryLocalizationByEntityIdHandler
+    : IRequestHandler<GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery, Result<List<ReportFundsExpendituresCategoryLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetReportFundsExpendituresCategoryLocalizationByEntityIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<List<ReportFundsExpendituresCategoryLocalizationDto>>> Handle(
+        GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<ReportFundsExpendituresCategoryLocalization>
+        {
+            Filter = l => l.EntityId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+            AsNoTracking = true,
+        };
+
+        var entities = await _repositoryWrapper.ReportFundsExpendituresCategoryLocalizationsRepository.GetAllAsync(queryOptions);
+        var responseDto = _mapper.Map<List<ReportFundsExpendituresCategoryLocalizationDto>>(entities);
+        return Result.Ok(responseDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresCategories/GetByEntityId/GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresCategories/GetByEntityId/GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresCategories.GetByEntityId;
+
+public record GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery(long Id)
+    : IRequest<Result<List<ReportFundsExpendituresCategoryLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryLocalizationValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+
+namespace VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresCategories;
+
+public class BaseReportFundsExpendituresCategoryLocalizationValidator
+    : AbstractValidator<UpdateReportFundsExpendituresCategoryLocalizationDto>
+{
+    public BaseReportFundsExpendituresCategoryLocalizationValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateReportFundsExpendituresCategoryLocalizationDto.Name)))
+            .MinimumLength(ReportFundsExpendituresCategoryLocalizationConstants.NameMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateReportFundsExpendituresCategoryLocalizationDto.Name),
+                ReportFundsExpendituresCategoryLocalizationConstants.NameMinLength))
+            .MaximumLength(ReportFundsExpendituresCategoryLocalizationConstants.NameMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateReportFundsExpendituresCategoryLocalizationDto.Name),
+                ReportFundsExpendituresCategoryLocalizationConstants.NameMaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryLocalizationValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Create;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Validators.Localization.Base;
+
+namespace VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresCategories;
+
+public class CreateReportFundsExpendituresCategoryLocalizationValidator
+    : AbstractValidator<CreateReportFundsExpendituresCategoryLocalizationCommand>
+{
+    public CreateReportFundsExpendituresCategoryLocalizationValidator(
+        BaseReportFundsExpendituresCategoryLocalizationValidator baseValidator)
+    {
+        RuleFor(c => c.CreateReportFundsExpendituresCategoryLocalizationDto)
+            .SetValidator(new LocalizationIdentityValidator<CreateReportFundsExpendituresCategoryLocalizationDto>());
+        RuleFor(c => c.CreateReportFundsExpendituresCategoryLocalizationDto)
+            .SetValidator(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryLocalizationValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresCategories;
+
+public class UpdateReportFundsExpendituresCategoryLocalizationValidator
+    : AbstractValidator<UpdateReportFundsExpendituresCategoryLocalizationCommand>
+{
+    public UpdateReportFundsExpendituresCategoryLocalizationValidator(
+        BaseReportFundsExpendituresCategoryLocalizationValidator baseValidator)
+    {
+        RuleFor(x => x.UpdateReportFundsExpendituresCategoryLocalizationDto)
+            .SetValidator(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/ReportFundsExpendituresCategoryLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/ReportFundsExpendituresCategoryLocalizationConfig.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class ReportFundsExpendituresCategoryLocalizationConfig
+    : EntityLocalizationConfig<ReportFundsExpendituresCategoryLocalization, ReportFundsExpendituresCategory>
+{
+    public override void Configure(EntityTypeBuilder<ReportFundsExpendituresCategoryLocalization> entity)
+    {
+        base.Configure(entity);
+
+        entity.Property(e => e.Name)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -94,6 +94,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<ReportFundsExpendituresCategory> ReportFundsExpendituresCategories { get; set; }
 
+    public DbSet<ReportFundsExpendituresCategoryLocalization> ReportFundsExpendituresCategoryLocalizations { get; set; }
+
     public DbSet<ReportFundsExpendituresRecord> ReportFundsExpendituresRecords { get; set; }
 
     public DbSet<ReportProgramExpendituresRecord> ReportProgramExpendituresRecords { get; set; }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/ReportFundsExpendituresCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/ReportFundsExpendituresCategoryLocalization.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class ReportFundsExpendituresCategoryLocalization : LocalizationBase<ReportFundsExpendituresCategory>
+{
+    public string Name { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresCategory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresCategory.cs
@@ -1,13 +1,16 @@
 using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.DAL.Entities;
 
-public class ReportFundsExpendituresCategory : BaseEntity
+public class ReportFundsExpendituresCategory : BaseEntity, ITranslatedEntity<ReportFundsExpendituresCategoryLocalization>
 {
     public string Name { get; set; } = "";
 
     public ReportFundsExpendituresType Type { get; set; }
 
     public ICollection<ReportFundsExpendituresRecord> Records { get; set; } = [];
+    public ICollection<ReportFundsExpendituresCategoryLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260506075426_AddReportFundsExpendituresCategoryLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260506075426_AddReportFundsExpendituresCategoryLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260506075426_AddReportFundsExpendituresCategoryLocalization")]
+    partial class AddReportFundsExpendituresCategoryLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260506075426_AddReportFundsExpendituresCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260506075426_AddReportFundsExpendituresCategoryLocalization.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReportFundsExpendituresCategoryLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReportFundsExpendituresCategoryLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReportFundsExpendituresCategoryLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_ReportFundsExpendituresCategoryLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ReportFundsExpendituresCategoryLocalizations_ReportFundsExpendituresCategories_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "ReportFundsExpendituresCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReportFundsExpendituresCategoryLocalizations_LanguageId",
+                table: "ReportFundsExpendituresCategoryLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReportFundsExpendituresCategoryLocalizations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -11,6 +11,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyPrograms;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.PdfSection;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.MainPage;
@@ -63,6 +64,8 @@ public interface IRepositoryWrapper
     IProgramSectionContentLocalizationsRepository ProgramSectionContentLocalizationsRepository { get; }
 
     ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository { get; }
+
+    IReportFundsExpendituresCategoryLocalizationsRepository ReportFundsExpendituresCategoryLocalizationsRepository { get; }
 
     IChangedLivesBlockRepository ChangedLivesBlockRepository { get; }
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/ReportFundsExpendituresCategories/IReportFundsExpendituresCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/ReportFundsExpendituresCategories/IReportFundsExpendituresCategoryLocalizationsRepository.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
+
+public interface IReportFundsExpendituresCategoryLocalizationsRepository
+    : IRepositoryBase<ReportFundsExpendituresCategoryLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -14,6 +14,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyPrograms;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.PdfSection;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.WhoWeAreContents;
@@ -43,6 +44,7 @@ using VictoryCenter.DAL.Repositories.Realizations.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyPrograms;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.PdfSection;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.ReportFundsExpendituresCategories;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.WhoWeAreContents;
@@ -101,6 +103,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IReportProgramExpendituresRecordsRepository? _reportProgramExpendituresRecordsRepository;
     private ISupportOptionsRepository? _supportOptionsRepository;
     private ITeamCategoryLocalizationsRepository? _teamCategoryLocalizationsRepository;
+    private IReportFundsExpendituresCategoryLocalizationsRepository? _reportFundsExpendituresCategoryLocalizationsRepository;
     private ITeamMemberLocalizationsRepository? _teamMemberLocalizationsRepository;
     private ITeamMembersRepository? _teamMembersRepository;
     private IUahBankDetailsRepository? _uahBankDetailsRepository;
@@ -200,6 +203,10 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository =>
         _teamCategoryLocalizationsRepository ??= new TeamCategoryLocalizationRepository(_victoryCenterDbContext);
+
+    public IReportFundsExpendituresCategoryLocalizationsRepository ReportFundsExpendituresCategoryLocalizationsRepository =>
+        _reportFundsExpendituresCategoryLocalizationsRepository ??=
+            new ReportFundsExpendituresCategoryLocalizationsRepository(_victoryCenterDbContext);
 
     public IProgramSectionContentsRepository ProgramSectionContentsRepository => _programSectionContentsRepository ??=
         new ProgramSectionContentsRepository(_victoryCenterDbContext);

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryLocalizationsRepository.cs
@@ -1,0 +1,16 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.ReportFundsExpendituresCategories;
+
+public class ReportFundsExpendituresCategoryLocalizationsRepository
+    : RepositoryBase<ReportFundsExpendituresCategoryLocalization>,
+      IReportFundsExpendituresCategoryLocalizationsRepository
+{
+    public ReportFundsExpendituresCategoryLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Create/CreateReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Create/CreateReportFundsExpendituresCategoryLocalizationTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.ReportFundsExpendituresCategoryLocalizations.Create;
+
+public class CreateReportFundsExpendituresCategoryLocalizationTests : BaseTestClass
+{
+    public CreateReportFundsExpendituresCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnOk()
+    {
+        var category = await Fixture.DbContext.ReportFundsExpendituresCategories.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 3)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateReportFundsExpendituresCategoryLocalizationDto
+        {
+            EntityId = category.Id,
+            LanguageId = language.Id,
+            Name = "New Localization Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategoryLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnNotFound_WhenEntityDoesNotExist()
+    {
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateReportFundsExpendituresCategoryLocalizationDto
+        {
+            EntityId = 999999,
+            LanguageId = language.Id,
+            Name = "Some Localization Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategoryLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnBadRequest_WhenNameIsInvalid()
+    {
+        var category = await Fixture.DbContext.ReportFundsExpendituresCategories.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateReportFundsExpendituresCategoryLocalizationDto
+        {
+            EntityId = category.Id,
+            LanguageId = language.Id,
+            Name = ""
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategoryLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Create/CreateReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Create/CreateReportFundsExpendituresCategoryLocalizationTests.cs
@@ -3,6 +3,8 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
 
@@ -18,14 +20,21 @@ public class CreateReportFundsExpendituresCategoryLocalizationTests : BaseTestCl
     [Fact]
     public async Task CreateLocalization_ShouldReturnOk()
     {
-        var category = await Fixture.DbContext.ReportFundsExpendituresCategories.FirstOrDefaultAsync()
-            ?? throw new InvalidOperationException("Couldn't setup existing entity");
-        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 3)
+        var freshCategory = new ReportFundsExpendituresCategory
+        {
+            Name = "Fresh Category For Localization",
+            Type = ReportFundsExpendituresType.Income,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.ReportFundsExpendituresCategories.AddAsync(freshCategory);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
             ?? throw new InvalidOperationException("Couldn't setup existing language");
 
         var createDto = new CreateReportFundsExpendituresCategoryLocalizationDto
         {
-            EntityId = category.Id,
+            EntityId = freshCategory.Id,
             LanguageId = language.Id,
             Name = "New Localization Name"
         };

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Delete/DeleteReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Delete/DeleteReportFundsExpendituresCategoryLocalizationTests.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.ReportFundsExpendituresCategoryLocalizations.Delete;
+
+public class DeleteReportFundsExpendituresCategoryLocalizationTests : BaseTestClass
+{
+    public DeleteReportFundsExpendituresCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task DeleteLocalization_ShouldReturnOk()
+    {
+        var localization = await Fixture.DbContext.ReportFundsExpendituresCategoryLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var response = await Fixture.HttpClient.DeleteAsync(
+            $"/api/ReportFundsExpendituresCategoryLocalizations/{localization.EntityId}/{localization.LanguageId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteLocalization_ShouldReturnNotFound_WhenLocalizationDoesNotExist()
+    {
+        var response = await Fixture.HttpClient.DeleteAsync(
+            "/api/ReportFundsExpendituresCategoryLocalizations/999999/999999");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/GetByEntityId/GetLocalizationsByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/GetByEntityId/GetLocalizationsByEntityIdTests.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.ReportFundsExpendituresCategoryLocalizations.GetByEntityId;
+
+public class GetLocalizationsByEntityIdTests : BaseTestClass
+{
+    public GetLocalizationsByEntityIdTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetLocalizationsByEntityId_ShouldReturnOk_WhenEntityExists()
+    {
+        var localization = await Fixture.DbContext.ReportFundsExpendituresCategoryLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var response = await Fixture.HttpClient.GetAsync(
+            $"/api/ReportFundsExpendituresCategoryLocalizations/{localization.EntityId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLocalizationsByEntityId_ShouldReturnOk_WithEmptyList_WhenEntityHasNoLocalizations()
+    {
+        var response = await Fixture.HttpClient.GetAsync(
+            "/api/ReportFundsExpendituresCategoryLocalizations/999999");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Update/UpdateReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresCategoryLocalizations/Update/UpdateReportFundsExpendituresCategoryLocalizationTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.ReportFundsExpendituresCategoryLocalizations.Update;
+
+public class UpdateReportFundsExpendituresCategoryLocalizationTests : BaseTestClass
+{
+    public UpdateReportFundsExpendituresCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnOk()
+    {
+        var localization = await Fixture.DbContext.ReportFundsExpendituresCategoryLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var updateDto = new UpdateReportFundsExpendituresCategoryLocalizationDto
+        {
+            Name = "Updated Localization Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresCategoryLocalizations/{localization.EntityId}/{localization.LanguageId}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnNotFound_WhenLocalizationDoesNotExist()
+    {
+        var updateDto = new UpdateReportFundsExpendituresCategoryLocalizationDto
+        {
+            Name = "Updated Localization Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            "/api/ReportFundsExpendituresCategoryLocalizations/999999/999999",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnBadRequest_WhenNameIsInvalid()
+    {
+        var localization = await Fixture.DbContext.ReportFundsExpendituresCategoryLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var updateDto = new UpdateReportFundsExpendituresCategoryLocalizationDto
+        {
+            Name = ""
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresCategoryLocalizations/{localization.EntityId}/{localization.LanguageId}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/ReportFundsExpendituresCategoryLocalizations/ReportFundsExpendituresCategoryLocalizationsSeeder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/ReportFundsExpendituresCategoryLocalizations/ReportFundsExpendituresCategoryLocalizationsSeeder.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.IntegrationTests.Utils.Seeders.Localizations.ReportFundsExpendituresCategoryLocalizations;
+
+public class ReportFundsExpendituresCategoryLocalizationsSeeder : ISeeder
+{
+    private readonly VictoryCenterDbContext _dbContext;
+    private readonly ILogger<ReportFundsExpendituresCategoryLocalizationsSeeder> _logger;
+    private readonly List<ReportFundsExpendituresCategory> _categories = [];
+    private readonly List<ReportFundsExpendituresCategoryLocalization> _localizations = [];
+
+    public ReportFundsExpendituresCategoryLocalizationsSeeder(
+        VictoryCenterDbContext dbContext,
+        ILogger<ReportFundsExpendituresCategoryLocalizationsSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public int Order => (int)SeederExecutionOrder.ReportFundsExpendituresCategoryLocalizations;
+    public string Name => nameof(ReportFundsExpendituresCategoryLocalizationsSeeder);
+
+    public async Task<SeederResult> SeedAsync()
+    {
+        try
+        {
+            _categories.AddRange(new List<ReportFundsExpendituresCategory>
+            {
+                new() { Name = "Localization Test Category 1", Type = ReportFundsExpendituresType.Income, CreatedAt = DateTimeOffset.UtcNow },
+                new() { Name = "Localization Test Category 2", Type = ReportFundsExpendituresType.Expense, CreatedAt = DateTimeOffset.UtcNow },
+            });
+
+            await _dbContext.ReportFundsExpendituresCategories.AddRangeAsync(_categories);
+            await _dbContext.SaveChangesAsync();
+
+            _localizations.AddRange(new List<ReportFundsExpendituresCategoryLocalization>
+            {
+                new() { EntityId = _categories[0].Id, LanguageId = 2, Name = "English Name 1", CreatedAt = DateTimeOffset.UtcNow },
+                new() { EntityId = _categories[1].Id, LanguageId = 2, Name = "English Name 2", CreatedAt = DateTimeOffset.UtcNow },
+            });
+
+            await _dbContext.ReportFundsExpendituresCategoryLocalizations.AddRangeAsync(_localizations);
+            await _dbContext.SaveChangesAsync();
+
+            if (!await VerifyAsync())
+            {
+                throw new InvalidOperationException($"Verification failed for seeder {Name}");
+            }
+
+            return new SeederResult { Success = true, CreatedCount = _localizations.Count };
+        }
+        catch (Exception ex)
+        {
+            await DisposeAsync();
+            _logger.LogError(ex, "Error in seeder {Name}", Name);
+            return new SeederResult { Success = false, ErrorMessage = ex.Message };
+        }
+    }
+
+    public async Task<bool> DisposeAsync()
+    {
+        try
+        {
+            if (_localizations.Count != 0)
+            {
+                _dbContext.ReportFundsExpendituresCategoryLocalizations.RemoveRange(_localizations);
+                await _dbContext.SaveChangesAsync();
+                _localizations.Clear();
+            }
+
+            if (_categories.Count != 0)
+            {
+                _dbContext.ReportFundsExpendituresCategories.RemoveRange(_categories);
+                await _dbContext.SaveChangesAsync();
+                _categories.Clear();
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error disposing seeder {Name}", Name);
+            return false;
+        }
+    }
+
+    public async Task<bool> VerifyAsync()
+    {
+        var count = await _dbContext.ReportFundsExpendituresCategoryLocalizations.CountAsync();
+        return count >= _localizations.Count;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
@@ -16,4 +16,5 @@ public enum SeederExecutionOrder
     PartnersSections,
     PartnersPageBanner,
     TeamCategoryLocalizations,
+    ReportFundsExpendituresCategoryLocalizations,
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
@@ -12,6 +12,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <Compile Remove="ControllerTests\Localizations\ReportFundsExpendituresCategoryLocalizations\GetByEntityId\GetReportFundsExpendituresCategoryLocalizationsByEntityIdTests.cs\**" />
+      <EmbeddedResource Remove="ControllerTests\Localizations\ReportFundsExpendituresCategoryLocalizations\GetByEntityId\GetReportFundsExpendituresCategoryLocalizationsByEntityIdTests.cs\**" />
+      <None Remove="ControllerTests\Localizations\ReportFundsExpendituresCategoryLocalizations\GetByEntityId\GetReportFundsExpendituresCategoryLocalizationsByEntityIdTests.cs\**" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />

--- a/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/VictoryCenter.IntegrationTests.csproj
@@ -12,12 +12,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Compile Remove="ControllerTests\Localizations\ReportFundsExpendituresCategoryLocalizations\GetByEntityId\GetReportFundsExpendituresCategoryLocalizationsByEntityIdTests.cs\**" />
-      <EmbeddedResource Remove="ControllerTests\Localizations\ReportFundsExpendituresCategoryLocalizations\GetByEntityId\GetReportFundsExpendituresCategoryLocalizationsByEntityIdTests.cs\**" />
-      <None Remove="ControllerTests\Localizations\ReportFundsExpendituresCategoryLocalizations\GetByEntityId\GetReportFundsExpendituresCategoryLocalizationsByEntityIdTests.cs\**" />
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryLocalizationTests.cs
@@ -1,0 +1,145 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresCategories;
+
+public class CreateReportFundsExpendituresCategoryLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization>> _mockLocalizationService;
+    private readonly IValidator<CreateReportFundsExpendituresCategoryLocalizationCommand> _validator;
+    private readonly CreateReportFundsExpendituresCategoryLocalizationHandler _handler;
+
+    private readonly CreateReportFundsExpendituresCategoryLocalizationDto _createDto = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "English Name"
+    };
+
+    private readonly ReportFundsExpendituresCategoryLocalization _entity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "English Name",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" }
+    };
+
+    private readonly ReportFundsExpendituresCategoryLocalizationDto _responseDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        Name = "English Name"
+    };
+
+    public CreateReportFundsExpendituresCategoryLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization>>();
+        _validator = new CreateReportFundsExpendituresCategoryLocalizationValidator(
+            new BaseReportFundsExpendituresCategoryLocalizationValidator());
+        _handler = new CreateReportFundsExpendituresCategoryLocalizationHandler(
+            _mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_responseDto.Name, result.Value.Name);
+        Assert.Equal(_responseDto.EntityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var invalidDto = new CreateReportFundsExpendituresCategoryLocalizationDto
+        {
+            EntityId = 0,
+            LanguageId = 0,
+            Name = ""
+        };
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresCategoryLocalizationCommand(invalidDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("EntityId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("LanguageId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("Name is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new KeyNotFoundException("Entity not found"));
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Entity not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(ReportFundsExpendituresCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new DbUpdateException());
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(ReportFundsExpendituresCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalizationDto>(_entity)).Returns(_responseDto);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity)).ReturnsAsync(_entity);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/DeleteReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/DeleteReportFundsExpendituresCategoryLocalizationTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Delete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresCategories;
+
+public class DeleteReportFundsExpendituresCategoryLocalizationTests
+{
+    private readonly Mock<ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization>> _mockLocalizationService;
+    private readonly DeleteReportFundsExpendituresCategoryLocalizationHandler _handler;
+
+    private readonly long _entityId = 1;
+    private readonly long _languageId = 2;
+
+    public DeleteReportFundsExpendituresCategoryLocalizationTests()
+    {
+        _mockLocalizationService = new Mock<ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization>>();
+        _handler = new DeleteReportFundsExpendituresCategoryLocalizationHandler(_mockLocalizationService.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteLocalization_Successfully()
+    {
+        _mockLocalizationService
+            .Setup(x => x.DeleteEntityLocalizationAsync(_entityId, _languageId))
+            .ReturnsAsync((_entityId, _languageId));
+
+        var command = new DeleteReportFundsExpendituresCategoryLocalizationCommand(_entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_entityId, result.Value.EntityId);
+        Assert.Equal(_languageId, result.Value.LanguageId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockLocalizationService
+            .Setup(x => x.DeleteEntityLocalizationAsync(_entityId, _languageId))
+            .ThrowsAsync(new KeyNotFoundException("Localization not found"));
+
+        var command = new DeleteReportFundsExpendituresCategoryLocalizationCommand(_entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Localization not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockLocalizationService
+            .Setup(x => x.DeleteEntityLocalizationAsync(_entityId, _languageId))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new DeleteReportFundsExpendituresCategoryLocalizationCommand(_entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntity(typeof(ReportFundsExpendituresCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockLocalizationService
+            .Setup(x => x.DeleteEntityLocalizationAsync(_entityId, _languageId))
+            .ThrowsAsync(new DbUpdateException());
+
+        var command = new DeleteReportFundsExpendituresCategoryLocalizationCommand(_entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntityInDatabase(typeof(ReportFundsExpendituresCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/GetReportFundsExpendituresCategoryLocalizationByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/GetReportFundsExpendituresCategoryLocalizationByEntityIdTests.cs
@@ -1,0 +1,104 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresCategories.GetByEntityId;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresCategories;
+
+public class GetReportFundsExpendituresCategoryLocalizationByEntityIdTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly GetReportFundsExpendituresCategoryLocalizationByEntityIdHandler _handler;
+
+    private readonly List<ReportFundsExpendituresCategoryLocalization> _entities = new()
+    {
+        new ReportFundsExpendituresCategoryLocalization
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            Name = "English Name",
+            Language = new LocalizationLanguage { Id = 2, Code = "en", CreatedAt = DateTimeOffset.UtcNow },
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        new ReportFundsExpendituresCategoryLocalization
+        {
+            EntityId = 1,
+            LanguageId = 3,
+            Name = "German Name",
+            Language = new LocalizationLanguage { Id = 3, Code = "de", CreatedAt = DateTimeOffset.UtcNow },
+            CreatedAt = DateTimeOffset.UtcNow
+        }
+    };
+
+    private readonly List<ReportFundsExpendituresCategoryLocalizationDto> _dtos = new()
+    {
+        new ReportFundsExpendituresCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+            Name = "English Name"
+        },
+        new ReportFundsExpendituresCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LocalizationInfoDto = new LocalizationInfoDto { Id = 3, Code = "de" },
+            Name = "German Name"
+        }
+    };
+
+    public GetReportFundsExpendituresCategoryLocalizationByEntityIdTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _handler = new GetReportFundsExpendituresCategoryLocalizationByEntityIdHandler(
+            _mockMapper.Object, _mockRepositoryWrapper.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnLocalizations_WhenEntityIdExists()
+    {
+        SetupRepositoryWrapper(_entities);
+        SetupMapper(_dtos);
+
+        var query = new GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery(1);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(2, result.Value.Count);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenEntityIdDoesNotExist()
+    {
+        SetupRepositoryWrapper(new List<ReportFundsExpendituresCategoryLocalization>());
+        SetupMapper(new List<ReportFundsExpendituresCategoryLocalizationDto>());
+
+        var query = new GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery(999);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    private void SetupRepositoryWrapper(IEnumerable<ReportFundsExpendituresCategoryLocalization> entitiesToReturn)
+    {
+        _mockRepositoryWrapper
+            .Setup(repo => repo.ReportFundsExpendituresCategoryLocalizationsRepository
+                .GetAllAsync(It.IsAny<QueryOptions<ReportFundsExpendituresCategoryLocalization>>()))
+            .ReturnsAsync(entitiesToReturn);
+    }
+
+    private void SetupMapper(IEnumerable<ReportFundsExpendituresCategoryLocalizationDto> dtosToReturn)
+    {
+        _mockMapper
+            .Setup(m => m.Map<List<ReportFundsExpendituresCategoryLocalizationDto>>(
+                It.IsAny<IEnumerable<ReportFundsExpendituresCategoryLocalization>>()))
+            .Returns(dtosToReturn.ToList());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryLocalizationTests.cs
@@ -1,0 +1,133 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresCategories;
+
+public class UpdateReportFundsExpendituresCategoryLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization>> _mockLocalizationService;
+    private readonly IValidator<UpdateReportFundsExpendituresCategoryLocalizationCommand> _validator;
+    private readonly UpdateReportFundsExpendituresCategoryLocalizationHandler _handler;
+
+    private readonly long _entityId = 1;
+    private readonly long _languageId = 2;
+
+    private readonly UpdateReportFundsExpendituresCategoryLocalizationDto _updateDto = new()
+    {
+        Name = "Updated English Name"
+    };
+
+    private readonly ReportFundsExpendituresCategoryLocalization _entity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Updated English Name",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" }
+    };
+
+    private readonly ReportFundsExpendituresCategoryLocalizationDto _responseDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        Name = "Updated English Name"
+    };
+
+    public UpdateReportFundsExpendituresCategoryLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization>>();
+        _validator = new UpdateReportFundsExpendituresCategoryLocalizationValidator(
+            new BaseReportFundsExpendituresCategoryLocalizationValidator());
+        _handler = new UpdateReportFundsExpendituresCategoryLocalizationHandler(
+            _mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var command = new UpdateReportFundsExpendituresCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_responseDto.Name, result.Value.Name);
+        Assert.Equal(_entityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var invalidDto = new UpdateReportFundsExpendituresCategoryLocalizationDto { Name = "" };
+        var command = new UpdateReportFundsExpendituresCategoryLocalizationCommand(invalidDto, _entityId, _languageId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Name is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new KeyNotFoundException("Localization not found"));
+
+        var command = new UpdateReportFundsExpendituresCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Localization not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new UpdateReportFundsExpendituresCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(ReportFundsExpendituresCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new DbUpdateException());
+
+        var command = new UpdateReportFundsExpendituresCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(ReportFundsExpendituresCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresCategoryLocalizationDto>(_entity)).Returns(_responseDto);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity)).ReturnsAsync(_entity);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryLocalizationValidatorTests.cs
@@ -1,0 +1,60 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresCategories;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.ReportFundsExpendituresCategories;
+
+public class BaseReportFundsExpendituresCategoryLocalizationValidatorTests
+{
+    private readonly BaseReportFundsExpendituresCategoryLocalizationValidator _validator;
+
+    public BaseReportFundsExpendituresCategoryLocalizationValidatorTests()
+    {
+        _validator = new BaseReportFundsExpendituresCategoryLocalizationValidator();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_ShouldHaveError_WhenName_IsNullOrEmpty(string? name)
+    {
+        var model = new UpdateReportFundsExpendituresCategoryLocalizationDto { Name = name! };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenName_IsTooShort()
+    {
+        var model = new UpdateReportFundsExpendituresCategoryLocalizationDto
+        {
+            Name = new string('a', ReportFundsExpendituresCategoryLocalizationConstants.NameMinLength - 1)
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenName_IsTooLong()
+    {
+        var model = new UpdateReportFundsExpendituresCategoryLocalizationDto
+        {
+            Name = new string('a', ReportFundsExpendituresCategoryLocalizationConstants.NameMaxLength + 1)
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenModel_IsValid()
+    {
+        var model = new UpdateReportFundsExpendituresCategoryLocalizationDto
+        {
+            Name = "Valid Name"
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.Name);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/ReportFundsExpendituresCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/ReportFundsExpendituresCategoryLocalizationsController.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Delete;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresCategories.Update;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresCategories.GetByEntityId;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin.Localization;
+
+public class ReportFundsExpendituresCategoryLocalizationsController : AuthorizedApiController
+{
+    [HttpGet("{entityId:long}")]
+    [ProducesResponseType(typeof(List<ReportFundsExpendituresCategoryLocalizationDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetReportFundsExpendituresCategoryLocalizations(
+        [FromRoute] long entityId)
+    {
+        return HandleResult(await Mediator.Send(
+            new GetReportFundsExpendituresCategoryLocalizationByEntityIdQuery(entityId)));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ReportFundsExpendituresCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateReportFundsExpendituresCategoryLocalization(
+        [FromBody] CreateReportFundsExpendituresCategoryLocalizationDto createDto)
+    {
+        return HandleResult(await Mediator.Send(
+            new CreateReportFundsExpendituresCategoryLocalizationCommand(createDto)));
+    }
+
+    [HttpPut("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(ReportFundsExpendituresCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateReportFundsExpendituresCategoryLocalization(
+        [FromBody] UpdateReportFundsExpendituresCategoryLocalizationDto updateDto,
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(
+            new UpdateReportFundsExpendituresCategoryLocalizationCommand(updateDto, EntityId, LanguageId)));
+    }
+
+    [HttpDelete("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(DeleteReportFundsExpendituresCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteReportFundsExpendituresCategoryLocalization(
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(
+            new DeleteReportFundsExpendituresCategoryLocalizationCommand(EntityId, LanguageId)));
+    }
+}


### PR DESCRIPTION
# GitHub Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2469


## Summary of issue

Implement localization support for report categories, enabling CRUD operations for category translations.

## Summary of change

Added support for category localization at the data level:
  - Created localization entity and configuration
  - Updated category entity to include localizations
  - Added DbSet and generated migration
Implemented repository layer for localization management
Added DTOs for CRUD operations
Implemented business logic:
  - Create, update, delete commands
  - Query for retrieving localizations
  - Validation rules and constants
Configured mappings between entities and DTOs
Added API controller for managing category localizations
Covered functionality with unit and integration tests

## Testing approach

Unit tests:
- Validators (create/update)
- Command and query handlers
Integration tests:
- Controller endpoints (CRUD operations)
- Verified correct behavior for valid and invalid scenarios
Manual verification:
- Ensured localizations are created, updated, retrieved, and deleted correctly
- Verified integration with existing category logic

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language localization support for Report Funds Expenditures Categories with new API endpoints enabling creation, retrieval, updating, and deletion of localized category entries across different languages.
  * Localization entries include comprehensive validation for category names and proper error handling for invalid requests or missing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->