### PR TITLE
  [Task/issue-2560]Make HISTORY GET endpoint public

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/HistorySections/GetAll/GetAllHistorySectionsQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/HistorySections/GetAll/GetAllHistorySectionsQuery.cs
@@ -2,6 +2,6 @@ using FluentResults;
 using MediatR;
 using VictoryCenter.BLL.DTOs.Admin.HistorySection;
 
-namespace VictoryCenter.BLL.Queries.Admin.HistorySections.GetAll;
+namespace VictoryCenter.BLL.Queries.Public.HistorySections.GetAll;
 
 public record GetAllHistorySectionsQuery() : IRequest<Result<List<HistorySectionDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/HistorySections/GetAll/GetAllHistorySectionsQueryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/HistorySections/GetAll/GetAllHistorySectionsQueryHandler.cs
@@ -9,7 +9,7 @@ using VictoryCenter.DAL.Entities.HistoryContents;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
-namespace VictoryCenter.BLL.Queries.Admin.HistorySections.GetAll;
+namespace VictoryCenter.BLL.Queries.Public.HistorySections.GetAll;
 
 public class GetAllHistorySectionsQueryHandler : IRequestHandler<GetAllHistorySectionsQuery, Result<List<HistorySectionDto>>>
 {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/GetAllHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/GetAllHistorySectionsTests.cs
@@ -1,7 +1,7 @@
 using AutoMapper;
 using Moq;
 using VictoryCenter.BLL.DTOs.Admin.HistorySection;
-using VictoryCenter.BLL.Queries.Admin.HistorySections.GetAll;
+using VictoryCenter.BLL.Queries.Public.HistorySections.GetAll;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HistoryContents;
 using VictoryCenter.DAL.Enums;

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/HistoryController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/HistoryController.cs
@@ -1,20 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.History.Update;
 using VictoryCenter.BLL.DTOs.Admin.HistorySection;
-using VictoryCenter.BLL.Queries.Admin.HistorySections.GetAll;
 using VictoryCenter.WebAPI.Controllers.Common;
 
 namespace VictoryCenter.WebAPI.Controllers.Admin;
 
 public class HistoryController : AuthorizedApiController
 {
-    [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<HistorySectionDto>))]
-    public async Task<IActionResult> GetSections()
-    {
-        return HandleResult(await Mediator.Send(new GetAllHistorySectionsQuery()));
-    }
-
     [HttpPut]
     public async Task<IActionResult> UpdateSections([FromBody] List<UpdateHistorySectionDto> updateSections)
     {

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/HistoryController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/HistoryController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.DTOs.Admin.HistorySection;
+using VictoryCenter.BLL.Queries.Public.HistorySections.GetAll;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Public;
+
+public class HistoryController : BaseApiController
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<HistorySectionDto>))]
+    public async Task<IActionResult> GetSections()
+    {
+        return HandleResult(await Mediator.Send(new GetAllHistorySectionsQuery()));
+    }
+}


### PR DESCRIPTION
dev
## JIRA

* [GitHub ticker](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2560)

## Summary of change

Previously, the HISTORY GET endpoint was available only for the admin panel, which made it impossible to fetch data for the public page from the frontend. Added a public endpoint for accessing HISTORY data.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * History sections are now accessible via a public API endpoint for all users

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Back/pull/2562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->