### PR TITLE
feature/issue-2681: [Main] Add opportunity to autosync Raised Metric values

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -7,6 +7,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
@@ -21,15 +22,18 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IMapper _mapper;
+    private readonly IMediator _mediator;
     private readonly IValidator<UpdateMainPageCommand> _validator;
 
     public UpdateMainPageHandler(
         IRepositoryWrapper repositoryWrapper,
         IMapper mapper,
+        IMediator mediator,
         IValidator<UpdateMainPageCommand> validator)
     {
         _repositoryWrapper = repositoryWrapper;
         _mapper = mapper;
+        _mediator = mediator;
         _validator = validator;
     }
 
@@ -60,6 +64,11 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
             await _repositoryWrapper.SaveChangesAsync();
 
             await SyncLocalizationsAsync(entity, request.UpdateMainPageDto.ImpactStatistics);
+
+            if (ShouldSyncRaisedFunds(request.UpdateMainPageDto.ImpactStatistics))
+            {
+                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+            }
 
             var resultEntity = await GetMainPageAggregateAsync(entity.Id);
             if (resultEntity is null)
@@ -191,6 +200,11 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
         entity.ImpactStatistics.ImageId = statDto.ImageId;
 
         SyncMetrics(entity.ImpactStatistics, statDto.Metrics);
+    }
+
+    private static bool ShouldSyncRaisedFunds(UpdateImpactStatisticDto? statDto)
+    {
+        return statDto?.Metrics.Any(metric => metric.Type == MetricType.Raised && metric.IsAutoSynced) == true;
     }
 
     private void SyncMetrics(ImpactStatisticsEntity stat, ICollection<UpdateMetricDto> metricsDto)

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -218,6 +218,7 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
                 existingMetric.Name = metricDto.Name;
                 existingMetric.Type = metricDto.Type;
                 existingMetric.Prefix = metricDto.Prefix;
+                existingMetric.IsAutoSynced = metricDto.IsAutoSynced;
             }
             else
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -67,7 +67,7 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
 
             if (ShouldSyncRaisedFunds(request.UpdateMainPageDto.ImpactStatistics))
             {
-                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+                await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
             }
 
             var resultEntity = await GetMainPageAggregateAsync(entity.Id);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommandHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommandHandler.cs
@@ -63,7 +63,7 @@ public class BulkDeleteReportFundsExpendituresRecordCommandHandler
                     ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportFundsExpendituresRecord)));
             }
 
-            await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+            await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
 
             return Result.Ok(request.Ids.ToArray());
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommandHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/BulkDelete/BulkDeleteReportFundsExpendituresRecordCommandHandler.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -12,12 +13,16 @@ namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDe
 public class BulkDeleteReportFundsExpendituresRecordCommandHandler
     : IRequestHandler<BulkDeleteReportFundsExpendituresRecordCommand, Result<long[]>>
 {
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<BulkDeleteReportFundsExpendituresRecordCommand> _validator;
 
     public BulkDeleteReportFundsExpendituresRecordCommandHandler(
-        IValidator<BulkDeleteReportFundsExpendituresRecordCommand> validator, IRepositoryWrapper repositoryWrapper)
+        IMediator mediator,
+        IValidator<BulkDeleteReportFundsExpendituresRecordCommand> validator,
+        IRepositoryWrapper repositoryWrapper)
     {
+        _mediator = mediator;
         _validator = validator;
         _repositoryWrapper = repositoryWrapper;
     }
@@ -57,6 +62,8 @@ public class BulkDeleteReportFundsExpendituresRecordCommandHandler
                 return Result.Fail(
                     ErrorMessagesConstants.FailedToDeleteEntities(typeof(ReportFundsExpendituresRecord)));
             }
+
+            await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
 
             return Result.Ok(request.Ids.ToArray());
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Create/CreateReportFundsExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Create/CreateReportFundsExpendituresRecordHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresRecords;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -15,15 +16,18 @@ public class CreateReportFundsExpendituresRecordHandler
     : IRequestHandler<CreateReportFundsExpendituresRecordCommand, Result<ReportFundsExpendituresRecordDto>>
 {
     private readonly IMapper _mapper;
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<CreateReportFundsExpendituresRecordCommand> _validator;
 
     public CreateReportFundsExpendituresRecordHandler(
         IMapper mapper,
+        IMediator mediator,
         IRepositoryWrapper repositoryWrapper,
         IValidator<CreateReportFundsExpendituresRecordCommand> validator)
     {
         _mapper = mapper;
+        _mediator = mediator;
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
     }
@@ -74,6 +78,8 @@ public class CreateReportFundsExpendituresRecordHandler
 
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
+                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+
                 return Result.Ok(_mapper.Map<ReportFundsExpendituresRecordDto>(entity));
             }
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Create/CreateReportFundsExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Create/CreateReportFundsExpendituresRecordHandler.cs
@@ -78,7 +78,7 @@ public class CreateReportFundsExpendituresRecordHandler
 
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
-                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+                await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
 
                 return Result.Ok(_mapper.Map<ReportFundsExpendituresRecordDto>(entity));
             }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Delete/DeleteReportFundsExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Delete/DeleteReportFundsExpendituresRecordHandler.cs
@@ -44,7 +44,7 @@ public class DeleteReportFundsExpendituresRecordHandler
         {
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
-                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+                await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
 
                 return Result.Ok(entityToDelete.Id);
             }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Delete/DeleteReportFundsExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Delete/DeleteReportFundsExpendituresRecordHandler.cs
@@ -2,6 +2,7 @@ using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -11,10 +12,14 @@ namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Delete
 public class DeleteReportFundsExpendituresRecordHandler
     : IRequestHandler<DeleteReportFundsExpendituresRecordCommand, Result<long>>
 {
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
 
-    public DeleteReportFundsExpendituresRecordHandler(IRepositoryWrapper repositoryWrapper)
+    public DeleteReportFundsExpendituresRecordHandler(
+        IMediator mediator,
+        IRepositoryWrapper repositoryWrapper)
     {
+        _mediator = mediator;
         _repositoryWrapper = repositoryWrapper;
     }
 
@@ -39,6 +44,8 @@ public class DeleteReportFundsExpendituresRecordHandler
         {
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
+                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+
                 return Result.Ok(entityToDelete.Id);
             }
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Update/UpdateReportFundsExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Update/UpdateReportFundsExpendituresRecordHandler.cs
@@ -93,7 +93,7 @@ public class UpdateReportFundsExpendituresRecordHandler
 
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
-                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+                await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
 
                 return Result.Ok(_mapper.Map<ReportFundsExpendituresRecordDto>(entityToUpdate));
             }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Update/UpdateReportFundsExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresRecords/Update/UpdateReportFundsExpendituresRecordHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresRecords;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -15,15 +16,18 @@ public class UpdateReportFundsExpendituresRecordHandler
     : IRequestHandler<UpdateReportFundsExpendituresRecordCommand, Result<ReportFundsExpendituresRecordDto>>
 {
     private readonly IMapper _mapper;
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<UpdateReportFundsExpendituresRecordCommand> _validator;
 
     public UpdateReportFundsExpendituresRecordHandler(
         IMapper mapper,
+        IMediator mediator,
         IRepositoryWrapper repositoryWrapper,
         IValidator<UpdateReportFundsExpendituresRecordCommand> validator)
     {
         _mapper = mapper;
+        _mediator = mediator;
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
     }
@@ -89,6 +93,8 @@ public class UpdateReportFundsExpendituresRecordHandler
 
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
+                await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
+
                 return Result.Ok(_mapper.Map<ReportFundsExpendituresRecordDto>(entityToUpdate));
             }
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/BaseMetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/BaseMetricDto.cs
@@ -8,4 +8,5 @@ public abstract record BaseMetricDto
     public string Name { get; init; } = null!;
     public MetricType Type { get; init; }
     public MetricPrefix? Prefix { get; init; }
+    public bool IsAutoSynced { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ImpactStatistics/Metrics/MetricDto.cs
@@ -10,6 +10,7 @@ public record MetricDto
     public string Name { get; init; } = null!;
     public MetricType Type { get; init; }
     public MetricPrefix? Prefix { get; init; }
+    public bool IsAutoSynced { get; init; }
     public bool IsHidden { get; init; }
     public long Priority { get; init; }
     public ICollection<MetricLocalizationDto> Localizations { get; init; } = [];

--- a/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/ReportFundsChangedNotification.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/ReportFundsChangedNotification.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace VictoryCenter.BLL.Notifications.ReportFunds;
+
+public record ReportFundsChangedNotification : INotification;

--- a/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/SyncRaisedFundsMetricHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/SyncRaisedFundsMetricHandler.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Notifications.ReportFunds;
+
+public class SyncRaisedFundsMetricHandler : INotificationHandler<ReportFundsChangedNotification>
+{
+    private const string EnglishLanguageCode = "en";
+
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public SyncRaisedFundsMetricHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task Handle(ReportFundsChangedNotification notification, CancellationToken cancellationToken)
+    {
+        var (incomeUahTotal, incomeUsdTotal, _, _, _, _) =
+            await _repositoryWrapper.ReportFundsExpendituresRecordsRepository.GetSummaryAsync();
+
+        var raisedMetric = await _repositoryWrapper.MetricRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<Metric>
+            {
+                AsNoTracking = false,
+                Filter = metric => metric.Type == MetricType.Raised,
+                Include = query => query
+                    .Include(metric => metric.Localizations)
+                    .ThenInclude(localization => localization.Language)
+            });
+
+        if (raisedMetric?.IsAutoSynced != true)
+        {
+            return;
+        }
+
+        raisedMetric.Value = ToMetricValue(incomeUahTotal);
+
+        var englishLanguage = await _repositoryWrapper.LocalizationLanguagesRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<LocalizationLanguage>
+            {
+                Filter = language => language.Code == EnglishLanguageCode
+            });
+
+        if (englishLanguage is null)
+        {
+            return;
+        }
+
+        var englishLocalization = raisedMetric.Localizations
+            .FirstOrDefault(localization => localization.Language.Code == EnglishLanguageCode);
+
+        if (englishLocalization is null)
+        {
+            await _repositoryWrapper.MetricLocalizationsRepository.CreateAsync(
+                new MetricLocalization
+                {
+                    EntityId = raisedMetric.Id,
+                    LanguageId = englishLanguage.Id,
+                    Value = incomeUsdTotal.ToString(CultureInfo.InvariantCulture),
+                    CreatedAt = DateTimeOffset.UtcNow
+                });
+        }
+        else
+        {
+            englishLocalization.Value = incomeUsdTotal.ToString(CultureInfo.InvariantCulture);
+            englishLocalization.TranslationStatus = TranslationStatus.Relevant;
+        }
+
+        await _repositoryWrapper.SaveChangesAsync();
+    }
+
+    private static int ToMetricValue(decimal value)
+    {
+        var roundedValue = Math.Round(value, 0, MidpointRounding.AwayFromZero);
+
+        if (roundedValue > int.MaxValue)
+        {
+            return int.MaxValue;
+        }
+
+        if (roundedValue < int.MinValue)
+        {
+            return int.MinValue;
+        }
+
+        return (int)roundedValue;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/SyncRaisedFundsMetricHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/SyncRaisedFundsMetricHandler.cs
@@ -50,6 +50,7 @@ public class SyncRaisedFundsMetricHandler : INotificationHandler<ReportFundsChan
 
         if (englishLanguage is null)
         {
+            await _repositoryWrapper.SaveChangesAsync();
             return;
         }
 

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MetricConfig.cs
@@ -31,6 +31,11 @@ internal class MetricConfig : IEntityTypeConfiguration<Metric>
             .Property(e => e.Prefix);
 
         entity
+            .Property(e => e.IsAutoSynced)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        entity
             .Property(e => e.StatisticId)
             .IsRequired();
 

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Metric.cs
@@ -13,6 +13,7 @@ public class Metric : BaseEntity, ITranslatedEntity<MetricLocalization>, IOrdera
     public string Name { get; set; } = null!;
     public MetricType Type { get; set; }
     public MetricPrefix? Prefix { get; set; }
+    public bool IsAutoSynced { get; set; }
     public bool IsHidden { get; set; }
     public long Priority { get; set; }
     public ICollection<MetricLocalization> Localizations { get; set; } = [];

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260528154919_AddAutoSyncAndLocalizationValueToMetrics.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260528154919_AddAutoSyncAndLocalizationValueToMetrics.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260528154919_AddAutoSyncAndLocalizationValueToMetrics")]
+    partial class AddAutoSyncAndLocalizationValueToMetrics
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260528154919_AddAutoSyncAndLocalizationValueToMetrics.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260528154919_AddAutoSyncAndLocalizationValueToMetrics.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutoSyncAndLocalizationValueToMetrics : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAutoSynced",
+                table: "Metrics",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAutoSynced",
+                table: "Metrics");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/UpdateMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/UpdateMainPageHandlerTests.cs
@@ -12,6 +12,7 @@ using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -348,6 +349,144 @@ public class UpdateMainPageHandlerTests
         Assert.Equal(2, entity.ImpactStatistics.Metrics.Count);
         Assert.Contains(entity.ImpactStatistics.Metrics, m => m.Id == 14 && m.Value == 999);
         Assert.Contains(entity.ImpactStatistics.Metrics, m => m.Name == "new-metric" && m.Value == 123);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldPublishReportFundsChangedNotification_WhenRaisedMetricIsAutoSynced()
+    {
+        // Arrange
+        var entity = GetExistingMainPageEntity(1);
+        var updateDto = GetValidUpdateDto(entity) with
+        {
+            ImpactStatistics = GetValidUpdateDto(entity).ImpactStatistics! with
+            {
+                Metrics =
+                [
+                    new UpdateMetricDto
+                    {
+                        Id = entity.ImpactStatistics!.Metrics.First().Id,
+                        Value = 500,
+                        Name = "raised",
+                        Type = MetricType.Raised,
+                        IsAutoSynced = true,
+                    },
+                ],
+            },
+        };
+
+        var command = new UpdateMainPageCommand(updateDto);
+
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .SetupSequence(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(entity)
+            .ReturnsAsync(entity);
+
+        _imageRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainAboutUs, entity.MainAboutUs))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, entity.MainPartners))
+            .Verifiable();
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mediatorMock
+            .Setup(mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.MainPage, MainPageDto>(entity))
+            .Returns(new MainPageDto { Id = entity.Id });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.True(entity.ImpactStatistics!.Metrics.Single().IsAutoSynced);
+        _mediatorMock.Verify(
+            mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.Is<CancellationToken>(token => token == CancellationToken.None)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotPublishReportFundsChangedNotification_WhenRaisedMetricIsNotAutoSynced()
+    {
+        // Arrange
+        var entity = GetExistingMainPageEntity(1);
+        var updateDto = GetValidUpdateDto(entity) with
+        {
+            ImpactStatistics = GetValidUpdateDto(entity).ImpactStatistics! with
+            {
+                Metrics =
+                [
+                    new UpdateMetricDto
+                    {
+                        Id = entity.ImpactStatistics!.Metrics.First().Id,
+                        Value = 500,
+                        Name = "raised",
+                        Type = MetricType.Raised,
+                        IsAutoSynced = false,
+                    },
+                ],
+            },
+        };
+
+        var command = new UpdateMainPageCommand(updateDto);
+
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .SetupSequence(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(entity)
+            .ReturnsAsync(entity);
+
+        _imageRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainAboutUs, entity.MainAboutUs))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, entity.MainPartners))
+            .Verifiable();
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.MainPage, MainPageDto>(entity))
+            .Returns(new MainPageDto { Id = entity.Id });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.False(entity.ImpactStatistics!.Metrics.Single().IsAutoSynced);
+        _mediatorMock.Verify(
+            mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private UpdateMainPageHandler CreateHandler() => new(

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/UpdateMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/UpdateMainPageHandlerTests.cs
@@ -2,6 +2,7 @@ using System.Transactions;
 using AutoMapper;
 using FluentValidation;
 using FluentValidation.Results;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.MainPage.Update;
@@ -26,6 +27,7 @@ public class UpdateMainPageHandlerTests
     private readonly Mock<IMainPageRepository> _mainPageRepositoryMock = new();
     private readonly Mock<IImageRepository> _imageRepositoryMock = new();
     private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<IMediator> _mediatorMock = new();
     private readonly Mock<IValidator<UpdateMainPageCommand>> _validatorMock = new();
 
     public UpdateMainPageHandlerTests()
@@ -351,6 +353,7 @@ public class UpdateMainPageHandlerTests
     private UpdateMainPageHandler CreateHandler() => new(
         _repositoryWrapperMock.Object,
         _mapperMock.Object,
+        _mediatorMock.Object,
         _validatorMock.Object);
 
     private void SetupValidationSuccess()

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Notifications/ReportFunds/SyncRaisedFundsMetricHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Notifications/ReportFunds/SyncRaisedFundsMetricHandlerTests.cs
@@ -1,0 +1,231 @@
+using Moq;
+using VictoryCenter.BLL.Notifications.ReportFunds;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.MainPage;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Notifications.ReportFunds;
+
+public class SyncRaisedFundsMetricHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<IReportFundsExpendituresRecordsRepository> _recordsRepositoryMock = new();
+    private readonly Mock<IMetricRepository> _metricRepositoryMock = new();
+    private readonly Mock<ILocalizationLanguagesRepository> _languagesRepositoryMock = new();
+    private readonly Mock<IMetricLocalizationsRepository> _metricLocalizationsRepositoryMock = new();
+
+    public SyncRaisedFundsMetricHandlerTests()
+    {
+        _repositoryWrapperMock
+            .SetupGet(wrapper => wrapper.ReportFundsExpendituresRecordsRepository)
+            .Returns(_recordsRepositoryMock.Object);
+        _repositoryWrapperMock
+            .SetupGet(wrapper => wrapper.MetricRepository)
+            .Returns(_metricRepositoryMock.Object);
+        _repositoryWrapperMock
+            .SetupGet(wrapper => wrapper.LocalizationLanguagesRepository)
+            .Returns(_languagesRepositoryMock.Object);
+        _repositoryWrapperMock
+            .SetupGet(wrapper => wrapper.MetricLocalizationsRepository)
+            .Returns(_metricLocalizationsRepositoryMock.Object);
+
+        _repositoryWrapperMock
+            .Setup(wrapper => wrapper.SaveChangesAsync())
+            .ReturnsAsync(1);
+        _metricLocalizationsRepositoryMock
+            .Setup(repository => repository.CreateAsync(It.IsAny<MetricLocalization>()))
+            .ReturnsAsync((MetricLocalization localization) => localization);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateRaisedMetricAndExistingEnglishLocalization_WhenAutoSynced()
+    {
+        // Arrange
+        var englishLanguage = new LocalizationLanguage { Id = 2, Code = "en", Name = "English" };
+        var metric = new Metric
+        {
+            Id = 10,
+            Type = MetricType.Raised,
+            IsAutoSynced = true,
+            Value = 1,
+            Name = "raised",
+            Localizations =
+            [
+                new MetricLocalization
+                {
+                    EntityId = 10,
+                    LanguageId = englishLanguage.Id,
+                    Language = englishLanguage,
+                    Value = "old",
+                    TranslationStatus = TranslationStatus.Outdated,
+                },
+            ],
+        };
+
+        SetupSummary(123.5m, 45.6m);
+        SetupRaisedMetric(metric);
+        SetupLanguages([englishLanguage]);
+
+        var handler = CreateHandler();
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(124, metric.Value);
+
+        var englishLocalization = metric.Localizations.Single();
+        Assert.Equal("45.6", englishLocalization.Value);
+        Assert.Equal(TranslationStatus.Relevant, englishLocalization.TranslationStatus);
+
+        _repositoryWrapperMock.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
+        _metricLocalizationsRepositoryMock.Verify(
+            repository => repository.CreateAsync(It.IsAny<MetricLocalization>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSaveMetricValue_WhenEnglishLanguageDoesNotExist()
+    {
+        // Arrange
+        var metric = new Metric
+        {
+            Id = 10,
+            Type = MetricType.Raised,
+            IsAutoSynced = true,
+            Value = 1,
+            Name = "raised",
+            Localizations = [],
+        };
+
+        SetupSummary(321.4m, 75.2m);
+        SetupRaisedMetric(metric);
+        SetupLanguages([]);
+
+        var handler = CreateHandler();
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(321, metric.Value);
+        _repositoryWrapperMock.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
+        _metricLocalizationsRepositoryMock.Verify(
+            repository => repository.CreateAsync(It.IsAny<MetricLocalization>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateEnglishLocalization_WhenItDoesNotExist()
+    {
+        // Arrange
+        var englishLanguage = new LocalizationLanguage { Id = 2, Code = "en", Name = "English" };
+        var metric = new Metric
+        {
+            Id = 10,
+            Type = MetricType.Raised,
+            IsAutoSynced = true,
+            Value = 1,
+            Name = "raised",
+            Localizations = [],
+        };
+
+        SetupSummary(99.5m, 78.9m);
+        SetupRaisedMetric(metric);
+        SetupLanguages([
+            new LocalizationLanguage { Id = 1, Code = "uk", Name = "Ukrainian" },
+            englishLanguage,
+        ]);
+
+        var handler = CreateHandler();
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(100, metric.Value);
+        _metricLocalizationsRepositoryMock.Verify(
+            repository => repository.CreateAsync(It.Is<MetricLocalization>(localization =>
+                localization.EntityId == metric.Id
+                && localization.LanguageId == englishLanguage.Id
+                && localization.Value == "78.9")),
+            Times.Once);
+        _repositoryWrapperMock.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDoNothing_WhenRaisedMetricIsNotAutoSynced()
+    {
+        // Arrange
+        var metric = new Metric
+        {
+            Id = 10,
+            Type = MetricType.Raised,
+            IsAutoSynced = false,
+            Value = 1,
+            Name = "raised",
+            Localizations = [],
+        };
+
+        SetupSummary(123.5m, 45.6m);
+        SetupRaisedMetric(metric);
+
+        var handler = CreateHandler();
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, metric.Value);
+        _languagesRepositoryMock.Verify(
+            repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<LocalizationLanguage>>()),
+            Times.Never);
+        _repositoryWrapperMock.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+    }
+
+    private SyncRaisedFundsMetricHandler CreateHandler() => new(_repositoryWrapperMock.Object);
+
+    private void SetupSummary(decimal incomeUahTotal, decimal incomeUsdTotal)
+    {
+        _recordsRepositoryMock
+            .Setup(repository => repository.GetSummaryAsync())
+            .ReturnsAsync((incomeUahTotal, incomeUsdTotal, 0, 0, 0, 0));
+    }
+
+    private void SetupRaisedMetric(Metric? metric)
+    {
+        _metricRepositoryMock
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Metric>>()))
+            .ReturnsAsync((QueryOptions<Metric>? options) =>
+            {
+                if (metric is null)
+                {
+                    return null;
+                }
+
+                var filter = options?.Filter;
+                return filter is null || filter.Compile()(metric)
+                    ? metric
+                    : null;
+            });
+    }
+
+    private void SetupLanguages(IEnumerable<LocalizationLanguage> languages)
+    {
+        _languagesRepositoryMock
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync((QueryOptions<LocalizationLanguage>? options) =>
+            {
+                var filter = options?.Filter;
+                return filter is null
+                    ? languages.FirstOrDefault()
+                    : languages.FirstOrDefault(filter.Compile());
+            });
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordTests.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
@@ -14,12 +15,14 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpendituresRe
 public class BulkDeleteReportFundsExpendituresRecordTests
 {
     private readonly Mock<IReportFundsExpendituresRecordsRepository> _recordsRepositoryMock;
+    private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
     private readonly IValidator<BulkDeleteReportFundsExpendituresRecordCommand> _validator;
 
     public BulkDeleteReportFundsExpendituresRecordTests()
     {
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _mediatorMock = new Mock<IMediator>();
         _recordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
         _validator = new BulkDeleteReportFundsExpendituresRecordCommandValidator();
     }
@@ -34,7 +37,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         SetupDependencies(entities, 1);
 
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -52,7 +55,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         // Arrange
         var command = new BulkDeleteReportFundsExpendituresRecordCommand(new[] { invalidId });
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -70,7 +73,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         // Arrange
         var command = new BulkDeleteReportFundsExpendituresRecordCommand(new[] { 1L, 1L });
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -89,7 +92,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         // Arrange
         var command = new BulkDeleteReportFundsExpendituresRecordCommand(Array.Empty<long>());
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -110,7 +113,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         var ids = Enumerable.Range(1, maxCount + 1).Select(i => (long)i).ToArray();
         var command = new BulkDeleteReportFundsExpendituresRecordCommand(ids);
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -135,7 +138,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         SetupDependencies(entities, 0);
 
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -157,7 +160,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         SetupDependencies(entities, 0);
 
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -191,7 +194,7 @@ public class BulkDeleteReportFundsExpendituresRecordTests
             .ThrowsAsync(new DbUpdateException());
 
         var handler = new BulkDeleteReportFundsExpendituresRecordCommandHandler(
-            _validator, _repositoryWrapperMock.Object);
+            _mediatorMock.Object, _validator, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/BulkDeleteReportFundsExpendituresRecordTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.BulkDelete;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.BLL.Validators.ReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -45,6 +46,11 @@ public class BulkDeleteReportFundsExpendituresRecordTests
         // Assert
         Assert.True(result.IsSuccess);
         Assert.Equal(ids, result.Value);
+        _mediatorMock.Verify(
+            mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.Is<CancellationToken>(token => token == CancellationToken.None)),
+            Times.Once);
     }
 
     [Theory]
@@ -219,5 +225,10 @@ public class BulkDeleteReportFundsExpendituresRecordTests
             repository.DeleteRange(It.IsAny<IEnumerable<ReportFundsExpendituresRecord>>()));
 
         _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
+        _mediatorMock
+            .Setup(mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Create;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresRecords;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.BLL.Validators.ReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
@@ -93,6 +94,11 @@ public class CreateReportFundsExpendituresRecordTests
         Assert.True(result.IsSuccess);
         Assert.Equal(_recordDto.CategoryId, result.Value.CategoryId);
         Assert.Equal(_recordDto.AmountUah, result.Value.AmountUah);
+        _mediatorMock.Verify(
+            mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.Is<CancellationToken>(token => token == CancellationToken.None)),
+            Times.Once);
     }
 
     [Fact]
@@ -259,6 +265,11 @@ public class CreateReportFundsExpendituresRecordTests
             .ReturnsAsync(existingRecordInCategory);
 
         _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
+        _mediatorMock
+            .Setup(mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _mapperMock
             .Setup(mapper => mapper.Map<ReportFundsExpendituresRecord>(It.IsAny<CreateReportFundsExpendituresRecordDto>()))

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/CreateReportFundsExpendituresRecordTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using MediatR;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Moq;
@@ -18,6 +19,7 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpendituresRe
 public class CreateReportFundsExpendituresRecordTests
 {
     private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
     private readonly Mock<IReportFundsExpendituresRecordsRepository> _recordsRepositoryMock;
     private readonly Mock<IReportFundsExpendituresCategoriesRepository> _categoriesRepositoryMock;
@@ -62,6 +64,7 @@ public class CreateReportFundsExpendituresRecordTests
     public CreateReportFundsExpendituresRecordTests()
     {
         _mapperMock = new Mock<IMapper>();
+        _mediatorMock = new Mock<IMediator>();
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _recordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
         _categoriesRepositoryMock = new Mock<IReportFundsExpendituresCategoriesRepository>();
@@ -77,6 +80,7 @@ public class CreateReportFundsExpendituresRecordTests
         SetupDependencies(category: _category, saveResult: 1);
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -98,6 +102,7 @@ public class CreateReportFundsExpendituresRecordTests
         var invalidDto = _createDto with { CategoryId = 0 };
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -118,6 +123,7 @@ public class CreateReportFundsExpendituresRecordTests
         SetupDependencies(category: null, saveResult: 1);
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -147,6 +153,7 @@ public class CreateReportFundsExpendituresRecordTests
         SetupDependencies(category: expenseCategory, saveResult: 1);
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -167,6 +174,7 @@ public class CreateReportFundsExpendituresRecordTests
         SetupDependencies(category: _category, saveResult: 1, existingRecordInCategory: _recordEntity);
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -187,6 +195,7 @@ public class CreateReportFundsExpendituresRecordTests
         SetupDependencies(category: _category, saveResult: 0);
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -211,6 +220,7 @@ public class CreateReportFundsExpendituresRecordTests
 
         var handler = new CreateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/DeleteReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/DeleteReportFundsExpendituresRecordTests.cs
@@ -1,3 +1,4 @@
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Delete;
@@ -12,6 +13,7 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpendituresRe
 public class DeleteReportFundsExpendituresRecordTests
 {
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IReportFundsExpendituresRecordsRepository> _recordsRepositoryMock;
 
     private readonly ReportFundsExpendituresRecord _record = new()
@@ -26,6 +28,7 @@ public class DeleteReportFundsExpendituresRecordTests
     public DeleteReportFundsExpendituresRecordTests()
     {
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _mediatorMock = new Mock<IMediator>();
         _recordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
     }
 
@@ -34,7 +37,7 @@ public class DeleteReportFundsExpendituresRecordTests
     {
         // Arrange
         SetupDependencies(_record, saveResult: 1);
-        var handler = new DeleteReportFundsExpendituresRecordHandler(_repositoryWrapperMock.Object);
+        var handler = new DeleteReportFundsExpendituresRecordHandler(_mediatorMock.Object, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -51,7 +54,7 @@ public class DeleteReportFundsExpendituresRecordTests
     {
         // Arrange
         SetupDependencies(null, saveResult: 1);
-        var handler = new DeleteReportFundsExpendituresRecordHandler(_repositoryWrapperMock.Object);
+        var handler = new DeleteReportFundsExpendituresRecordHandler(_mediatorMock.Object, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -70,7 +73,7 @@ public class DeleteReportFundsExpendituresRecordTests
     {
         // Arrange
         SetupDependencies(_record, saveResult: 0);
-        var handler = new DeleteReportFundsExpendituresRecordHandler(_repositoryWrapperMock.Object);
+        var handler = new DeleteReportFundsExpendituresRecordHandler(_mediatorMock.Object, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -92,7 +95,7 @@ public class DeleteReportFundsExpendituresRecordTests
         _repositoryWrapperMock
             .Setup(wrapper => wrapper.SaveChangesAsync())
             .ThrowsAsync(new DbUpdateException("Database error"));
-        var handler = new DeleteReportFundsExpendituresRecordHandler(_repositoryWrapperMock.Object);
+        var handler = new DeleteReportFundsExpendituresRecordHandler(_mediatorMock.Object, _repositoryWrapperMock.Object);
 
         // Act
         var result = await handler.Handle(

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/DeleteReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/DeleteReportFundsExpendituresRecordTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Delete;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
@@ -47,6 +48,11 @@ public class DeleteReportFundsExpendituresRecordTests
         // Assert
         Assert.True(result.IsSuccess);
         Assert.Equal(_record.Id, result.Value);
+        _mediatorMock.Verify(
+            mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.Is<CancellationToken>(token => token == CancellationToken.None)),
+            Times.Once);
     }
 
     [Fact]
@@ -120,5 +126,10 @@ public class DeleteReportFundsExpendituresRecordTests
 
         _recordsRepositoryMock.Setup(repository => repository.Delete(It.IsAny<ReportFundsExpendituresRecord>()));
         _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
+        _mediatorMock
+            .Setup(mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/UpdateReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/UpdateReportFundsExpendituresRecordTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpendituresRecords.Update;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresRecords;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.BLL.Validators.ReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Enums;
@@ -82,6 +83,11 @@ public class UpdateReportFundsExpendituresRecordTests
         Assert.True(result.IsSuccess);
         Assert.Equal(_recordDto.AmountUah, result.Value.AmountUah);
         Assert.Equal(_recordDto.AmountUsd, result.Value.AmountUsd);
+        _mediatorMock.Verify(
+            mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.Is<CancellationToken>(token => token == CancellationToken.None)),
+            Times.Once);
     }
 
     [Fact]
@@ -341,6 +347,11 @@ public class UpdateReportFundsExpendituresRecordTests
 
         _recordsRepositoryMock.Setup(repository => repository.Update(It.IsAny<ReportFundsExpendituresRecord>()));
         _repositoryWrapperMock.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveResult);
+        _mediatorMock
+            .Setup(mediator => mediator.Publish(
+                It.IsAny<ReportFundsChangedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         _mapperMock
             .Setup(mapper => mapper.Map(

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/UpdateReportFundsExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresRecords/UpdateReportFundsExpendituresRecordTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using MediatR;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Moq;
@@ -18,6 +19,7 @@ namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpendituresRe
 public class UpdateReportFundsExpendituresRecordTests
 {
     private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
     private readonly Mock<IReportFundsExpendituresRecordsRepository> _recordsRepositoryMock;
     private readonly Mock<IReportFundsExpendituresCategoriesRepository> _categoriesRepositoryMock;
@@ -53,6 +55,7 @@ public class UpdateReportFundsExpendituresRecordTests
     public UpdateReportFundsExpendituresRecordTests()
     {
         _mapperMock = new Mock<IMapper>();
+        _mediatorMock = new Mock<IMediator>();
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _recordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
         _categoriesRepositoryMock = new Mock<IReportFundsExpendituresCategoriesRepository>();
@@ -66,6 +69,7 @@ public class UpdateReportFundsExpendituresRecordTests
         SetupDependencies(recordToUpdate: _existingRecord, category: null, saveResult: 1);
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -95,6 +99,7 @@ public class UpdateReportFundsExpendituresRecordTests
         SetupDependencies(recordToUpdate: _existingRecord, category: matchingCategory, saveResult: 1);
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -114,6 +119,7 @@ public class UpdateReportFundsExpendituresRecordTests
         var invalidDto = _updateDto with { CategoryId = 0 };
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -134,6 +140,7 @@ public class UpdateReportFundsExpendituresRecordTests
         SetupDependencies(recordToUpdate: null, category: null, saveResult: 1);
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -158,6 +165,7 @@ public class UpdateReportFundsExpendituresRecordTests
 
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -188,6 +196,7 @@ public class UpdateReportFundsExpendituresRecordTests
         SetupDependencies(recordToUpdate: _existingRecord, category: expenseCategory, saveResult: 1);
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -231,6 +240,7 @@ public class UpdateReportFundsExpendituresRecordTests
 
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -251,6 +261,7 @@ public class UpdateReportFundsExpendituresRecordTests
         SetupDependencies(recordToUpdate: _existingRecord, category: null, saveResult: 0);
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 
@@ -275,6 +286,7 @@ public class UpdateReportFundsExpendituresRecordTests
 
         var handler = new UpdateReportFundsExpendituresRecordHandler(
             _mapperMock.Object,
+            _mediatorMock.Object,
             _repositoryWrapperMock.Object,
             _validator);
 


### PR DESCRIPTION
dev
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2681

## Summary of issue

Main Page Raised Funds metric needs to support the UI-controlled `IsAutoSynced` flag and automatically synchronize UAH/USD values with reporting income totals when auto-sync is enabled.

## Summary of change

**DAL**
* Added `IsAutoSynced` field to the `Metric` entity.
* Configured `IsAutoSynced` as a required metric property with default value `false`.
* Added database schema support for metric auto-sync and metric localization value.

**BLL**
* Added `IsAutoSynced` to metric request DTOs through `BaseMetricDto`.
* Added `IsAutoSynced` to `MetricDto` response model.
* Added `Value` support for metric localization DTOs.
* Updated Main Page metric update logic to persist `IsAutoSynced`.
* Added `ReportFundsChangedNotification`.
* Added notification handler to synchronize Raised Funds metric from reporting income totals.
* Synchronization updates UAH value in `Metric.Value`.
* Synchronization updates USD value in English `MetricLocalization.Value`.
* Reporting create, update, delete, and bulk delete handlers now publish synchronization notification after successful save.
* Main Page update handler publishes synchronization notification when Raised metric is set to `IsAutoSynced = true`.

**WebAPI**
* No WebAPI controller changes.
* Existing endpoints now return and accept the new metric fields through updated DTOs.

**Public page**
* Public Main Page response now includes `IsAutoSynced` for metrics.
* Public Main Page response now includes localized USD `Value` for metric localizations.

## Testing approach
* Updated affected unit test setup to inject mocked `IMediator`.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fundraising metrics now automatically update whenever financial records change, providing real-time visibility into fundraising progress
  * Metrics can be configured for automatic synchronization to eliminate manual tracking and ensure impact statistics remain current
  * Financial record modifications instantly propagate to related metrics without requiring user intervention

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Back/pull/2682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->