### PR TITLE
Fix/issue-2521 [Single Program] [FAQ Template][Редагування]The system does not save new data after publishing or saving a draft

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -56,6 +56,9 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                         .ThenInclude(c => c.Language)
                         .Include(x => x.Localizations)
                         .ThenInclude(x => x.Language)
+                        .Include(x => x.Sections)
+                        .ThenInclude(s => s.Contents)
+                        .ThenInclude(c => (c as FaqQuestionProgramContent)!.FaqQuestion)
                 });
 
             if (program is null)


### PR DESCRIPTION
## GitHub ticket
* [#2521](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2521)

## Summary of issue
When editing a "Часті питання" section in an existing program, changes to "Питання" and "Відповідь" fields were not being saved. The title field saved correctly, but FAQ content always reverted to the original values after saving.

## Root cause
The `FaqQuestion` entity was not included in the database query inside `UpdateHippotherapyProgramHandler`. Because of this, EF Core was not tracking the entity, `content.FaqQuestion` was always `null`, and `UpdateFaqQuestionContent` exited immediately without applying any changes.

## Summary of change
- Added `.ThenInclude(c => (c as FaqQuestionProgramContent)!.FaqQuestion)` to the program query in `UpdateHippotherapyProgramHandler` so EF Core loads and tracks the `FaqQuestion` entity and persists changes on save

## Testing approach
1. Login as Admin
2. Create a new program
3. Add a "Часті питання" section with valid data
4. Make changes to "Питання" and "Відповідь" fields
5. Click "Зберегти" → in "Зберегти зміни?" popup click "Так"
6. Click "Зберегти як чернетку" → in "Зберегти зміни?" popup click "Так"
7. Go back to editing the same program
8. Verify that changes in "Питання" and "Відповідь" fields are saved correctly

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling when updating hippotherapy programs to ensure FAQ questions are properly tracked and managed during the update process, preventing orphaned references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Back/pull/2621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->