### PR TITLE
Feature/issue-2523: [Reports] Add localization support for ReportFundsExpendituresSettings disclaimer

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Create/CreateReportFundsExpendituresSettingsLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Create/CreateReportFundsExpendituresSettingsLocalizationCommand.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Create;
+
+public record CreateReportFundsExpendituresSettingsLocalizationCommand(
+    CreateReportFundsExpendituresSettingsLocalizationDto CreateReportFundsExpendituresSettingsLocalizationDto)
+    : IRequest<Result<ReportFundsExpendituresSettingsLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Create/CreateReportFundsExpendituresSettingsLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Create/CreateReportFundsExpendituresSettingsLocalizationHandler.cs
@@ -1,0 +1,62 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities.Localization;
+using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Create;
+
+public class CreateReportFundsExpendituresSettingsLocalizationHandler
+    : IRequestHandler<CreateReportFundsExpendituresSettingsLocalizationCommand, Result<ReportFundsExpendituresSettingsLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization> _localizationService;
+    private readonly IValidator<CreateReportFundsExpendituresSettingsLocalizationCommand> _validator;
+
+    public CreateReportFundsExpendituresSettingsLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization> localizationService,
+        IValidator<CreateReportFundsExpendituresSettingsLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<ReportFundsExpendituresSettingsLocalizationDto>> Handle(
+        CreateReportFundsExpendituresSettingsLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var entity = _mapper.Map<ReportFundsExpendituresSettingsLocalization>(request.CreateReportFundsExpendituresSettingsLocalizationDto);
+            var result = await _localizationService.CreateEntityLocalizationAsync(entity);
+            var responseDto = _mapper.Map<ReportFundsExpendituresSettingsLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(
+                ErrorMessagesConstants.FailedToCreateEntity(typeof(ReportFundsExpendituresSettingsLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(
+                ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(ReportFundsExpendituresSettingsLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsLocalizationCommand.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Update;
+
+public record UpdateReportFundsExpendituresSettingsLocalizationCommand(
+    UpdateReportFundsExpendituresSettingsLocalizationDto UpdateReportFundsExpendituresSettingsLocalizationDto,
+    long EntityId,
+    long LanguageId)
+    : IRequest<Result<ReportFundsExpendituresSettingsLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsLocalizationHandler.cs
@@ -1,0 +1,64 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities.Localization;
+using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Update;
+
+public class UpdateReportFundsExpendituresSettingsLocalizationHandler
+    : IRequestHandler<UpdateReportFundsExpendituresSettingsLocalizationCommand, Result<ReportFundsExpendituresSettingsLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization> _localizationService;
+    private readonly IValidator<UpdateReportFundsExpendituresSettingsLocalizationCommand> _validator;
+
+    public UpdateReportFundsExpendituresSettingsLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization> localizationService,
+        IValidator<UpdateReportFundsExpendituresSettingsLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<ReportFundsExpendituresSettingsLocalizationDto>> Handle(
+        UpdateReportFundsExpendituresSettingsLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var entity = _mapper.Map<ReportFundsExpendituresSettingsLocalization>(request.UpdateReportFundsExpendituresSettingsLocalizationDto);
+            entity.EntityId = request.EntityId;
+            entity.LanguageId = request.LanguageId;
+            var result = await _localizationService.UpdateEntityLocalizationAsync(entity);
+            var responseDto = _mapper.Map<ReportFundsExpendituresSettingsLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(ReportFundsExpendituresSettingsLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<ReportFundsExpendituresSettingsLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(ReportFundsExpendituresSettingsLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsHandler.cs
@@ -6,7 +6,10 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresSettings;
 using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
 using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
 
 namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresSettings.Update;
@@ -43,8 +46,30 @@ public class UpdateReportFundsExpendituresSettingsHandler
             }
 
             var entityToUpdate = settingsResult.Value;
+            var disclaimerChanged = entityToUpdate.DisclaimerTitle != request.UpdateReportFundsExpendituresSettingsDto.DisclaimerTitle;
+
             _mapper.Map(request.UpdateReportFundsExpendituresSettingsDto, entityToUpdate);
             _repositoryWrapper.ReportFundsExpendituresSettingsRepository.Update(entityToUpdate);
+
+            if (disclaimerChanged)
+            {
+                var localizations = (await _repositoryWrapper.ReportFundsExpendituresSettingsLocalizationsRepository
+                    .GetAllAsync(new QueryOptions<ReportFundsExpendituresSettingsLocalization>
+                    {
+                        Filter = l => l.EntityId == entityToUpdate.Id,
+                        AsNoTracking = false
+                    })).ToList();
+
+                foreach (var loc in localizations)
+                {
+                    loc.TranslationStatus = TranslationStatus.Outdated;
+                }
+
+                if (localizations.Count > 0)
+                {
+                    _repositoryWrapper.ReportFundsExpendituresSettingsLocalizationsRepository.UpdateRange(localizations);
+                }
+            }
 
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresSettings/CreateReportFundsExpendituresSettingsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresSettings/CreateReportFundsExpendituresSettingsLocalizationDto.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+public class CreateReportFundsExpendituresSettingsLocalizationDto
+    : UpdateReportFundsExpendituresSettingsLocalizationDto, ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsLocalizationDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+public class ReportFundsExpendituresSettingsLocalizationDto
+{
+    public long EntityId { get; init; }
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+    public string DisclaimerTitle { get; set; } = null!;
+    public TranslationStatus TranslationStatus { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsLocalizationDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+public class UpdateReportFundsExpendituresSettingsLocalizationDto
+{
+    public string DisclaimerTitle { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresCategories/ReportFundsExpendituresCategoryDto.cs
@@ -1,3 +1,4 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresCategories;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
@@ -7,4 +8,5 @@ public record ReportFundsExpendituresCategoryDto
     public long Id { get; init; }
     public string Name { get; init; } = null!;
     public ReportFundsExpendituresType Type { get; init; }
+    public IEnumerable<ReportFundsExpendituresCategoryLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsLocalizationProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsLocalizationProfile.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Mapping.Localization.ReportFundsExpendituresSettings;
+
+public class ReportFundsExpendituresSettingsLocalizationProfile : Profile
+{
+    public ReportFundsExpendituresSettingsLocalizationProfile()
+    {
+        CreateMap<CreateReportFundsExpendituresSettingsLocalizationDto, ReportFundsExpendituresSettingsLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateReportFundsExpendituresSettingsLocalizationDto, ReportFundsExpendituresSettingsLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+
+        CreateMap<ReportFundsExpendituresSettingsLocalization, ReportFundsExpendituresSettingsLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresSettings/GetByEntityId/GetReportFundsExpendituresSettingsLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresSettings/GetByEntityId/GetReportFundsExpendituresSettingsLocalizationByEntityIdHandler.cs
@@ -1,0 +1,39 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresSettings.GetByEntityId;
+
+public class GetReportFundsExpendituresSettingsLocalizationByEntityIdHandler
+    : IRequestHandler<GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery, Result<List<ReportFundsExpendituresSettingsLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetReportFundsExpendituresSettingsLocalizationByEntityIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<List<ReportFundsExpendituresSettingsLocalizationDto>>> Handle(
+        GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<ReportFundsExpendituresSettingsLocalization>
+        {
+            Filter = l => l.EntityId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+            AsNoTracking = true,
+        };
+
+        var entities = await _repositoryWrapper.ReportFundsExpendituresSettingsLocalizationsRepository.GetAllAsync(queryOptions);
+        var responseDto = _mapper.Map<List<ReportFundsExpendituresSettingsLocalizationDto>>(entities);
+        return Result.Ok(responseDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresSettings/GetByEntityId/GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/ReportFundsExpendituresSettings/GetByEntityId/GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresSettings.GetByEntityId;
+
+public record GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery(long Id)
+    : IRequest<Result<List<ReportFundsExpendituresSettingsLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportFundsExpendituresCategories/GetAll/GetAllReportFundsExpendituresCategoriesHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportFundsExpendituresCategories/GetAll/GetAllReportFundsExpendituresCategoriesHandler.cs
@@ -1,8 +1,11 @@
 using AutoMapper;
 using FluentResults;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
 
 namespace VictoryCenter.BLL.Queries.Admin.ReportFundsExpendituresCategories.GetAll;
 
@@ -24,7 +27,11 @@ public class GetAllReportFundsExpendituresCategoriesHandler
         GetAllReportFundsExpendituresCategoriesQuery request,
         CancellationToken cancellationToken)
     {
-        var categories = await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.GetAllAsync();
+        var categories = await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.GetAllAsync(
+            new QueryOptions<ReportFundsExpendituresCategory>
+            {
+                Include = c => c.Include(c => c.Localizations).ThenInclude(l => l.Language)
+            });
 
         return Result.Ok(_mapper.Map<IEnumerable<ReportFundsExpendituresCategoryDto>>(categories));
     }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsLocalizationValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresSettings;
+
+public class BaseReportFundsExpendituresSettingsLocalizationValidator
+    : AbstractValidator<UpdateReportFundsExpendituresSettingsLocalizationDto>
+{
+    public BaseReportFundsExpendituresSettingsLocalizationValidator()
+    {
+        RuleFor(x => x.DisclaimerTitle)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateReportFundsExpendituresSettingsLocalizationDto.DisclaimerTitle)))
+            .MinimumLength(ReportFundsExpendituresSettingsConstants.DisclaimerMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateReportFundsExpendituresSettingsLocalizationDto.DisclaimerTitle),
+                ReportFundsExpendituresSettingsConstants.DisclaimerMinLength))
+            .MaximumLength(ReportFundsExpendituresSettingsConstants.DisclaimerMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateReportFundsExpendituresSettingsLocalizationDto.DisclaimerTitle),
+                ReportFundsExpendituresSettingsConstants.DisclaimerMaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresSettings/CreateReportFundsExpendituresSettingsLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresSettings/CreateReportFundsExpendituresSettingsLocalizationValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Create;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.Validators.Localization.Base;
+
+namespace VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresSettings;
+
+public class CreateReportFundsExpendituresSettingsLocalizationValidator
+    : AbstractValidator<CreateReportFundsExpendituresSettingsLocalizationCommand>
+{
+    public CreateReportFundsExpendituresSettingsLocalizationValidator(
+        BaseReportFundsExpendituresSettingsLocalizationValidator baseValidator)
+    {
+        RuleFor(c => c.CreateReportFundsExpendituresSettingsLocalizationDto)
+            .SetValidator(new LocalizationIdentityValidator<CreateReportFundsExpendituresSettingsLocalizationDto>());
+        RuleFor(c => c.CreateReportFundsExpendituresSettingsLocalizationDto)
+            .SetValidator(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsLocalizationValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresSettings;
+
+public class UpdateReportFundsExpendituresSettingsLocalizationValidator
+    : AbstractValidator<UpdateReportFundsExpendituresSettingsLocalizationCommand>
+{
+    public UpdateReportFundsExpendituresSettingsLocalizationValidator(
+        BaseReportFundsExpendituresSettingsLocalizationValidator baseValidator)
+    {
+        RuleFor(x => x.UpdateReportFundsExpendituresSettingsLocalizationDto)
+            .SetValidator(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/ReportFundsExpendituresSettingsLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/ReportFundsExpendituresSettingsLocalizationConfig.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class ReportFundsExpendituresSettingsLocalizationConfig
+    : EntityLocalizationConfig<ReportFundsExpendituresSettingsLocalization, ReportFundsExpendituresSettings>
+{
+    public override void Configure(EntityTypeBuilder<ReportFundsExpendituresSettingsLocalization> entity)
+    {
+        base.Configure(entity);
+
+        entity.Property(e => e.DisclaimerTitle)
+            .HasMaxLength(1000)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -92,6 +92,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<ReportFundsExpendituresSettings> ReportFundsExpendituresSettings { get; set; }
 
+    public DbSet<ReportFundsExpendituresSettingsLocalization> ReportFundsExpendituresSettingsLocalizations { get; set; }
+
     public DbSet<ReportFundsExpendituresCategory> ReportFundsExpendituresCategories { get; set; }
 
     public DbSet<ReportFundsExpendituresCategoryLocalization> ReportFundsExpendituresCategoryLocalizations { get; set; }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/ReportFundsExpendituresSettingsLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/ReportFundsExpendituresSettingsLocalization.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class ReportFundsExpendituresSettingsLocalization : LocalizationBase<ReportFundsExpendituresSettings>
+{
+    public string DisclaimerTitle { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresSettings.cs
@@ -1,9 +1,13 @@
 using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 
 namespace VictoryCenter.DAL.Entities;
 
-public class ReportFundsExpendituresSettings : BaseEntity
+public class ReportFundsExpendituresSettings : BaseEntity, ITranslatedEntity<ReportFundsExpendituresSettingsLocalization>
 {
     public string DisclaimerTitle { get; set; } = "";
     public decimal ExchangeRate { get; set; }
+
+    public ICollection<ReportFundsExpendituresSettingsLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260515061809_AddReportFundsExpendituresSettingsLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260515061809_AddReportFundsExpendituresSettingsLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515061809_AddReportFundsExpendituresSettingsLocalization")]
+    partial class AddReportFundsExpendituresSettingsLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260515061809_AddReportFundsExpendituresSettingsLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260515061809_AddReportFundsExpendituresSettingsLocalization.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReportFundsExpendituresSettingsLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReportFundsExpendituresSettingsLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    DisclaimerTitle = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReportFundsExpendituresSettingsLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_ReportFundsExpendituresSettingsLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ReportFundsExpendituresSettingsLocalizations_ReportFundsExpendituresSettings_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "ReportFundsExpendituresSettings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReportFundsExpendituresSettingsLocalizations_LanguageId",
+                table: "ReportFundsExpendituresSettingsLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReportFundsExpendituresSettingsLocalizations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -12,6 +12,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgram
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.PdfSection;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.MainPage;
@@ -67,6 +68,8 @@ public interface IRepositoryWrapper
     ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository { get; }
 
     IReportFundsExpendituresCategoryLocalizationsRepository ReportFundsExpendituresCategoryLocalizationsRepository { get; }
+
+    IReportFundsExpendituresSettingsLocalizationsRepository ReportFundsExpendituresSettingsLocalizationsRepository { get; }
 
     IChangedLivesBlockRepository ChangedLivesBlockRepository { get; }
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/ReportFundsExpendituresSettings/IReportFundsExpendituresSettingsLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/ReportFundsExpendituresSettings/IReportFundsExpendituresSettingsLocalizationsRepository.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
+
+public interface IReportFundsExpendituresSettingsLocalizationsRepository
+    : IRepositoryBase<ReportFundsExpendituresSettingsLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -15,6 +15,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgram
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.PdfSection;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.WhoWeAreContents;
@@ -45,6 +46,7 @@ using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyProgr
 using VictoryCenter.DAL.Repositories.Realizations.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.PdfSection;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamCategories;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.TeamMembers;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.WhoWeAreContents;
@@ -106,6 +108,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private ISupportOptionsRepository? _supportOptionsRepository;
     private ITeamCategoryLocalizationsRepository? _teamCategoryLocalizationsRepository;
     private IReportFundsExpendituresCategoryLocalizationsRepository? _reportFundsExpendituresCategoryLocalizationsRepository;
+    private IReportFundsExpendituresSettingsLocalizationsRepository? _reportFundsExpendituresSettingsLocalizationsRepository;
     private ITeamMemberLocalizationsRepository? _teamMemberLocalizationsRepository;
     private ITeamMembersRepository? _teamMembersRepository;
     private IUahBankDetailsRepository? _uahBankDetailsRepository;
@@ -210,6 +213,10 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IReportFundsExpendituresCategoryLocalizationsRepository ReportFundsExpendituresCategoryLocalizationsRepository =>
         _reportFundsExpendituresCategoryLocalizationsRepository ??=
             new ReportFundsExpendituresCategoryLocalizationsRepository(_victoryCenterDbContext);
+
+    public IReportFundsExpendituresSettingsLocalizationsRepository ReportFundsExpendituresSettingsLocalizationsRepository =>
+        _reportFundsExpendituresSettingsLocalizationsRepository ??=
+            new ReportFundsExpendituresSettingsLocalizationsRepository(_victoryCenterDbContext);
 
     public IProgramSectionContentsRepository ProgramSectionContentsRepository => _programSectionContentsRepository ??=
         new ProgramSectionContentsRepository(_victoryCenterDbContext);

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsLocalizationsRepository.cs
@@ -1,0 +1,16 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.ReportFundsExpendituresSettings;
+
+public class ReportFundsExpendituresSettingsLocalizationsRepository
+    : RepositoryBase<ReportFundsExpendituresSettingsLocalization>,
+      IReportFundsExpendituresSettingsLocalizationsRepository
+{
+    public ReportFundsExpendituresSettingsLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresSettingsLocalizations/Create/CreateReportFundsExpendituresSettingsLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresSettingsLocalizations/Create/CreateReportFundsExpendituresSettingsLocalizationTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.ReportFundsExpendituresSettingsLocalizations.Create;
+
+public class CreateReportFundsExpendituresSettingsLocalizationTests : BaseTestClass
+{
+    public CreateReportFundsExpendituresSettingsLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnOk()
+    {
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var existingLocalization = await Fixture.DbContext.ReportFundsExpendituresSettingsLocalizations
+            .FirstOrDefaultAsync(l =>
+                l.EntityId == ReportFundsExpendituresSettingsConstants.SingletonSettingsId &&
+                l.LanguageId == language.Id);
+
+        if (existingLocalization is not null)
+        {
+            Fixture.DbContext.ReportFundsExpendituresSettingsLocalizations.Remove(existingLocalization);
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
+        var createDto = new CreateReportFundsExpendituresSettingsLocalizationDto
+        {
+            EntityId = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
+            LanguageId = language.Id,
+            DisclaimerTitle = "New localized disclaimer text"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresSettingsLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnNotFound_WhenEntityDoesNotExist()
+    {
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateReportFundsExpendituresSettingsLocalizationDto
+        {
+            EntityId = 999999,
+            LanguageId = language.Id,
+            DisclaimerTitle = "Some disclaimer text"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresSettingsLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnBadRequest_WhenDisclaimerTitleIsInvalid()
+    {
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateReportFundsExpendituresSettingsLocalizationDto
+        {
+            EntityId = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
+            LanguageId = language.Id,
+            DisclaimerTitle = ""
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresSettingsLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresSettingsLocalizations/Update/UpdateReportFundsExpendituresSettingsLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/ReportFundsExpendituresSettingsLocalizations/Update/UpdateReportFundsExpendituresSettingsLocalizationTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.ReportFundsExpendituresSettingsLocalizations.Update;
+
+public class UpdateReportFundsExpendituresSettingsLocalizationTests : BaseTestClass
+{
+    public UpdateReportFundsExpendituresSettingsLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnOk()
+    {
+        var localization = await Fixture.DbContext.ReportFundsExpendituresSettingsLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var updateDto = new UpdateReportFundsExpendituresSettingsLocalizationDto
+        {
+            DisclaimerTitle = "Updated localized disclaimer text"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresSettingsLocalizations/{localization.EntityId}/{localization.LanguageId}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnNotFound_WhenLocalizationDoesNotExist()
+    {
+        var updateDto = new UpdateReportFundsExpendituresSettingsLocalizationDto
+        {
+            DisclaimerTitle = "Updated localized disclaimer text"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            "/api/ReportFundsExpendituresSettingsLocalizations/999999/999999",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnBadRequest_WhenDisclaimerTitleIsInvalid()
+    {
+        var localization = await Fixture.DbContext.ReportFundsExpendituresSettingsLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var updateDto = new UpdateReportFundsExpendituresSettingsLocalizationDto
+        {
+            DisclaimerTitle = ""
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresSettingsLocalizations/{localization.EntityId}/{localization.LanguageId}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/GetAll/GetAllReportFundsExpendituresCategoriesTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/GetAll/GetAllReportFundsExpendituresCategoriesTests.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
 using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.IntegrationTests.Utils;
 using VictoryCenter.IntegrationTests.Utils.DbFixture;
@@ -34,5 +35,41 @@ public class GetAllReportFundsExpendituresCategoriesTests : BaseTestClass
 
         Assert.NotNull(responseContent);
         Assert.NotEmpty(responseContent);
+    }
+
+    [Fact]
+    public async Task GetAllCategories_ShouldIncludeLocalizations()
+    {
+        var category = new ReportFundsExpendituresCategory
+        {
+            Name = "Category with localization",
+            Type = ReportFundsExpendituresType.Income,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.ReportFundsExpendituresCategories.AddAsync(category);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        await Fixture.DbContext.ReportFundsExpendituresCategoryLocalizations.AddAsync(
+            new ReportFundsExpendituresCategoryLocalization
+            {
+                EntityId = category.Id,
+                LanguageId = 2,
+                Name = "Category EN",
+                TranslationStatus = TranslationStatus.Relevant,
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+        await Fixture.DbContext.SaveChangesAsync();
+
+        HttpResponseMessage response = await Fixture.HttpClient.GetAsync("/api/ReportFundsExpendituresCategories/");
+        response.EnsureSuccessStatusCode();
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        IEnumerable<ReportFundsExpendituresCategoryDto>? responseContent =
+            JsonConvert.DeserializeObject<IEnumerable<ReportFundsExpendituresCategoryDto>>(responseString);
+
+        Assert.NotNull(responseContent);
+        var seeded = responseContent.FirstOrDefault(c => c.Id == category.Id);
+        Assert.NotNull(seeded);
+        Assert.NotEmpty(seeded.Localizations);
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/ReportFundsExpendituresSettingsLocalizations/ReportFundsExpendituresSettingsLocalizationsSeeder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/ReportFundsExpendituresSettingsLocalizations/ReportFundsExpendituresSettingsLocalizationsSeeder.cs
@@ -1,0 +1,104 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.IntegrationTests.Utils.Seeders.Localizations.ReportFundsExpendituresSettingsLocalizations;
+
+public class ReportFundsExpendituresSettingsLocalizationsSeeder : ISeeder
+{
+    private readonly VictoryCenterDbContext _dbContext;
+    private readonly ILogger<ReportFundsExpendituresSettingsLocalizationsSeeder> _logger;
+    private readonly List<ReportFundsExpendituresSettingsLocalization> _localizations = [];
+
+    public ReportFundsExpendituresSettingsLocalizationsSeeder(
+        VictoryCenterDbContext dbContext,
+        ILogger<ReportFundsExpendituresSettingsLocalizationsSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public int Order => (int)SeederExecutionOrder.ReportFundsExpendituresSettingsLocalizations;
+    public string Name => nameof(ReportFundsExpendituresSettingsLocalizationsSeeder);
+
+    public async Task<SeederResult> SeedAsync()
+    {
+        try
+        {
+            await EnsureSettingsExistsAsync();
+
+            _localizations.Add(new ReportFundsExpendituresSettingsLocalization
+            {
+                EntityId = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
+                LanguageId = 2,
+                DisclaimerTitle = "English disclaimer for testing",
+                CreatedAt = DateTimeOffset.UtcNow
+            });
+
+            await _dbContext.ReportFundsExpendituresSettingsLocalizations.AddRangeAsync(_localizations);
+            await _dbContext.SaveChangesAsync();
+
+            if (!await VerifyAsync())
+            {
+                throw new InvalidOperationException($"Verification failed for seeder {Name}");
+            }
+
+            return new SeederResult { Success = true, CreatedCount = _localizations.Count };
+        }
+        catch (Exception ex)
+        {
+            await DisposeAsync();
+            _logger.LogError(ex, "Error in seeder {Name}", Name);
+            return new SeederResult { Success = false, ErrorMessage = ex.Message };
+        }
+    }
+
+    public async Task<bool> DisposeAsync()
+    {
+        try
+        {
+            if (_localizations.Count != 0)
+            {
+                _dbContext.ReportFundsExpendituresSettingsLocalizations.RemoveRange(_localizations);
+                await _dbContext.SaveChangesAsync();
+                _localizations.Clear();
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error disposing seeder {Name}", Name);
+            return false;
+        }
+    }
+
+    public async Task<bool> VerifyAsync()
+    {
+        var count = await _dbContext.ReportFundsExpendituresSettingsLocalizations.CountAsync();
+        return count >= _localizations.Count;
+    }
+
+    private async Task EnsureSettingsExistsAsync()
+    {
+        var existing = await _dbContext.ReportFundsExpendituresSettings
+            .FirstOrDefaultAsync(e => e.Id == ReportFundsExpendituresSettingsConstants.SingletonSettingsId);
+
+        if (existing is not null)
+        {
+            return;
+        }
+
+        await _dbContext.ReportFundsExpendituresSettings.AddAsync(new ReportFundsExpendituresSettings
+        {
+            Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
+            DisclaimerTitle = "Initial disclaimer",
+            ExchangeRate = 40m,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
@@ -17,4 +17,5 @@ public enum SeederExecutionOrder
     PartnersPageBanner,
     TeamCategoryLocalizations,
     ReportFundsExpendituresCategoryLocalizations,
+    ReportFundsExpendituresSettingsLocalizations,
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresSettings/CreateReportFundsExpendituresSettingsLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresSettings/CreateReportFundsExpendituresSettingsLocalizationTests.cs
@@ -1,0 +1,145 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Entities.Localization;
+using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresSettings;
+
+public class CreateReportFundsExpendituresSettingsLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization>> _mockLocalizationService;
+    private readonly IValidator<CreateReportFundsExpendituresSettingsLocalizationCommand> _validator;
+    private readonly CreateReportFundsExpendituresSettingsLocalizationHandler _handler;
+
+    private readonly CreateReportFundsExpendituresSettingsLocalizationDto _createDto = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        DisclaimerTitle = "English disclaimer text"
+    };
+
+    private readonly ReportFundsExpendituresSettingsLocalization _entity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        DisclaimerTitle = "English disclaimer text",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" }
+    };
+
+    private readonly ReportFundsExpendituresSettingsLocalizationDto _responseDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        DisclaimerTitle = "English disclaimer text"
+    };
+
+    public CreateReportFundsExpendituresSettingsLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization>>();
+        _validator = new CreateReportFundsExpendituresSettingsLocalizationValidator(
+            new BaseReportFundsExpendituresSettingsLocalizationValidator());
+        _handler = new CreateReportFundsExpendituresSettingsLocalizationHandler(
+            _mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresSettingsLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_responseDto.DisclaimerTitle, result.Value.DisclaimerTitle);
+        Assert.Equal(_responseDto.EntityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var invalidDto = new CreateReportFundsExpendituresSettingsLocalizationDto
+        {
+            EntityId = 0,
+            LanguageId = 0,
+            DisclaimerTitle = ""
+        };
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresSettingsLocalizationCommand(invalidDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("EntityId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("LanguageId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("DisclaimerTitle is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new KeyNotFoundException("Entity not found"));
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresSettingsLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Entity not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresSettingsLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(ReportFundsExpendituresSettingsLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new DbUpdateException());
+
+        var result = await _handler.Handle(
+            new CreateReportFundsExpendituresSettingsLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(ReportFundsExpendituresSettingsLocalization)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_createDto)).Returns(_entity);
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalizationDto>(_entity)).Returns(_responseDto);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity)).ReturnsAsync(_entity);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresSettings/GetReportFundsExpendituresSettingsLocalizationByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresSettings/GetReportFundsExpendituresSettingsLocalizationByEntityIdTests.cs
@@ -1,0 +1,104 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresSettings.GetByEntityId;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresSettings;
+
+public class GetReportFundsExpendituresSettingsLocalizationByEntityIdTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly GetReportFundsExpendituresSettingsLocalizationByEntityIdHandler _handler;
+
+    private readonly List<ReportFundsExpendituresSettingsLocalization> _entities = new()
+    {
+        new ReportFundsExpendituresSettingsLocalization
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            DisclaimerTitle = "English disclaimer",
+            Language = new LocalizationLanguage { Id = 2, Code = "en", CreatedAt = DateTimeOffset.UtcNow },
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        new ReportFundsExpendituresSettingsLocalization
+        {
+            EntityId = 1,
+            LanguageId = 3,
+            DisclaimerTitle = "Deutscher Haftungsausschluss",
+            Language = new LocalizationLanguage { Id = 3, Code = "de", CreatedAt = DateTimeOffset.UtcNow },
+            CreatedAt = DateTimeOffset.UtcNow
+        }
+    };
+
+    private readonly List<ReportFundsExpendituresSettingsLocalizationDto> _dtos = new()
+    {
+        new ReportFundsExpendituresSettingsLocalizationDto
+        {
+            EntityId = 1,
+            LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+            DisclaimerTitle = "English disclaimer"
+        },
+        new ReportFundsExpendituresSettingsLocalizationDto
+        {
+            EntityId = 1,
+            LocalizationInfoDto = new LocalizationInfoDto { Id = 3, Code = "de" },
+            DisclaimerTitle = "Deutscher Haftungsausschluss"
+        }
+    };
+
+    public GetReportFundsExpendituresSettingsLocalizationByEntityIdTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _handler = new GetReportFundsExpendituresSettingsLocalizationByEntityIdHandler(
+            _mockMapper.Object, _mockRepositoryWrapper.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnLocalizations_WhenEntityIdExists()
+    {
+        SetupRepositoryWrapper(_entities);
+        SetupMapper(_dtos);
+
+        var query = new GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery(1);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(2, result.Value.Count);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenEntityIdDoesNotExist()
+    {
+        SetupRepositoryWrapper(new List<ReportFundsExpendituresSettingsLocalization>());
+        SetupMapper(new List<ReportFundsExpendituresSettingsLocalizationDto>());
+
+        var query = new GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery(999);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    private void SetupRepositoryWrapper(IEnumerable<ReportFundsExpendituresSettingsLocalization> entitiesToReturn)
+    {
+        _mockRepositoryWrapper
+            .Setup(repo => repo.ReportFundsExpendituresSettingsLocalizationsRepository
+                .GetAllAsync(It.IsAny<QueryOptions<ReportFundsExpendituresSettingsLocalization>>()))
+            .ReturnsAsync(entitiesToReturn);
+    }
+
+    private void SetupMapper(IEnumerable<ReportFundsExpendituresSettingsLocalizationDto> dtosToReturn)
+    {
+        _mockMapper
+            .Setup(m => m.Map<List<ReportFundsExpendituresSettingsLocalizationDto>>(
+                It.IsAny<IEnumerable<ReportFundsExpendituresSettingsLocalization>>()))
+            .Returns(dtosToReturn.ToList());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsLocalizationTests.cs
@@ -1,0 +1,133 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Entities.Localization;
+using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.ReportFundsExpendituresSettings;
+
+public class UpdateReportFundsExpendituresSettingsLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization>> _mockLocalizationService;
+    private readonly IValidator<UpdateReportFundsExpendituresSettingsLocalizationCommand> _validator;
+    private readonly UpdateReportFundsExpendituresSettingsLocalizationHandler _handler;
+
+    private readonly long _entityId = 1;
+    private readonly long _languageId = 2;
+
+    private readonly UpdateReportFundsExpendituresSettingsLocalizationDto _updateDto = new()
+    {
+        DisclaimerTitle = "Updated disclaimer text"
+    };
+
+    private readonly ReportFundsExpendituresSettingsLocalization _entity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        DisclaimerTitle = "Updated disclaimer text",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" }
+    };
+
+    private readonly ReportFundsExpendituresSettingsLocalizationDto _responseDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        DisclaimerTitle = "Updated disclaimer text"
+    };
+
+    public UpdateReportFundsExpendituresSettingsLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<ReportFundsExpendituresSettingsEntity, ReportFundsExpendituresSettingsLocalization>>();
+        _validator = new UpdateReportFundsExpendituresSettingsLocalizationValidator(
+            new BaseReportFundsExpendituresSettingsLocalizationValidator());
+        _handler = new UpdateReportFundsExpendituresSettingsLocalizationHandler(
+            _mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var command = new UpdateReportFundsExpendituresSettingsLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_responseDto.DisclaimerTitle, result.Value.DisclaimerTitle);
+        Assert.Equal(_entityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var invalidDto = new UpdateReportFundsExpendituresSettingsLocalizationDto { DisclaimerTitle = "" };
+        var command = new UpdateReportFundsExpendituresSettingsLocalizationCommand(invalidDto, _entityId, _languageId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("DisclaimerTitle is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new KeyNotFoundException("Localization not found"));
+
+        var command = new UpdateReportFundsExpendituresSettingsLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Localization not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new UpdateReportFundsExpendituresSettingsLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(ReportFundsExpendituresSettingsLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new DbUpdateException());
+
+        var command = new UpdateReportFundsExpendituresSettingsLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(ReportFundsExpendituresSettingsLocalization)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalization>(_updateDto)).Returns(_entity);
+        _mockMapper.Setup(m => m.Map<ReportFundsExpendituresSettingsLocalizationDto>(_entity)).Returns(_responseDto);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity)).ReturnsAsync(_entity);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
@@ -6,7 +6,9 @@ using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresSettings.Update;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresSettings;
 using VictoryCenter.BLL.Validators.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Options;
 using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
@@ -18,6 +20,7 @@ public class UpdateReportFundsExpendituresSettingsTests
     private readonly Mock<IMapper> _mapperMock;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
     private readonly Mock<IReportFundsExpendituresSettingsRepository> _settingsRepositoryMock;
+    private readonly Mock<IReportFundsExpendituresSettingsLocalizationsRepository> _localizationsRepositoryMock;
     private readonly IValidator<UpdateReportFundsExpendituresSettingsCommand> _validator;
 
     private readonly UpdateReportFundsExpendituresSettingsDto _updateDto = new()
@@ -45,6 +48,7 @@ public class UpdateReportFundsExpendituresSettingsTests
         _mapperMock = new Mock<IMapper>();
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _settingsRepositoryMock = new Mock<IReportFundsExpendituresSettingsRepository>();
+        _localizationsRepositoryMock = new Mock<IReportFundsExpendituresSettingsLocalizationsRepository>();
         _validator = new UpdateReportFundsExpendituresSettingsValidator(new BaseReportFundsExpendituresSettingsValidator());
     }
 
@@ -166,6 +170,11 @@ public class UpdateReportFundsExpendituresSettingsTests
     {
         _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportFundsExpendituresSettingsRepository)
             .Returns(_settingsRepositoryMock.Object);
+        _repositoryWrapperMock.SetupGet(wrapper => wrapper.ReportFundsExpendituresSettingsLocalizationsRepository)
+            .Returns(_localizationsRepositoryMock.Object);
+        _localizationsRepositoryMock
+            .Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<ReportFundsExpendituresSettingsLocalization>>()))
+            .ReturnsAsync(new List<ReportFundsExpendituresSettingsLocalization>());
 
         _settingsRepositoryMock
             .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ReportFundsExpendituresSettingsEntity>>()))

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsLocalizationValidatorTests.cs
@@ -1,0 +1,60 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.Validators.Localization.ReportFundsExpendituresSettings;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.ReportFundsExpendituresSettings;
+
+public class BaseReportFundsExpendituresSettingsLocalizationValidatorTests
+{
+    private readonly BaseReportFundsExpendituresSettingsLocalizationValidator _validator;
+
+    public BaseReportFundsExpendituresSettingsLocalizationValidatorTests()
+    {
+        _validator = new BaseReportFundsExpendituresSettingsLocalizationValidator();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_ShouldHaveError_WhenDisclaimerTitle_IsNullOrEmpty(string? disclaimerTitle)
+    {
+        var model = new UpdateReportFundsExpendituresSettingsLocalizationDto { DisclaimerTitle = disclaimerTitle! };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.DisclaimerTitle);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDisclaimerTitle_IsTooShort()
+    {
+        var model = new UpdateReportFundsExpendituresSettingsLocalizationDto
+        {
+            DisclaimerTitle = new string('a', ReportFundsExpendituresSettingsConstants.DisclaimerMinLength - 1)
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.DisclaimerTitle);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDisclaimerTitle_IsTooLong()
+    {
+        var model = new UpdateReportFundsExpendituresSettingsLocalizationDto
+        {
+            DisclaimerTitle = new string('a', ReportFundsExpendituresSettingsConstants.DisclaimerMaxLength + 1)
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.DisclaimerTitle);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenModel_IsValid()
+    {
+        var model = new UpdateReportFundsExpendituresSettingsLocalizationDto
+        {
+            DisclaimerTitle = "Valid disclaimer text"
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisclaimerTitle);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/ReportFundsExpendituresSettingsLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/ReportFundsExpendituresSettingsLocalizationsController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.ReportFundsExpendituresSettings.Update;
+using VictoryCenter.BLL.DTOs.Admin.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.Queries.Admin.Localization.ReportFundsExpendituresSettings.GetByEntityId;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin.Localization;
+
+public class ReportFundsExpendituresSettingsLocalizationsController : AuthorizedApiController
+{
+    [HttpGet("{entityId:long}")]
+    [ProducesResponseType(typeof(List<ReportFundsExpendituresSettingsLocalizationDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetReportFundsExpendituresSettingsLocalizations(
+        [FromRoute] long entityId)
+    {
+        return HandleResult(await Mediator.Send(
+            new GetReportFundsExpendituresSettingsLocalizationByEntityIdQuery(entityId)));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ReportFundsExpendituresSettingsLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateReportFundsExpendituresSettingsLocalization(
+        [FromBody] CreateReportFundsExpendituresSettingsLocalizationDto createDto)
+    {
+        return HandleResult(await Mediator.Send(
+            new CreateReportFundsExpendituresSettingsLocalizationCommand(createDto)));
+    }
+
+    [HttpPut("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(ReportFundsExpendituresSettingsLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateReportFundsExpendituresSettingsLocalization(
+        [FromBody] UpdateReportFundsExpendituresSettingsLocalizationDto updateDto,
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(
+            new UpdateReportFundsExpendituresSettingsLocalizationCommand(updateDto, EntityId, LanguageId)));
+    }
+}


### PR DESCRIPTION
## GitHub Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2523


## Summary of issue

Adds back-end localization for the disclaimer text in the Report Funds & Expenditures settings. Previously the disclaimer had no translation support, so only a single version could be stored.

## Summary of change

- Added ReportFundsExpendituresSettingsLocalization entity, EF config, repository, and migration 
- Added Create / Update / Get handlers and controller endpoints
- When the source DisclaimerTitle is updated in settings, all existing language localizations are automatically marked as TranslationStatus.Outdated 
- Added validators, profile, and response DTO 
- Added unit tests for Create, Update, and Get handlers and validators; updated existing UpdateReportFundsExpendituresSettings' unit tests to mock the new localization repository 
- Added integration tests for Create and Update localization endpoints

## Testing approach

1. Get response before creating a localization

<img width="716" height="447" alt="image" src="https://github.com/user-attachments/assets/4358145b-134c-4d6a-a0dc-b4c1d79a0f76" />

2. Creating a new one

<img width="717" height="548" alt="image" src="https://github.com/user-attachments/assets/12e0e73a-e323-4667-b9fe-c6e7edbcee35" />

3. Updating

<img width="731" height="563" alt="image" src="https://github.com/user-attachments/assets/9ff342ab-1b89-4733-8b7a-39dc89462fe5" />

4. Get updated

<img width="736" height="587" alt="image" src="https://github.com/user-attachments/assets/b21f9bed-c0c3-4a63-baf8-f48b16faa8a7" />


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
