### PR TITLE
Feature/issue 2470

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportProgramExpendituresRecords/ReportProgramExpendituresSummaryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportProgramExpendituresRecords/ReportProgramExpendituresSummaryDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
+
+public record ReportProgramExpendituresSummaryDto
+{
+    public decimal TotalAmountUah { get; init; }
+
+    public decimal TotalAmountUsd { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportProgramExpendituresRecords/GetSummary/GetReportProgramExpendituresSummaryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportProgramExpendituresRecords/GetSummary/GetReportProgramExpendituresSummaryHandler.cs
@@ -1,0 +1,31 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Queries.Admin.ReportProgramExpendituresRecords.GetSummary;
+
+public class GetReportProgramExpendituresSummaryHandler
+    : IRequestHandler<GetReportProgramExpendituresSummaryQuery, Result<ReportProgramExpendituresSummaryDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetReportProgramExpendituresSummaryHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<ReportProgramExpendituresSummaryDto>> Handle(
+        GetReportProgramExpendituresSummaryQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (totalAmountUah, totalAmountUsd) =
+            await _repositoryWrapper.ReportProgramExpendituresRecordsRepository.GetSummaryAsync();
+
+        return Result.Ok(new ReportProgramExpendituresSummaryDto
+        {
+            TotalAmountUah = totalAmountUah,
+            TotalAmountUsd = totalAmountUsd,
+        });
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportProgramExpendituresRecords/GetSummary/GetReportProgramExpendituresSummaryQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportProgramExpendituresRecords/GetSummary/GetReportProgramExpendituresSummaryQuery.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
+
+namespace VictoryCenter.BLL.Queries.Admin.ReportProgramExpendituresRecords.GetSummary;
+
+public record GetReportProgramExpendituresSummaryQuery
+    : IRequest<Result<ReportProgramExpendituresSummaryDto>>;

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/ReportProgramExpendituresRecords/IReportProgramExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/ReportProgramExpendituresRecords/IReportProgramExpendituresRecordsRepository.cs
@@ -6,4 +6,6 @@ namespace VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRec
 public interface IReportProgramExpendituresRecordsRepository : IRepositoryBase<ReportProgramExpendituresRecord>
 {
     Task<bool> RecordWithinSameCategoryWithSameYearExistsAsync(ReportProgramExpendituresRecord record);
+
+    Task<(decimal TotalAmountUah, decimal TotalAmountUsd)> GetSummaryAsync();
 }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportProgramExpendituresRecords/ReportProgramExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/ReportProgramExpendituresRecords/ReportProgramExpendituresRecordsRepository.cs
@@ -9,6 +9,8 @@ namespace VictoryCenter.DAL.Repositories.Realizations.ReportProgramExpendituresR
 public class ReportProgramExpendituresRecordsRepository : RepositoryBase<ReportProgramExpendituresRecord>,
     IReportProgramExpendituresRecordsRepository
 {
+    private readonly record struct Summary(decimal TotalAmountUah, decimal TotalAmountUsd);
+
     public ReportProgramExpendituresRecordsRepository(VictoryCenterDbContext context)
         : base(context)
     {
@@ -21,5 +23,21 @@ public class ReportProgramExpendituresRecordsRepository : RepositoryBase<ReportP
             .AnyAsync(e =>
                 e.HippotherapyProgramCategoryId == record.HippotherapyProgramCategoryId &&
                 e.ReportingYear == record.ReportingYear);
+    }
+
+    public async Task<(decimal TotalAmountUah, decimal TotalAmountUsd)> GetSummaryAsync()
+    {
+        var summary = await DbContext
+            .ReportProgramExpendituresRecords
+            .AsNoTracking()
+            .GroupBy(_ => 1)
+            .Select(group => new Summary(
+                group.Sum(record => record.AmountUah),
+                group.Sum(record => record.AmountUsd)))
+            .FirstOrDefaultAsync();
+
+        return (
+            Math.Round(summary.TotalAmountUah, 2, MidpointRounding.AwayFromZero),
+            Math.Round(summary.TotalAmountUsd, 2, MidpointRounding.AwayFromZero));
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/GetSummary/GetReportProgramExpendituresSummaryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportProgramExpendituresRecords/GetSummary/GetReportProgramExpendituresSummaryTests.cs
@@ -1,0 +1,86 @@
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.ReportProgramExpendituresRecords.GetSummary;
+
+public class GetReportProgramExpendituresSummaryTests : BaseTestClass
+{
+    private const string Endpoint = "/api/ReportProgramExpendituresRecords/summary";
+
+    public GetReportProgramExpendituresSummaryTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetSummary_ShouldReturnRoundedTotals()
+    {
+        // Arrange
+        await SeedProgramExpendituresRecordsAsync(
+            (100.125m, 10.124m),
+            (200.235m, 20.235m));
+
+        // Act
+        var responseContent = await GetSummaryAsync();
+
+        // Assert
+        Assert.Equal(300.36m, responseContent.TotalAmountUah);
+        Assert.Equal(30.36m, responseContent.TotalAmountUsd);
+    }
+
+    [Fact]
+    public async Task GetSummary_ShouldReturnZeroTotals_WhenRecordsDoNotExist()
+    {
+        // Act
+        var responseContent = await GetSummaryAsync();
+
+        // Assert
+        Assert.Equal(0m, responseContent.TotalAmountUah);
+        Assert.Equal(0m, responseContent.TotalAmountUsd);
+    }
+
+    private async Task<ReportProgramExpendituresSummaryDto> GetSummaryAsync()
+    {
+        var response = await Fixture.HttpClient.GetAsync(Endpoint);
+        response.EnsureSuccessStatusCode();
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var responseContent =
+            JsonConvert.DeserializeObject<ReportProgramExpendituresSummaryDto>(responseString);
+
+        Assert.NotNull(responseContent);
+
+        return responseContent!;
+    }
+
+    private async Task SeedProgramExpendituresRecordsAsync(params (decimal AmountUah, decimal AmountUsd)[] amounts)
+    {
+        var categories = amounts
+            .Select((_, index) => new HippotherapyProgramCategory
+            {
+                Name = $"Summary program category {Guid.NewGuid()} {index}",
+                CreatedAt = DateTimeOffset.UtcNow
+            })
+            .ToArray();
+
+        await Fixture.DbContext.HippotherapyProgramCategories.AddRangeAsync(categories);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var records = categories
+            .Select((category, index) => new ReportProgramExpendituresRecord
+            {
+                HippotherapyProgramCategoryId = category.Id,
+                ReportingYear = 2025,
+                AmountUah = amounts[index].AmountUah,
+                AmountUsd = amounts[index].AmountUsd,
+                CreatedAt = DateTimeOffset.UtcNow
+            })
+            .ToArray();
+
+        await Fixture.DbContext.ReportProgramExpendituresRecords.AddRangeAsync(records);
+        await Fixture.DbContext.SaveChangesAsync();
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/GetReportProgramExpendituresSummaryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/GetReportProgramExpendituresSummaryTests.cs
@@ -1,0 +1,54 @@
+using Moq;
+using VictoryCenter.BLL.Queries.Admin.ReportProgramExpendituresRecords.GetSummary;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportProgramExpendituresRecords;
+
+public class GetReportProgramExpendituresSummaryTests
+{
+    private readonly Mock<IReportProgramExpendituresRecordsRepository> _recordsRepositoryMock;
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+
+    public GetReportProgramExpendituresSummaryTests()
+    {
+        _recordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSummary()
+    {
+        // Arrange
+        SetupSummary(125000.50m, 3012.25m);
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(
+            new GetReportProgramExpendituresSummaryQuery(),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(125000.50m, result.Value.TotalAmountUah);
+        Assert.Equal(3012.25m, result.Value.TotalAmountUsd);
+
+        _recordsRepositoryMock.Verify(repository => repository.GetSummaryAsync(), Times.Once);
+    }
+
+    private GetReportProgramExpendituresSummaryHandler CreateHandler()
+    {
+        return new GetReportProgramExpendituresSummaryHandler(_repositoryWrapperMock.Object);
+    }
+
+    private void SetupSummary(decimal totalAmountUah, decimal totalAmountUsd)
+    {
+        _repositoryWrapperMock
+            .SetupGet(wrapper => wrapper.ReportProgramExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+
+        _recordsRepositoryMock
+            .Setup(repository => repository.GetSummaryAsync())
+            .ReturnsAsync((totalAmountUah, totalAmountUsd));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportProgramExpendituresRecordsController.cs
@@ -5,6 +5,7 @@ using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Update;
 using VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Delete;
 using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
 using VictoryCenter.BLL.Queries.Admin.ReportProgramExpendituresRecords.GetAll;
+using VictoryCenter.BLL.Queries.Admin.ReportProgramExpendituresRecords.GetSummary;
 using VictoryCenter.WebAPI.Controllers.Common;
 
 namespace VictoryCenter.WebAPI.Controllers.Admin;
@@ -42,6 +43,13 @@ public class ReportProgramExpendituresRecordsController : AuthorizedApiControlle
     {
         return HandleResult(await Mediator.Send(
             new GetAllReportProgramExpendituresRecordsQuery(hippotherapyProgramCategoryIds)));
+    }
+
+    [HttpGet("summary")]
+    [ProducesResponseType(typeof(ReportProgramExpendituresSummaryDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetReportProgramExpendituresSummaryAsync()
+    {
+        return HandleResult(await Mediator.Send(new GetReportProgramExpendituresSummaryQuery()));
     }
 
     [HttpPost("bulk-delete")]


### PR DESCRIPTION
## GitHub Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2470


## Description
Adds GET `/api/ReportProgramExpendituresRecords/summary` to return total program expenses in UAH and USD, rounded to 2 decimal places. Adds DTO, MediatR query/handler, repository aggregation, controller action, unit test, and integration tests.

```json
{
  "method": "GET",
  "path": "/api/ReportProgramExpendituresRecords/summary",
  "response": {
    "totalAmountUah": 300.36,
    "totalAmountUsd": 30.36
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve program expenditure summaries, displaying total expenditure amounts in both Ukrainian hryvnia (UAH) and US dollars (USD) with proper rounding applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->