### PR TITLE
Feature/issue 2509-2510 - [Main] Add opportunity to change visibility and reorder metrics

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ReorderMetrics/ReorderMetricsCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ReorderMetrics/ReorderMetricsCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+namespace VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ReorderMetrics;
+
+public record ReorderMetricsCommand(ReorderMetricsDto ReorderDto)
+    : IRequest<Result<Unit>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ReorderMetrics/ReorderMetricsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ReorderMetrics/ReorderMetricsHandler.cs
@@ -1,0 +1,54 @@
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Exceptions.ReorderExceptions;
+using VictoryCenter.BLL.Interfaces.ReorderService;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ReorderMetrics;
+
+public class ReorderMetricsHandler : IRequestHandler<ReorderMetricsCommand, Result<Unit>>
+{
+    private readonly IValidator<ReorderMetricsCommand> _validator;
+    private readonly IReorderService _reorderService;
+
+    public ReorderMetricsHandler(
+        IValidator<ReorderMetricsCommand> validator,
+        IReorderService reorderService)
+    {
+        _validator = validator;
+        _reorderService = reorderService;
+    }
+
+    public async Task<Result<Unit>> Handle(ReorderMetricsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var orderedIds = request.ReorderDto.OrderedIds;
+            var statisticId = request.ReorderDto.StatisticId;
+
+            await _reorderService.SwapElementsAsync<Metric>(
+                idsOrder: orderedIds,
+                idSelector: e => e.Id,
+                groupSelector: e => e.StatisticId == statisticId);
+
+            return Result.Ok();
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<Unit>(ex.Message);
+        }
+        catch (ReorderException ex)
+        {
+            return Result.Fail(ReorderConstants.ErrorWithReordering(ex.Message));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<Unit>(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(Metric)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ToggleMetricVisibility/ToggleMetricVisibilityCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ToggleMetricVisibility/ToggleMetricVisibilityCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+namespace VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ToggleMetricVisibility;
+
+public record ToggleMetricVisibilityCommand(long MetricId, UpdateMetricVisibilityDto Dto)
+    : IRequest<Result<Unit>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ToggleMetricVisibility/ToggleMetricVisibilityHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ImpactStatistics/ToggleMetricVisibility/ToggleMetricVisibilityHandler.cs
@@ -1,0 +1,39 @@
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.MainPage;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ToggleMetricVisibility;
+
+public class ToggleMetricVisibilityHandler : IRequestHandler<ToggleMetricVisibilityCommand, Result<Unit>>
+{
+    private readonly IMetricVisibilityService _metricVisibilityService;
+
+    public ToggleMetricVisibilityHandler(IMetricVisibilityService metricVisibilityService)
+    {
+        _metricVisibilityService = metricVisibilityService;
+    }
+
+    public async Task<Result<Unit>> Handle(ToggleMetricVisibilityCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _metricVisibilityService.ToggleMetricVisibilityAsync(request.MetricId, request.Dto.IsHidden);
+            return Result.Ok();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Result.Fail<Unit>(ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Result.Fail<Unit>(ex.Message);
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<Unit>(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(Metric)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -206,8 +206,8 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
             }
         }
 
-        long nextPriority = stat.Metrics.Any() 
-            ? stat.Metrics.Max(m => m.Priority) + 1 
+        long nextPriority = stat.Metrics.Any()
+            ? stat.Metrics.Max(m => m.Priority) + 1
             : 1;
 
         foreach (var metricDto in metricsDto)
@@ -224,7 +224,7 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
                 var newMetric = _mapper.Map<Metric>(metricDto);
                 newMetric.Statistics = stat;
 
-                newMetric.Priority = nextPriority++; 
+                newMetric.Priority = nextPriority++;
 
                 stat.Metrics.Add(newMetric);
             }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -206,6 +206,10 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
             }
         }
 
+        long nextPriority = stat.Metrics.Any() 
+            ? stat.Metrics.Max(m => m.Priority) + 1 
+            : 1;
+
         foreach (var metricDto in metricsDto)
         {
             if (metricDto.Id.HasValue && existingMetricsById.TryGetValue(metricDto.Id.Value, out var existingMetric))
@@ -219,6 +223,9 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
             {
                 var newMetric = _mapper.Map<Metric>(metricDto);
                 newMetric.Statistics = stat;
+
+                newMetric.Priority = nextPriority++; 
+
                 stat.Metrics.Add(newMetric);
             }
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -12,6 +12,7 @@ using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
+using ImpactStatisticsEntity = VictoryCenter.DAL.Entities.ImpactStatistics;
 using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
 
 namespace VictoryCenter.BLL.Commands.Admin.MainPage.Update;
@@ -181,7 +182,7 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
 
         if (entity.ImpactStatistics is null)
         {
-            entity.ImpactStatistics = _mapper.Map<ImpactStatistics>(statDto);
+            entity.ImpactStatistics = _mapper.Map<ImpactStatisticsEntity>(statDto);
             entity.ImpactStatistics.MainPageId = entity.Id;
             return;
         }
@@ -192,7 +193,7 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
         SyncMetrics(entity.ImpactStatistics, statDto.Metrics);
     }
 
-    private void SyncMetrics(ImpactStatistics stat, ICollection<UpdateMetricDto> metricsDto)
+    private void SyncMetrics(ImpactStatisticsEntity stat, ICollection<UpdateMetricDto> metricsDto)
     {
         var existingMetricsById = stat.Metrics.ToDictionary(m => m.Id);
         var requestMetricIds = metricsDto.Where(m => m.Id.HasValue).Select(m => m.Id!.Value).ToHashSet();

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
@@ -10,5 +10,6 @@ public record MetricDto
     public string Name { get; init; } = null!;
     public MetricType Type { get; init; }
     public MetricPrefix? Prefix { get; init; }
+    public bool IsHidden { get; init; }
     public ICollection<MetricLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
@@ -11,5 +11,6 @@ public record MetricDto
     public MetricType Type { get; init; }
     public MetricPrefix? Prefix { get; init; }
     public bool IsHidden { get; init; }
+    public long Priority { get; init; }
     public ICollection<MetricLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/ReorderMetricsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/ReorderMetricsDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+public record ReorderMetricsDto : BaseReorderDto
+{
+    public long StatisticId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/UpdateMetricVisibilityDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/UpdateMetricVisibilityDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+
+public record UpdateMetricVisibilityDto
+{
+    public bool IsHidden { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/MainPage/IMetricVisibilityService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/MainPage/IMetricVisibilityService.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.Interfaces.MainPage;
+
+public interface IMetricVisibilityService
+{
+    Task ToggleMetricVisibilityAsync(long id, bool isHidden);
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/MainPage/MainPageProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/MainPage/MainPageProfile.cs
@@ -49,12 +49,14 @@ public class MainPageProfile : Profile
             .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
             .ForMember(dest => dest.StatisticId, opt => opt.Ignore())
             .ForMember(dest => dest.Statistics, opt => opt.Ignore())
+            .ForMember(dest => dest.Priority, opt => opt.Ignore())
             .ForMember(dest => dest.Localizations, opt => opt.Ignore());
 
         CreateMap<MainPageEntity, MainPageDto>();
         CreateMap<MainAboutUs, MainAboutUsDto>();
         CreateMap<MainPartners, MainPartnersDto>();
-        CreateMap<ImpactStatistics, ImpactStatisticDto>();
+        CreateMap<ImpactStatistics, ImpactStatisticDto>()
+            .ForMember(dest => dest.Metrics, opt => opt.MapFrom(src => src.Metrics.OrderBy(m => m.Priority)));
         CreateMap<Metric, MetricDto>();
 
         CreateMap<UpdateMainPageDto, MainPageEntity>()
@@ -79,6 +81,7 @@ public class MainPageProfile : Profile
             .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
             .ForMember(dest => dest.StatisticId, opt => opt.Ignore())
             .ForMember(dest => dest.Statistics, opt => opt.Ignore())
+            .ForMember(dest => dest.Priority, opt => opt.Ignore())
             .ForMember(dest => dest.Localizations, opt => opt.Ignore());
 
         CreateMap<ImpactStatisticsLocalization, ImpactStatisticLocalizationDto>();

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -33,7 +33,7 @@ public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainP
                     .Include(e => e.MainPartners).ThenInclude(p => p!.Localizations).ThenInclude(l => l.Language)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Image)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Localizations)
-                    .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics.Where(m => !m.IsHidden)).ThenInclude(m => m.Localizations),
+                    .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics.Where(m => !m.IsHidden).OrderBy(m => m.Priority)).ThenInclude(m => m.Localizations),
                 AsNoTracking = true
             });
 

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -33,7 +33,7 @@ public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainP
                     .Include(e => e.MainPartners).ThenInclude(p => p!.Localizations).ThenInclude(l => l.Language)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Image)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Localizations)
-                    .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics).ThenInclude(m => m.Localizations),
+                    .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics.Where(m => !m.IsHidden)).ThenInclude(m => m.Localizations),
                 AsNoTracking = true
             });
 

--- a/VictoryCenter/VictoryCenter.BLL/Services/MainPage/MetricVisibilityService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/MainPage/MetricVisibilityService.cs
@@ -1,0 +1,58 @@
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Interfaces.MainPage;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Services.MainPage;
+
+public class MetricVisibilityService : IMetricVisibilityService
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public MetricVisibilityService(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task ToggleMetricVisibilityAsync(long id, bool isHidden)
+    {
+        var metricRepository = _repositoryWrapper.GetRepository<Metric>();
+
+        var metric = await metricRepository.GetFirstOrDefaultAsync(new QueryOptions<Metric>
+        {
+            Filter = m => m.Id == id
+        });
+
+        if (metric is null)
+        {
+            throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(id, typeof(Metric)));
+        }
+
+        if (metric.IsHidden == isHidden)
+        {
+            return;
+        }
+
+        if (isHidden)
+        {
+            var visibleCount = await metricRepository.CountAsync(new QueryOptions<Metric>
+            {
+                Filter = m => m.StatisticId == metric.StatisticId && !m.IsHidden
+            });
+
+            if (visibleCount <= 1)
+            {
+                throw new InvalidOperationException("Cannot hide the last visible metric in the block.");
+            }
+        }
+
+        metric.IsHidden = isHidden;
+        metricRepository.Update(metric);
+
+        if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+        {
+            throw new InvalidOperationException(ErrorMessagesConstants.FailedToUpdateEntity(typeof(Metric)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Services/MainPage/MetricVisibilityService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/MainPage/MetricVisibilityService.cs
@@ -17,6 +17,8 @@ public class MetricVisibilityService : IMetricVisibilityService
 
     public async Task ToggleMetricVisibilityAsync(long id, bool isHidden)
     {
+        using var transaction = _repositoryWrapper.BeginTransaction();
+
         var metricRepository = _repositoryWrapper.GetRepository<Metric>();
 
         var metric = await metricRepository.GetFirstOrDefaultAsync(new QueryOptions<Metric>
@@ -54,5 +56,7 @@ public class MetricVisibilityService : IMetricVisibilityService
         {
             throw new InvalidOperationException(ErrorMessagesConstants.FailedToUpdateEntity(typeof(Metric)));
         }
+
+        transaction.Complete();
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Commands/ReorderMetricsCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Commands/ReorderMetricsCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ReorderMetrics;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Commands;
+
+public class ReorderMetricsCommandValidator : AbstractValidator<ReorderMetricsCommand>
+{
+    public ReorderMetricsCommandValidator()
+    {
+        RuleFor(x => x.ReorderDto)
+            .NotNull()
+            .WithMessage(x => "Reorder metrics data cannot be null.")
+            .SetValidator(new ReorderMetricsDtoValidator()!);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/ReorderMetricsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/ReorderMetricsDtoValidator.cs
@@ -8,7 +8,7 @@ namespace VictoryCenter.BLL.Validators.MainPage.Dto;
 public class ReorderMetricsDtoValidator : BaseReorderValidator<ReorderMetricsDto>
 {
     public ReorderMetricsDtoValidator()
-        : base(MainPageConstants.ExactMetricCount)
+        : base(MainPageConstants.ImpactStatistic.ExactMetricCount)
     {
         RuleFor(x => x.StatisticId)
             .GreaterThan(0)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/ReorderMetricsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/ReorderMetricsDtoValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.Validators.Common;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class ReorderMetricsDtoValidator : BaseReorderValidator<ReorderMetricsDto>
+{
+    public ReorderMetricsDtoValidator()
+        : base(MainPageConstants.ExactMetricCount)
+    {
+        RuleFor(x => x.StatisticId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(ReorderMetricsDto.StatisticId)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
@@ -37,5 +37,10 @@ internal class MetricConfig : IEntityTypeConfiguration<Metric>
         entity
             .Property(e => e.CreatedAt)
             .IsRequired();
+
+        entity
+            .Property(e => e.isHidden)
+            .IsRequired()
+            .HasDefaultValue(false);
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
@@ -42,5 +42,9 @@ internal class MetricConfig : IEntityTypeConfiguration<Metric>
             .Property(e => e.IsHidden)
             .IsRequired()
             .HasDefaultValue(false);
+
+        entity
+            .Property(e => e.Priority)
+            .IsRequired();
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
@@ -39,7 +39,7 @@ internal class MetricConfig : IEntityTypeConfiguration<Metric>
             .IsRequired();
 
         entity
-            .Property(e => e.isHidden)
+            .Property(e => e.IsHidden)
             .IsRequired()
             .HasDefaultValue(false);
     }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
@@ -5,7 +5,7 @@ using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.DAL.Entities;
 
-public class Metric : BaseEntity, ITranslatedEntity<MetricLocalization>
+public class Metric : BaseEntity, ITranslatedEntity<MetricLocalization>, IOrderableEntity
 {
     public long StatisticId { get; set; }
     public ImpactStatistics Statistics { get; set; } = null!;
@@ -14,5 +14,6 @@ public class Metric : BaseEntity, ITranslatedEntity<MetricLocalization>
     public MetricType Type { get; set; }
     public MetricPrefix? Prefix { get; set; }
     public bool IsHidden { get; set; }
+    public long Priority { get; set; }
     public ICollection<MetricLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
@@ -13,5 +13,6 @@ public class Metric : BaseEntity, ITranslatedEntity<MetricLocalization>
     public string Name { get; set; } = null!;
     public MetricType Type { get; set; }
     public MetricPrefix? Prefix { get; set; }
+    public bool IsHidden { get; set; }
     public ICollection<MetricLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260511165323_AddIsHiddenToMetric.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260511165323_AddIsHiddenToMetric.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511165323_AddIsHiddenToMetric")]
+    partial class AddIsHiddenToMetric
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260511165323_AddIsHiddenToMetric.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260511165323_AddIsHiddenToMetric.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsHiddenToMetric : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260511190421_AddPriorityToMetrics.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260511190421_AddPriorityToMetrics.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511190421_AddPriorityToMetrics")]
+    partial class AddPriorityToMetrics
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260511190421_AddPriorityToMetrics.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260511190421_AddPriorityToMetrics.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriorityToMetrics : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsHidden",
+                table: "Metrics",
+                type: "bit",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "bit");
+
+            migrationBuilder.AddColumn<long>(
+                name: "Priority",
+                table: "Metrics",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Priority",
+                table: "Metrics");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsHidden",
+                table: "Metrics",
+                type: "bit",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "bit",
+                oldDefaultValue: false);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -92,6 +92,7 @@ public interface IRepositoryWrapper
     IMainPartnersLocalizationsRepository MainPartnersLocalizationsRepository { get; }
     IImpactStatisticsRepository ImpactStatisticsRepository { get; }
     IImpactStatisticsLocalizationsRepository ImpactStatisticsLocalizationsRepository { get; }
+    IMetricRepository MetricRepository { get; }
     IMetricLocalizationsRepository MetricLocalizationsRepository { get; }
     IHistorySectionsRepository HistorySectionsRepository { get; }
     IHistorySectionContentsRepository HistorySectionContentsRepository { get; }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMetricRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMetricRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+
+public interface IMetricRepository : IRepositoryBase<Metric>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -121,6 +121,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IMainPartnersLocalizationsRepository? _mainPartnersLocalizationsRepository;
     private IImpactStatisticsRepository? _impactStatisticsRepository;
     private IImpactStatisticsLocalizationsRepository? _impactStatisticsLocalizationsRepository;
+    private IMetricRepository? _metricRepository;
     private IMetricLocalizationsRepository? _metricLocalizationsRepository;
     private IHistorySectionsRepository? _historySectionsRepository;
     private IHistorySectionContentsRepository? _historySectionContentsRepository;
@@ -284,6 +285,9 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public IImpactStatisticsLocalizationsRepository ImpactStatisticsLocalizationsRepository =>
         _impactStatisticsLocalizationsRepository ??= new ImpactStatisticsLocalizationsRepository(_victoryCenterDbContext);
+
+    public IMetricRepository MetricRepository =>
+        _metricRepository ??= new MetricRepository(_victoryCenterDbContext);
 
     public IMetricLocalizationsRepository MetricLocalizationsRepository =>
         _metricLocalizationsRepository ??= new MetricLocalizationsRepository(_victoryCenterDbContext);

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MetricRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MetricRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.MainPage;
+
+public class MetricRepository : RepositoryBase<Metric>, IMetricRepository
+{
+    public MetricRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
+++ b/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
@@ -6,7 +6,7 @@ using VictoryCenter.DbUpdate;
 
 try
 {
-    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebApi"));
+    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebAPI"));
 
     DotEnv.Load(new DotEnvOptions(envFilePaths: new[] { Path.Combine(webApiProjectPath, ".env") }));
 

--- a/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
+++ b/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
@@ -6,7 +6,7 @@ using VictoryCenter.DbUpdate;
 
 try
 {
-    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebAPI"));
+    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebApi"));
 
     DotEnv.Load(new DotEnvOptions(envFilePaths: new[] { Path.Combine(webApiProjectPath, ".env") }));
 

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/ReorderMetrics/ReorderMetricsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/ReorderMetrics/ReorderMetricsTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.ReorderMetrics;
+
+public class ReorderMetricsTests : BaseTestClass
+{
+    private readonly Uri _endpointUri = new("/api/MainPage/metrics/reorder", UriKind.Relative);
+
+    public ReorderMetricsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ReorderMetrics_WithValidOrder_ShouldReturnOkAndChangePriority()
+    {
+        // Arrange
+        var targetStatistic = await EnsureImpactStatisticsExistsAsync();
+
+        var orderedIds = targetStatistic.Metrics.OrderBy(m => m.Priority).Select(m => m.Id).ToList();
+
+        orderedIds.Reverse();
+
+        var reorderDto = new ReorderMetricsDto
+        {
+            StatisticId = targetStatistic.Id,
+            OrderedIds = orderedIds
+        };
+        var serializedDto = JsonSerializer.Serialize(reorderDto);
+        var content = new StringContent(serializedDto, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync(_endpointUri, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        var metricsAfterReorder = await Fixture.DbContext.Metrics
+            .Where(m => m.StatisticId == targetStatistic.Id)
+            .OrderBy(m => m.Priority)
+            .ToListAsync();
+
+        Assert.Equal(orderedIds, metricsAfterReorder.Select(m => m.Id));
+    }
+
+    [Fact]
+    public async Task ReorderMetrics_WithNonExistentStatisticId_ShouldReturnBadRequest()
+    {
+        // Arrange
+        var targetStatistic = await EnsureImpactStatisticsExistsAsync();
+        var metricIds = targetStatistic.Metrics.Select(m => m.Id).ToList();
+
+        var reorderDto = new ReorderMetricsDto
+        {
+            StatisticId = long.MaxValue,
+            OrderedIds = metricIds
+        };
+        var serializedDto = JsonSerializer.Serialize(reorderDto);
+        var content = new StringContent(serializedDto, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await Fixture.HttpClient.PutAsync(_endpointUri, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private async Task<ImpactStatistics> EnsureImpactStatisticsExistsAsync()
+    {
+        var existing = await Fixture.DbContext.ImpactStatistics
+            .Include(s => s.Metrics)
+            .Where(s => s.Metrics.Count > 1)
+            .FirstOrDefaultAsync();
+
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var image = new Image
+        {
+            Url = "https://example.com/test-reorder.jpg",
+            BlobName = "test-blob-name",
+            MimeType = "image/jpeg",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        await Fixture.DbContext.Images.AddAsync(image);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var mainPage = new DAL.Entities.MainPage
+        {
+            Title = "Test MainPage",
+            Description = "Test Desc",
+            ImageId = image.Id,
+            ImpactStatistics = new ImpactStatistics
+            {
+                Title = "Test Stat",
+                ImageId = image.Id,
+                Metrics =
+                [
+                    new Metric { Value = 10, Name = "Metric 1", Type = MetricType.Raised, Priority = 1 },
+                    new Metric { Value = 20, Name = "Metric 2", Type = MetricType.Partners, Priority = 2 }
+                ]
+            }
+        };
+
+        await Fixture.DbContext.MainPages.AddAsync(mainPage);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        return mainPage.ImpactStatistics!;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
@@ -101,11 +101,60 @@ public class UpdateMainPageTests : BaseTestClass
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task ToggleMetricVisibility_ValidData_ShouldReturnOkAndUpdateEntity()
+    {
+        var mainPage = await EnsureMainPageExistsAsync();
+        var existingMetric = mainPage.ImpactStatistics!.Metrics.First();
+
+        var dto = new UpdateMetricVisibilityDto { IsHidden = true };
+
+        var response = await PutVisibilityRaw(existingMetric.Id, dto);
+
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Expected OK, but got {response.StatusCode}. Error details: {errorContent}");
+        }
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        var updatedMainPage = await Fixture.DbContext.MainPages
+            .Include(m => m.ImpactStatistics)
+                .ThenInclude(s => s!.Metrics)
+            .SingleAsync(m => m.Id == mainPage.Id);
+
+        var updatedMetric = updatedMainPage.ImpactStatistics!.Metrics.First(m => m.Id == existingMetric.Id);
+
+        Assert.True(updatedMetric.IsHidden);
+    }
+
+    [Fact]
+    public async Task ToggleMetricVisibility_NonExistentMetric_ShouldReturnNotFound()
+    {
+        var nonExistentId = 999999;
+        var dto = new UpdateMetricVisibilityDto { IsHidden = true };
+
+        var response = await PutVisibilityRaw(nonExistentId, dto);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     private async Task<HttpResponseMessage> PutRaw(UpdateMainPageDto payload)
     {
         var serialized = JsonSerializer.Serialize(payload);
         return await Fixture.HttpClient.PutAsync(
             _endpointUri,
+            new StringContent(serialized, Encoding.UTF8, "application/json"));
+    }
+
+    private async Task<HttpResponseMessage> PutVisibilityRaw(long metricId, UpdateMetricVisibilityDto payload)
+    {
+        var serialized = JsonSerializer.Serialize(payload);
+        return await Fixture.HttpClient.PutAsync(
+            $"/api/MainPage/metrics/{metricId}/visibility",
             new StringContent(serialized, Encoding.UTF8, "application/json"));
     }
 
@@ -141,7 +190,7 @@ public class UpdateMainPageTests : BaseTestClass
                 .ThenInclude(s => s!.Metrics)
             .FirstOrDefaultAsync();
 
-        if (existing is not null)
+        if (existing is not null && existing.ImpactStatistics?.Metrics.Count > 1)
         {
             return existing;
         }
@@ -158,7 +207,11 @@ public class UpdateMainPageTests : BaseTestClass
             {
                 Title = "Seed Stat",
                 ImageId = image.Id,
-                Metrics = [new Metric { Value = 100, Name = "children", Type = MetricType.Raised }],
+                Metrics =
+                [
+                    new Metric { Value = 100, Name = "children", Type = MetricType.Raised, IsHidden = false },
+                    new Metric { Value = 200, Name = "families", Type = MetricType.Partners, IsHidden = false }
+                ],
             },
         };
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/ReorderMetricsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/ReorderMetricsHandlerTests.cs
@@ -1,0 +1,136 @@
+using System.Linq.Expressions;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ReorderMetrics;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.Exceptions.ReorderExceptions;
+using VictoryCenter.BLL.Interfaces.ReorderService;
+using VictoryCenter.BLL.Validators.MainPage.Commands;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.MainPage;
+
+public class ReorderMetricsHandlerTests
+{
+    private readonly Mock<IReorderService> _mockReorderService;
+    private readonly IValidator<ReorderMetricsCommand> _validator;
+
+    public ReorderMetricsHandlerTests()
+    {
+        _mockReorderService = new Mock<IReorderService>();
+        _validator = new ReorderMetricsCommandValidator();
+    }
+
+    [Theory]
+    [InlineData(2L, 1L)]
+    [InlineData(3L, 2L, 1L)]
+    public async Task Handle_ValidDto_ShouldReturnOk(params long[] orderedIds)
+    {
+        // Arrange
+        var reorderDto = new ReorderMetricsDto
+        {
+            OrderedIds = [.. orderedIds],
+            StatisticId = 1L
+        };
+        var command = new ReorderMetricsCommand(reorderDto);
+        SetupReorderService();
+
+        var handler = new ReorderMetricsHandler(_validator, _mockReorderService.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+
+        _mockReorderService.Verify(
+            service => service.SwapElementsAsync(
+                It.Is<List<long>>(ids => ids.SequenceEqual(orderedIds)),
+                It.IsAny<Expression<Func<Metric, long>>>(),
+                It.IsAny<Expression<Func<Metric, bool>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidDto_ShouldReturnValidationFailure()
+    {
+        // Arrange
+        var reorderDto = new ReorderMetricsDto
+        {
+            OrderedIds = [],
+            StatisticId = 0L
+        };
+        var command = new ReorderMetricsCommand(reorderDto);
+
+        var handler = new ReorderMetricsHandler(_validator, _mockReorderService.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsFailed);
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_DbUpdateExceptionThrown_ShouldReturnFailure()
+    {
+        // Arrange
+        var reorderDto = new ReorderMetricsDto { OrderedIds = [2, 1], StatisticId = 1L };
+        var command = new ReorderMetricsCommand(reorderDto);
+
+        _mockReorderService.Setup(service => service.SwapElementsAsync<Metric>(
+            It.IsAny<List<long>>(),
+            It.IsAny<Expression<Func<Metric, long>>>(),
+            It.IsAny<Expression<Func<Metric, bool>>>()))
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = new ReorderMetricsHandler(_validator, _mockReorderService.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsFailed);
+        Assert.Equal(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(Metric)), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ReorderExceptionThrown_ShouldReturnFailure()
+    {
+        // Arrange
+        var reorderDto = new ReorderMetricsDto { OrderedIds = [2, 1], StatisticId = 1L };
+        var command = new ReorderMetricsCommand(reorderDto);
+        var reorderErrorMessage = "Test metric reorder error";
+
+        _mockReorderService.Setup(service => service.SwapElementsAsync<Metric>(
+            It.IsAny<List<long>>(),
+            It.IsAny<Expression<Func<Metric, long>>>(),
+            It.IsAny<Expression<Func<Metric, bool>>>()))
+            .ThrowsAsync(new ReorderException(reorderErrorMessage));
+
+        var handler = new ReorderMetricsHandler(_validator, _mockReorderService.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsFailed);
+        Assert.Equal(ReorderConstants.ErrorWithReordering(reorderErrorMessage), result.Errors[0].Message);
+    }
+
+    private void SetupReorderService()
+    {
+        _mockReorderService
+            .Setup(service => service.SwapElementsAsync<Metric>(
+                It.IsAny<List<long>>(),
+                It.IsAny<Expression<Func<Metric, long>>>(),
+                It.IsAny<Expression<Func<Metric, bool>>>()))
+            .Returns(Task.CompletedTask);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/ToggleMetricVisibilityHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/ToggleMetricVisibilityHandlerTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ToggleMetricVisibility;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
+using VictoryCenter.BLL.Interfaces.MainPage;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.MainPage;
+
+public class ToggleMetricVisibilityHandlerTests
+{
+    private readonly Mock<IMetricVisibilityService> _metricVisibilityServiceMock = new();
+
+    [Fact]
+    public async Task Handle_ShouldReturnOk_WhenServiceSucceeds()
+    {
+        // Arrange
+        var command = new ToggleMetricVisibilityCommand(1, new UpdateMetricVisibilityDto { IsHidden = true });
+
+        _metricVisibilityServiceMock
+            .Setup(x => x.ToggleMetricVisibilityAsync(command.MetricId, command.Dto.IsHidden))
+            .Returns(Task.CompletedTask);
+
+        var handler = new ToggleMetricVisibilityHandler(_metricVisibilityServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _metricVisibilityServiceMock.Verify(x => x.ToggleMetricVisibilityAsync(command.MetricId, command.Dto.IsHidden), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenServiceThrowsKeyNotFoundException()
+    {
+        // Arrange
+        var command = new ToggleMetricVisibilityCommand(1, new UpdateMetricVisibilityDto { IsHidden = true });
+        var exceptionMessage = "Metric not found";
+
+        _metricVisibilityServiceMock
+            .Setup(x => x.ToggleMetricVisibilityAsync(It.IsAny<long>(), It.IsAny<bool>()))
+            .ThrowsAsync(new KeyNotFoundException(exceptionMessage));
+
+        var handler = new ToggleMetricVisibilityHandler(_metricVisibilityServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(exceptionMessage, result.Errors.First().Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenServiceThrowsInvalidOperationException()
+    {
+        // Arrange
+        var command = new ToggleMetricVisibilityCommand(1, new UpdateMetricVisibilityDto { IsHidden = true });
+        var exceptionMessage = "Cannot hide the last visible metric.";
+
+        _metricVisibilityServiceMock
+            .Setup(x => x.ToggleMetricVisibilityAsync(It.IsAny<long>(), It.IsAny<bool>()))
+            .ThrowsAsync(new InvalidOperationException(exceptionMessage));
+
+        var handler = new ToggleMetricVisibilityHandler(_metricVisibilityServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(exceptionMessage, result.Errors.First().Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenServiceThrowsDbUpdateException()
+    {
+        // Arrange
+        var command = new ToggleMetricVisibilityCommand(1, new UpdateMetricVisibilityDto { IsHidden = true });
+
+        _metricVisibilityServiceMock
+            .Setup(x => x.ToggleMetricVisibilityAsync(It.IsAny<long>(), It.IsAny<bool>()))
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = new ToggleMetricVisibilityHandler(_metricVisibilityServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(Metric)), result.Errors.First().Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
@@ -44,7 +44,8 @@ public class MainPageController : AuthorizedApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> ReorderMetrics([FromBody] ReorderMetricsDto reorderMetricsDto) {
+    public async Task<IActionResult> ReorderMetrics([FromBody] ReorderMetricsDto reorderMetricsDto)
+    {
         return HandleResult(await Mediator.Send(new ReorderMetricsCommand(reorderMetricsDto)));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ReorderMetrics;
 using VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ToggleMetricVisibility;
 using VictoryCenter.BLL.Commands.Admin.MainPage.Create;
 using VictoryCenter.BLL.Commands.Admin.MainPage.Update;
@@ -37,5 +38,13 @@ public class MainPageController : AuthorizedApiController
         [FromBody] UpdateMetricVisibilityDto dto)
     {
         return HandleResult(await Mediator.Send(new ToggleMetricVisibilityCommand(id, dto)));
+    }
+
+    [HttpPut("metrics/reorder")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReorderMetrics([FromBody] ReorderMetricsDto reorderMetricsDto) {
+        return HandleResult(await Mediator.Send(new ReorderMetricsCommand(reorderMetricsDto)));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/MainPageController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.ImpactStatistics.ToggleMetricVisibility;
 using VictoryCenter.BLL.Commands.Admin.MainPage.Create;
 using VictoryCenter.BLL.Commands.Admin.MainPage.Update;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -24,5 +26,16 @@ public class MainPageController : AuthorizedApiController
     public async Task<IActionResult> UpdateMainPage([FromBody] UpdateMainPageDto updateMainPageDto)
     {
         return HandleResult(await Mediator.Send(new UpdateMainPageCommand(updateMainPageDto)));
+    }
+
+    [HttpPut("metrics/{id:long}/visibility")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ToggleMetricVisibility(
+        [FromRoute] long id,
+        [FromBody] UpdateMetricVisibilityDto dto)
+    {
+        return HandleResult(await Mediator.Send(new ToggleMetricVisibilityCommand(id, dto)));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -14,6 +14,7 @@ using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.BlobStorage;
 using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
 using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Interfaces.MainPage;
 using VictoryCenter.BLL.Interfaces.PaymentService;
 using VictoryCenter.BLL.Interfaces.PdfStorage;
 using VictoryCenter.BLL.Interfaces.ReorderService;
@@ -26,6 +27,7 @@ using VictoryCenter.BLL.Options.Payment;
 using VictoryCenter.BLL.Services.BlobStorage;
 using VictoryCenter.BLL.Services.HippotherapyPrograms;
 using VictoryCenter.BLL.Services.Localization;
+using VictoryCenter.BLL.Services.MainPage;
 using VictoryCenter.BLL.Services.PaymentService;
 using VictoryCenter.BLL.Services.PdfStorage;
 using VictoryCenter.BLL.Services.ReorderService;
@@ -145,6 +147,7 @@ public static class ServicesConfiguration
         services.AddScoped<IPaymentService, PaymentService>();
 
         services.AddScoped<IReorderService, ReorderService>();
+        services.AddScoped<IMetricVisibilityService, MetricVisibilityService>();
 
         services.AddScoped(typeof(ISearchService<>), typeof(SearchService<>));
 


### PR DESCRIPTION
dev
## Github Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2509
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2510

## Summary of issue

Admin needs the ability to manage metrics in the Statistics block:
1. **Visibility:** Hide/unhide individual metrics without deleting them. Hidden metrics must be immediately excluded from the public page. The last visible metric cannot be hidden.
2. **Reordering:** Change the sequence of metrics via drag-and-drop. The new order must be applied immediately and reflected on the public web page.

## Summary of change

DAL
- Added `IsHidden` (bool) and `Priority` (long) fields to `Metric` entity.
- Implemented `IOrderableEntity` for `Metric`.
- Added corresponding configurations to `MetricConfig`.
- Added `MetricRepository` and `IMetricRepository`, registered in `RepositoryWrapper`.
- Created migrations: `AddMetricIsHidden` and `AddPriorityToMetrics`.

BLL
- Added `IsHidden` and `Priority` to `MetricDto` (response).
- Added `UpdateMetricVisibilityDto` and `ReorderMetricsDto`.
- Implemented `MetricVisibilityService` with validation (cannot hide the last visible metric).
- Implemented `ToggleMetricVisibilityCommand` & `ToggleMetricVisibilityHandler`.
- Implemented `ReorderMetricsCommand` & `ReorderMetricsHandler` utilizing `IReorderService`.
- Added validators for the new commands and DTOs.
- Updated `UpdateMainPageHandler` (`SyncMetrics`) to automatically assign sequential `Priority` to newly created metrics.
- Updated `MainPageProfile` to order metrics by `Priority`.

WebAPI
- Added `PUT /api/MainPage/metrics/{id}/visibility` endpoint.
- Added `PUT /api/MainPage/metrics/reorder` endpoint.

Public page
- Updated `GetMainPageHandler` to exclude metrics where `IsHidden = true` and sort the remaining ones by `Priority`.

## Testing approach
- Added unit tests for `ToggleMetricVisibilityHandler` and `MetricVisibilityService`.
- Added unit tests for `ReorderMetricsHandler` and validators.
- Added integration tests for `PUT /api/MainPage/metrics/{id}/visibility`.
- Added integration tests for `PUT /api/MainPage/metrics/reorder`.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can toggle metric visibility (hide/show individual metrics)
  * Hidden metrics are excluded from public main page displays and metrics are ordered by priority
  * Safeguard prevents hiding the last visible metric in a statistic group
  * Admins can reorder metrics within a statistic

* **Tests**
  * Added unit and integration tests covering visibility toggling and reordering operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Back/pull/2511)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->