### PR TITLE
Feature/issue 2524: [Main] Backend Support for Donations Section on Main Page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/MainPage/Create/CreateMainPageLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/MainPage/Create/CreateMainPageLocalizationHandler.cs
@@ -21,6 +21,7 @@ public class CreateMainPageLocalizationHandler : IRequestHandler<CreateMainPageL
     private readonly ILocalizationService<MainPageEntity, MainPageLocalization> _mainPageLocalizationService;
     private readonly ILocalizationService<MainAboutUs, MainAboutUsLocalization> _mainAboutUsLocalizationService;
     private readonly ILocalizationService<MainPartners, MainPartnersLocalization> _mainPartnersLocalizationService;
+    private readonly ILocalizationService<MainDonations, MainDonationsLocalization> _mainDonationsLocalizationService;
 
     public CreateMainPageLocalizationHandler(
         IMapper mapper,
@@ -28,7 +29,8 @@ public class CreateMainPageLocalizationHandler : IRequestHandler<CreateMainPageL
         IRepositoryWrapper repositoryWrapper,
         ILocalizationService<MainPageEntity, MainPageLocalization> mainPageLocalizationService,
         ILocalizationService<MainAboutUs, MainAboutUsLocalization> mainAboutUsLocalizationService,
-        ILocalizationService<MainPartners, MainPartnersLocalization> mainPartnersLocalizationService)
+        ILocalizationService<MainPartners, MainPartnersLocalization> mainPartnersLocalizationService,
+        ILocalizationService<MainDonations, MainDonationsLocalization> mainDonationsLocalizationService)
     {
         _mapper = mapper;
         _validator = validator;
@@ -36,6 +38,7 @@ public class CreateMainPageLocalizationHandler : IRequestHandler<CreateMainPageL
         _mainPageLocalizationService = mainPageLocalizationService;
         _mainAboutUsLocalizationService = mainAboutUsLocalizationService;
         _mainPartnersLocalizationService = mainPartnersLocalizationService;
+        _mainDonationsLocalizationService = mainDonationsLocalizationService;
     }
 
     public async Task<Result<MainPageLocalizationDto>> Handle(CreateMainPageLocalizationCommand request, CancellationToken cancellationToken)
@@ -69,12 +72,22 @@ public class CreateMainPageLocalizationHandler : IRequestHandler<CreateMainPageL
                 mainPartnersDto = _mapper.Map<MainPartnersLocalizationDto>(createdPartners);
             }
 
+            MainDonationsLocalizationDto? mainDonationsDto = null;
+            if (dto.MainDonations is not null)
+            {
+                var mainDonationsEntity = _mapper.Map<MainDonationsLocalization>(dto.MainDonations);
+                mainDonationsEntity.LanguageId = dto.LanguageId;
+                var createdDonations = await _mainDonationsLocalizationService.CreateEntityLocalizationAsync(mainDonationsEntity);
+                mainDonationsDto = _mapper.Map<MainDonationsLocalizationDto>(createdDonations);
+            }
+
             transaction.Complete();
 
             var response = _mapper.Map<MainPageLocalizationDto>(createdMainPage) with
             {
                 MainAboutUs = mainAboutUsDto,
-                MainPartners = mainPartnersDto
+                MainPartners = mainPartnersDto,
+                MainDonations = mainDonationsDto
             };
 
             return Result.Ok(response);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/MainPage/Update/UpdateMainPageLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/MainPage/Update/UpdateMainPageLocalizationHandler.cs
@@ -22,6 +22,7 @@ public class UpdateMainPageLocalizationHandler : IRequestHandler<UpdateMainPageL
     private readonly ILocalizationService<MainPageEntity, MainPageLocalization> _mainPageLocalizationService;
     private readonly ILocalizationService<MainAboutUs, MainAboutUsLocalization> _mainAboutUsLocalizationService;
     private readonly ILocalizationService<MainPartners, MainPartnersLocalization> _mainPartnersLocalizationService;
+    private readonly ILocalizationService<MainDonations, MainDonationsLocalization> _mainDonationsLocalizationService;
 
     public UpdateMainPageLocalizationHandler(
         IMapper mapper,
@@ -29,7 +30,8 @@ public class UpdateMainPageLocalizationHandler : IRequestHandler<UpdateMainPageL
         IValidator<UpdateMainPageLocalizationCommand> validator,
         ILocalizationService<MainPageEntity, MainPageLocalization> mainPageLocalizationService,
         ILocalizationService<MainAboutUs, MainAboutUsLocalization> mainAboutUsLocalizationService,
-        ILocalizationService<MainPartners, MainPartnersLocalization> mainPartnersLocalizationService)
+        ILocalizationService<MainPartners, MainPartnersLocalization> mainPartnersLocalizationService,
+        ILocalizationService<MainDonations, MainDonationsLocalization> mainDonationsLocalizationService)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
@@ -37,6 +39,7 @@ public class UpdateMainPageLocalizationHandler : IRequestHandler<UpdateMainPageL
         _mainPageLocalizationService = mainPageLocalizationService;
         _mainAboutUsLocalizationService = mainAboutUsLocalizationService;
         _mainPartnersLocalizationService = mainPartnersLocalizationService;
+        _mainDonationsLocalizationService = mainDonationsLocalizationService;
     }
 
     public async Task<Result<MainPageLocalizationDto>> Handle(UpdateMainPageLocalizationCommand request, CancellationToken cancellationToken)
@@ -54,6 +57,7 @@ public class UpdateMainPageLocalizationHandler : IRequestHandler<UpdateMainPageL
                     Include = query => query
                         .Include(e => e.MainAboutUs)
                         .Include(e => e.MainPartners)
+                        .Include(e => e.MainDonations)
                 });
 
             if (mainPage is null)
@@ -98,12 +102,28 @@ public class UpdateMainPageLocalizationHandler : IRequestHandler<UpdateMainPageL
                 mainPartnersDto = _mapper.Map<MainPartnersLocalizationDto>(updatedPartners);
             }
 
+            MainDonationsLocalizationDto? mainDonationsDto = null;
+            if (dto.MainDonations is not null)
+            {
+                if (mainPage.MainDonations is null)
+                {
+                    return Result.Fail<MainPageLocalizationDto>(ErrorMessagesConstants.NotFound());
+                }
+
+                var mainDonationsLocalizationEntity = _mapper.Map<MainDonationsLocalization>(dto.MainDonations);
+                mainDonationsLocalizationEntity.EntityId = mainPage.MainDonations.Id;
+                mainDonationsLocalizationEntity.LanguageId = request.LanguageId;
+                var updatedDonations = await _mainDonationsLocalizationService.UpdateEntityLocalizationAsync(mainDonationsLocalizationEntity);
+                mainDonationsDto = _mapper.Map<MainDonationsLocalizationDto>(updatedDonations);
+            }
+
             transaction.Complete();
 
             var response = _mapper.Map<MainPageLocalizationDto>(updatedMainPageLocalization) with
             {
                 MainAboutUs = mainAboutUsDto,
-                MainPartners = mainPartnersDto
+                MainPartners = mainPartnersDto,
+                MainDonations = mainDonationsDto
             };
 
             return Result.Ok(response);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Create/CreateMainPageHandler.cs
@@ -58,6 +58,11 @@ public class CreateMainPageHandler : IRequestHandler<CreateMainPageCommand, Resu
                 requestedImageIds.Add(request.CreateMainPageDto.ImpactStatistics.ImageId!.Value);
             }
 
+            if (request.CreateMainPageDto.MainDonations?.ImageId.HasValue == true)
+            {
+                requestedImageIds.Add(request.CreateMainPageDto.MainDonations.ImageId!.Value);
+            }
+
             if (requestedImageIds.Count > 0)
             {
                 var existingImageIds = (await _repositoryWrapper.ImageRepository
@@ -102,6 +107,8 @@ public class CreateMainPageHandler : IRequestHandler<CreateMainPageCommand, Resu
                         .Include(e => e.Localizations).ThenInclude(l => l.Language)
                         .Include(e => e.MainAboutUs).ThenInclude(a => a!.Localizations).ThenInclude(l => l.Language)
                         .Include(e => e.MainPartners).ThenInclude(p => p!.Localizations).ThenInclude(l => l.Language)
+                        .Include(e => e.MainDonations).ThenInclude(d => d!.Image)
+                        .Include(e => e.MainDonations).ThenInclude(d => d!.Localizations).ThenInclude(l => l.Language)
                         .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Image)
                         .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Localizations).ThenInclude(l => l.Language)
                         .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics).ThenInclude(m => m.Localizations).ThenInclude(l => l.Language)

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/MainPage/Update/UpdateMainPageHandler.cs
@@ -100,6 +100,8 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
                 .Include(e => e.Localizations).ThenInclude(l => l.Language)
                 .Include(e => e.MainAboutUs).ThenInclude(a => a!.Localizations).ThenInclude(l => l.Language)
                 .Include(e => e.MainPartners).ThenInclude(p => p!.Localizations).ThenInclude(l => l.Language)
+                .Include(e => e.MainDonations).ThenInclude(d => d!.Image)
+                .Include(e => e.MainDonations).ThenInclude(d => d!.Localizations).ThenInclude(l => l.Language)
                 .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Image)
                 .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Localizations)
                 .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics).ThenInclude(m => m.Localizations),
@@ -125,6 +127,11 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
         if (requestDto.ImpactStatistics?.ImageId.HasValue == true)
         {
             requestedImageIds.Add(requestDto.ImpactStatistics.ImageId!.Value);
+        }
+
+        if (requestDto.MainDonations?.ImageId.HasValue == true)
+        {
+            requestedImageIds.Add(requestDto.MainDonations.ImageId!.Value);
         }
 
         if (requestedImageIds.Count == 0)
@@ -178,6 +185,18 @@ public class UpdateMainPageHandler : IRequestHandler<UpdateMainPageCommand, Resu
             else
             {
                 _mapper.Map(dto.MainPartners, entity.MainPartners);
+            }
+        }
+
+        if (dto.MainDonations is not null)
+        {
+            if (entity.MainDonations is null)
+            {
+                entity.MainDonations = _mapper.Map<DAL.Entities.MainDonations>(dto.MainDonations);
+            }
+            else
+            {
+                _mapper.Map(dto.MainDonations, entity.MainDonations);
             }
         }
     }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/CreateMainDonationsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/CreateMainDonationsLocalizationDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+
+public record CreateMainDonationsLocalizationDto : BaseMainPageLocalizationDto
+{
+    public long EntityId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/CreateMainPageLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/CreateMainPageLocalizationDto.cs
@@ -8,4 +8,5 @@ public record CreateMainPageLocalizationDto : BaseMainPageLocalizationDto, ILoca
     public long LanguageId { get; init; }
     public CreateMainAboutUsLocalizationDto? MainAboutUs { get; init; }
     public CreateMainPartnersLocalizationDto? MainPartners { get; init; }
+    public CreateMainDonationsLocalizationDto? MainDonations { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/MainDonationsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/MainDonationsLocalizationDto.cs
@@ -3,12 +3,9 @@ using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
 
-public record MainPageLocalizationDto : BaseMainPageLocalizationDto
+public record MainDonationsLocalizationDto : BaseMainPageLocalizationDto
 {
     public long EntityId { get; init; }
     public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
     public TranslationStatus TranslationStatus { get; init; }
-    public MainAboutUsLocalizationDto? MainAboutUs { get; init; }
-    public MainPartnersLocalizationDto? MainPartners { get; init; }
-    public MainDonationsLocalizationDto? MainDonations { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/UpdateMainDonationsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/UpdateMainDonationsLocalizationDto.cs
@@ -1,0 +1,5 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+
+public record UpdateMainDonationsLocalizationDto : BaseMainPageLocalizationDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/UpdateMainPageLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/MainPage/UpdateMainPageLocalizationDto.cs
@@ -4,4 +4,5 @@ public record UpdateMainPageLocalizationDto : BaseMainPageLocalizationDto
 {
     public UpdateMainAboutUsLocalizationDto? MainAboutUs { get; init; }
     public UpdateMainPartnersLocalizationDto? MainPartners { get; init; }
+    public UpdateMainDonationsLocalizationDto? MainDonations { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/BaseMainDonationsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/BaseMainDonationsDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+public abstract record BaseMainDonationsDto
+{
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+    public long? ImageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/CreateMainDonationsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/CreateMainDonationsDto.cs
@@ -1,0 +1,5 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+public record CreateMainDonationsDto : BaseMainDonationsDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/MainDonationsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/MainDonationsDto.cs
@@ -1,0 +1,13 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+public record MainDonationsDto
+{
+    public long Id { get; init; }
+    public string Title { get; init; } = null!;
+    public string Description { get; init; } = null!;
+    public ImageDto? Image { get; init; }
+    public ICollection<MainDonationsLocalizationDto> Localizations { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/UpdateMainDonationsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainDonations/UpdateMainDonationsDto.cs
@@ -1,0 +1,5 @@
+namespace VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+public record UpdateMainDonationsDto : BaseMainDonationsDto
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/CreateMainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/CreateMainPageDto.cs
@@ -1,5 +1,6 @@
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 
 namespace VictoryCenter.BLL.DTOs.Admin.MainPages;
@@ -8,5 +9,6 @@ public record CreateMainPageDto : BaseMainPageDto
 {
     public CreateMainAboutUsDto? MainAboutUs { get; init; }
     public CreateMainPartnersDto? MainPartners { get; init; }
+    public CreateMainDonationsDto? MainDonations { get; init; }
     public CreateImpactStatisticDto? ImpactStatistics { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/MainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/MainPageDto.cs
@@ -1,5 +1,6 @@
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
 using VictoryCenter.BLL.DTOs.Common;
@@ -15,6 +16,7 @@ public record MainPageDto
 
     public MainAboutUsDto? MainAboutUs { get; init; }
     public MainPartnersDto? MainPartners { get; init; }
+    public MainDonationsDto? MainDonations { get; init; }
     public ImpactStatisticDto? ImpactStatistics { get; init; }
     public ICollection<MainPageLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/UpdateMainPageDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/MainPages/UpdateMainPageDto.cs
@@ -1,4 +1,5 @@
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 
@@ -8,5 +9,6 @@ public record UpdateMainPageDto : BaseMainPageDto
 {
     public UpdateMainAboutUsDto? MainAboutUs { get; init; }
     public UpdateMainPartnersDto? MainPartners { get; init; }
+    public UpdateMainDonationsDto? MainDonations { get; init; }
     public UpdateImpactStatisticDto? ImpactStatistics { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/MainPage/MainPageLocalizationProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/MainPage/MainPageLocalizationProfile.cs
@@ -18,7 +18,8 @@ public class MainPageLocalizationProfile : Profile
         CreateMap<MainPageLocalization, MainPageLocalizationDto>()
             .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language))
             .ForMember(dest => dest.MainAboutUs, opt => opt.Ignore())
-            .ForMember(dest => dest.MainPartners, opt => opt.Ignore());
+            .ForMember(dest => dest.MainPartners, opt => opt.Ignore())
+            .ForMember(dest => dest.MainDonations, opt => opt.Ignore());
 
         CreateMap<CreateMainAboutUsLocalizationDto, MainAboutUsLocalization>()
             .ForMember(dest => dest.LanguageId, opt => opt.Ignore())
@@ -38,6 +39,16 @@ public class MainPageLocalizationProfile : Profile
             .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
 
         CreateMap<MainPartnersLocalization, MainPartnersLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+
+        CreateMap<CreateMainDonationsLocalizationDto, MainDonationsLocalization>()
+            .ForMember(dest => dest.LanguageId, opt => opt.Ignore())
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateMainDonationsLocalizationDto, MainDonationsLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+
+        CreateMap<MainDonationsLocalization, MainDonationsLocalizationDto>()
             .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/MainPage/MainPageProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/MainPage/MainPageProfile.cs
@@ -4,6 +4,7 @@ using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
 using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.DAL.Entities;
@@ -36,6 +37,14 @@ public class MainPageProfile : Profile
             .ForMember(dest => dest.MainPage, opt => opt.Ignore())
             .ForMember(dest => dest.Localizations, opt => opt.Ignore());
 
+        CreateMap<CreateMainDonationsDto, MainDonations>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Image, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPageId, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPage, opt => opt.Ignore())
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore());
+
         CreateMap<CreateImpactStatisticDto, ImpactStatistics>()
             .ForMember(dest => dest.Id, opt => opt.Ignore())
             .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
@@ -55,6 +64,7 @@ public class MainPageProfile : Profile
         CreateMap<MainPageEntity, MainPageDto>();
         CreateMap<MainAboutUs, MainAboutUsDto>();
         CreateMap<MainPartners, MainPartnersDto>();
+        CreateMap<MainDonations, MainDonationsDto>();
         CreateMap<ImpactStatistics, ImpactStatisticDto>()
             .ForMember(dest => dest.Metrics, opt => opt.MapFrom(src => src.Metrics.OrderBy(m => m.Priority)));
         CreateMap<Metric, MetricDto>();
@@ -66,6 +76,14 @@ public class MainPageProfile : Profile
             .ForMember(dest => dest.Localizations, opt => opt.Ignore());
 
         CreateMap<UpdateMainPartnersDto, MainPartners>()
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore());
+
+        CreateMap<UpdateMainDonationsDto, MainDonations>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+            .ForMember(dest => dest.Image, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPageId, opt => opt.Ignore())
+            .ForMember(dest => dest.MainPage, opt => opt.Ignore())
             .ForMember(dest => dest.Localizations, opt => opt.Ignore());
 
         CreateMap<UpdateImpactStatisticDto, ImpactStatistics>()

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -31,6 +31,8 @@ public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainP
                     .Include(e => e.Localizations).ThenInclude(l => l.Language)
                     .Include(e => e.MainAboutUs).ThenInclude(a => a!.Localizations).ThenInclude(l => l.Language)
                     .Include(e => e.MainPartners).ThenInclude(p => p!.Localizations).ThenInclude(l => l.Language)
+                    .Include(e => e.MainDonations).ThenInclude(d => d!.Image)
+                    .Include(e => e.MainDonations).ThenInclude(d => d!.Localizations).ThenInclude(l => l.Language)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Image)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Localizations)
                     .Include(e => e.ImpactStatistics).ThenInclude(s => s!.Metrics.Where(m => !m.IsHidden).OrderBy(m => m.Priority)).ThenInclude(m => m.Localizations),

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainDonationsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainDonationsLocalizationDtoValidator.cs
@@ -8,6 +8,8 @@ public class CreateMainDonationsLocalizationDtoValidator : AbstractValidator<Cre
 {
     public CreateMainDonationsLocalizationDtoValidator(BaseMainPageLocalizationDtoValidator baseValidator)
     {
+        ArgumentNullException.ThrowIfNull(baseValidator);
+
         RuleFor(x => x.EntityId)
             .GreaterThan(0)
             .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateMainDonationsLocalizationDto.EntityId)));

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainDonationsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainDonationsLocalizationDtoValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+
+namespace VictoryCenter.BLL.Validators.Localization.MainPage;
+
+public class CreateMainDonationsLocalizationDtoValidator : AbstractValidator<CreateMainDonationsLocalizationDto>
+{
+    public CreateMainDonationsLocalizationDtoValidator(BaseMainPageLocalizationDtoValidator baseValidator)
+    {
+        RuleFor(x => x.EntityId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateMainDonationsLocalizationDto.EntityId)));
+
+        Include(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainPageLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainPageLocalizationDtoValidator.cs
@@ -9,7 +9,8 @@ public class CreateMainPageLocalizationDtoValidator : AbstractValidator<CreateMa
     public CreateMainPageLocalizationDtoValidator(
         BaseMainPageLocalizationDtoValidator baseValidator,
         CreateMainAboutUsLocalizationDtoValidator mainAboutUsValidator,
-        CreateMainPartnersLocalizationDtoValidator mainPartnersValidator)
+        CreateMainPartnersLocalizationDtoValidator mainPartnersValidator,
+        CreateMainDonationsLocalizationDtoValidator mainDonationsValidator)
     {
         RuleFor(x => x)
             .SetValidator(new LocalizationIdentityValidator<CreateMainPageLocalizationDto>());
@@ -23,5 +24,9 @@ public class CreateMainPageLocalizationDtoValidator : AbstractValidator<CreateMa
         RuleFor(x => x.MainPartners)
             .SetValidator(mainPartnersValidator!)
             .When(x => x.MainPartners != null);
+
+        RuleFor(x => x.MainDonations)
+            .SetValidator(mainDonationsValidator!)
+            .When(x => x.MainDonations != null);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+
+namespace VictoryCenter.BLL.Validators.Localization.MainPage;
+
+public class UpdateMainDonationsLocalizationDtoValidator : AbstractValidator<UpdateMainDonationsLocalizationDto>
+{
+    public UpdateMainDonationsLocalizationDtoValidator(BaseMainPageLocalizationDtoValidator baseValidator)
+    {
+        Include(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidator.cs
@@ -7,6 +7,8 @@ public class UpdateMainDonationsLocalizationDtoValidator : AbstractValidator<Upd
 {
     public UpdateMainDonationsLocalizationDtoValidator(BaseMainPageLocalizationDtoValidator baseValidator)
     {
+        ArgumentNullException.ThrowIfNull(baseValidator);
+
         Include(baseValidator);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainPageLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainPageLocalizationDtoValidator.cs
@@ -8,7 +8,8 @@ public class UpdateMainPageLocalizationDtoValidator : AbstractValidator<UpdateMa
     public UpdateMainPageLocalizationDtoValidator(
         BaseMainPageLocalizationDtoValidator baseValidator,
         UpdateMainAboutUsLocalizationDtoValidator mainAboutUsValidator,
-        UpdateMainPartnersLocalizationDtoValidator mainPartnersValidator)
+        UpdateMainPartnersLocalizationDtoValidator mainPartnersValidator,
+        UpdateMainDonationsLocalizationDtoValidator mainDonationsValidator)
     {
         Include(baseValidator);
 
@@ -19,5 +20,9 @@ public class UpdateMainPageLocalizationDtoValidator : AbstractValidator<UpdateMa
         RuleFor(x => x.MainPartners)
             .SetValidator(mainPartnersValidator!)
             .When(x => x.MainPartners != null);
+
+        RuleFor(x => x.MainDonations)
+            .SetValidator(mainDonationsValidator!)
+            .When(x => x.MainDonations != null);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainDonationsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainDonationsDtoValidator.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public abstract class BaseMainDonationsDtoValidator<TDto> : AbstractValidator<TDto>
+    where TDto : BaseMainDonationsDto
+{
+    protected BaseMainDonationsDtoValidator()
+    {
+        RuleFor(x => x.Title)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Title)))
+            .MinimumLength(MainPageConstants.Title.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MinLength))
+            .MaximumLength(MainPageConstants.Title.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MaxLength));
+
+        RuleFor(x => x.Description)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Description)))
+            .MinimumLength(MainPageConstants.Description.MinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MinLength))
+            .MaximumLength(MainPageConstants.Description.MaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MaxLength));
+
+        RuleFor(x => x.ImageId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(BaseMainDonationsDto.ImageId)))
+            .When(x => x.ImageId.HasValue);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainDonationsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainDonationsDtoValidator.cs
@@ -34,6 +34,6 @@ public abstract class BaseMainDonationsDtoValidator<TDto> : AbstractValidator<TD
         RuleFor(x => x.ImageId)
             .GreaterThan(0)
             .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(BaseMainDonationsDto.ImageId)))
-            .When(x => x.ImageId.HasValue);
+            .When(x => x.ImageId is not null);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainDonationsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainDonationsDtoValidator.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class CreateMainDonationsDtoValidator : BaseMainDonationsDtoValidator<CreateMainDonationsDto>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPageDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/CreateMainPageDtoValidator.cs
@@ -18,6 +18,12 @@ public class CreateMainPageDtoValidator : BaseMainPageDtoValidator<CreateMainPag
                 .SetValidator(new CreateMainPartnersDtoValidator());
         });
 
+        When(x => x.MainDonations is not null, () =>
+        {
+            RuleFor(x => x.MainDonations!)
+                .SetValidator(new CreateMainDonationsDtoValidator());
+        });
+
         When(x => x.ImpactStatistics is not null, () =>
         {
             RuleFor(x => x.ImpactStatistics!)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/UpdateMainDonationsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/UpdateMainDonationsDtoValidator.cs
@@ -1,0 +1,7 @@
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
+
+namespace VictoryCenter.BLL.Validators.MainPage.Dto;
+
+public class UpdateMainDonationsDtoValidator : BaseMainDonationsDtoValidator<UpdateMainDonationsDto>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/UpdateMainPageDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/UpdateMainPageDtoValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 
@@ -19,6 +20,12 @@ public class UpdateMainPageDtoValidator : BaseMainPageDtoValidator<UpdateMainPag
         {
             RuleFor(x => x.MainPartners!)
                 .SetValidator((IValidator<UpdateMainPartnersDto?>)new UpdateMainPartnersDtoValidator());
+        });
+
+        When(x => x.MainDonations is not null, () =>
+        {
+            RuleFor(x => x.MainDonations!)
+                .SetValidator((IValidator<UpdateMainDonationsDto?>)new UpdateMainDonationsDtoValidator());
         });
 
         When(x => x.ImpactStatistics is not null, () =>

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/MainDonationsLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/MainDonationsLocalizationConfig.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class MainDonationsLocalizationConfig : EntityLocalizationConfig<MainDonationsLocalization, MainDonations>
+{
+    public override void Configure(EntityTypeBuilder<MainDonationsLocalization> entity)
+    {
+        base.Configure(entity);
+
+        entity.Property(e => e.Title)
+            .IsRequired(false);
+
+        entity.Property(e => e.Description)
+            .IsRequired(false);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainDonationsConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainDonationsConfig.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+internal class MainDonationsConfig : IEntityTypeConfiguration<MainDonations>
+{
+    public void Configure(EntityTypeBuilder<MainDonations> entity)
+    {
+        entity
+            .HasKey(e => e.Id);
+
+        entity
+            .Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        entity
+            .Property(e => e.Title)
+            .IsRequired();
+
+        entity
+            .Property(e => e.Description)
+            .IsRequired();
+
+        entity
+            .Property(e => e.ImageId);
+
+        entity
+            .HasOne(e => e.Image)
+            .WithOne()
+            .HasForeignKey<MainDonations>(e => e.ImageId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        entity
+            .Property(e => e.MainPageId)
+            .IsRequired();
+
+        entity
+            .Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPageConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPageConfig.cs
@@ -45,6 +45,12 @@ internal class MainPageConfig : IEntityTypeConfiguration<MainPage>
             .OnDelete(DeleteBehavior.Cascade);
 
         entity
+            .HasOne(e => e.MainDonations)
+            .WithOne(e => e.MainPage)
+            .HasForeignKey<MainDonations>(e => e.MainPageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity
             .HasOne(e => e.ImpactStatistics)
             .WithOne(e => e.MainPage)
             .HasForeignKey<ImpactStatistics>(e => e.MainPageId)

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -108,6 +108,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<MainPartners> MainPartners { get; set; }
 
+    public DbSet<MainDonations> MainDonations { get; set; }
+
     public DbSet<ImpactStatistics> ImpactStatistics { get; set; }
 
     public DbSet<MainPageLocalization> MainPageLocalizations { get; set; }
@@ -115,6 +117,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
     public DbSet<MainAboutUsLocalization> MainAboutUsLocalizations { get; set; }
 
     public DbSet<MainPartnersLocalization> MainPartnersLocalizations { get; set; }
+
+    public DbSet<MainDonationsLocalization> MainDonationsLocalizations { get; set; }
 
     public DbSet<ImpactStatisticsLocalization> ImpactStatisticsLocalizations { get; set; }
 

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/MainDonationsLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/MainDonationsLocalization.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class MainDonationsLocalization : LocalizationBase<MainDonations>
+{
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/MainDonations.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/MainDonations.cs
@@ -1,0 +1,19 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class MainDonations : BaseEntity, ITranslatedEntity<MainDonationsLocalization>
+{
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+
+    public long? ImageId { get; set; }
+    public Image? Image { get; set; }
+
+    public long MainPageId { get; set; }
+    public MainPage MainPage { get; set; } = null!;
+
+    public ICollection<MainDonationsLocalization> Localizations { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/MainPage.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/MainPage.cs
@@ -14,6 +14,7 @@ public class MainPage : BaseEntity, ITranslatedEntity<MainPageLocalization>
 
     public MainAboutUs? MainAboutUs { get; set; }
     public MainPartners? MainPartners { get; set; }
+    public MainDonations? MainDonations { get; set; }
     public ImpactStatistics? ImpactStatistics { get; set; }
 
     public ICollection<MainPageLocalization> Localizations { get; set; } = [];

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260601193334_AddMainDonations.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260601193334_AddMainDonations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260601193334_AddMainDonations")]
+    partial class AddMainDonations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260601193334_AddMainDonations.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260601193334_AddMainDonations.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMainDonations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MainDonations",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ImageId = table.Column<long>(type: "bigint", nullable: true),
+                    MainPageId = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MainDonations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MainDonations_Images_ImageId",
+                        column: x => x.ImageId,
+                        principalSchema: "media",
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_MainDonations_MainPages_MainPageId",
+                        column: x => x.MainPageId,
+                        principalTable: "MainPages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MainDonationsLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MainDonationsLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_MainDonationsLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_MainDonationsLocalizations_MainDonations_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "MainDonations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainDonations_ImageId",
+                table: "MainDonations",
+                column: "ImageId",
+                unique: true,
+                filter: "[ImageId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainDonations_MainPageId",
+                table: "MainDonations",
+                column: "MainPageId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainDonationsLocalizations_LanguageId",
+                table: "MainDonationsLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MainDonationsLocalizations");
+
+            migrationBuilder.DropTable(
+                name: "MainDonations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -90,9 +90,11 @@ public interface IRepositoryWrapper
     IMainPageRepository MainPageRepository { get; }
     IMainAboutUsRepository MainAboutUsRepository { get; }
     IMainPartnersRepository MainPartnersRepository { get; }
+    IMainDonationsRepository MainDonationsRepository { get; }
     IMainPageLocalizationsRepository MainPageLocalizationsRepository { get; }
     IMainAboutUsLocalizationsRepository MainAboutUsLocalizationsRepository { get; }
     IMainPartnersLocalizationsRepository MainPartnersLocalizationsRepository { get; }
+    IMainDonationsLocalizationsRepository MainDonationsLocalizationsRepository { get; }
     IImpactStatisticsRepository ImpactStatisticsRepository { get; }
     IImpactStatisticsLocalizationsRepository ImpactStatisticsLocalizationsRepository { get; }
     IMetricRepository MetricRepository { get; }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/MainPage/IMainDonationsLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/MainPage/IMainDonationsLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.MainPage;
+
+public interface IMainDonationsLocalizationsRepository : IRepositoryBase<MainDonationsLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainDonationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/MainPage/IMainDonationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+
+public interface IMainDonationsRepository : IRepositoryBase<MainDonations>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -119,9 +119,11 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IMainPageRepository? _mainPageRepository;
     private IMainAboutUsRepository? _mainAboutUsRepository;
     private IMainPartnersRepository? _mainPartnersRepository;
+    private IMainDonationsRepository? _mainDonationsRepository;
     private IMainPageLocalizationsRepository? _mainPageLocalizationsRepository;
     private IMainAboutUsLocalizationsRepository? _mainAboutUsLocalizationsRepository;
     private IMainPartnersLocalizationsRepository? _mainPartnersLocalizationsRepository;
+    private IMainDonationsLocalizationsRepository? _mainDonationsLocalizationsRepository;
     private IImpactStatisticsRepository? _impactStatisticsRepository;
     private IImpactStatisticsLocalizationsRepository? _impactStatisticsLocalizationsRepository;
     private IMetricRepository? _metricRepository;
@@ -278,6 +280,9 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IMainPartnersRepository MainPartnersRepository =>
         _mainPartnersRepository ??= new MainPartnersRepository(_victoryCenterDbContext);
 
+    public IMainDonationsRepository MainDonationsRepository =>
+        _mainDonationsRepository ??= new MainDonationsRepository(_victoryCenterDbContext);
+
     public IMainPageLocalizationsRepository MainPageLocalizationsRepository =>
         _mainPageLocalizationsRepository ??= new MainPageLocalizationsRepository(_victoryCenterDbContext);
 
@@ -286,6 +291,9 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public IMainPartnersLocalizationsRepository MainPartnersLocalizationsRepository =>
         _mainPartnersLocalizationsRepository ??= new MainPartnersLocalizationsRepository(_victoryCenterDbContext);
+
+    public IMainDonationsLocalizationsRepository MainDonationsLocalizationsRepository =>
+        _mainDonationsLocalizationsRepository ??= new MainDonationsLocalizationsRepository(_victoryCenterDbContext);
 
     public IImpactStatisticsRepository ImpactStatisticsRepository =>
         _impactStatisticsRepository ??= new ImpactStatisticsRepository(_victoryCenterDbContext);

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/MainPage/MainDonationsLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/MainPage/MainDonationsLocalizationsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.MainPage;
+
+public class MainDonationsLocalizationsRepository
+    : RepositoryBase<MainDonationsLocalization>, IMainDonationsLocalizationsRepository
+{
+    public MainDonationsLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainDonationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/MainPage/MainDonationsRepository.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.MainPage;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.MainPage;
+
+public class MainDonationsRepository : RepositoryBase<MainDonations>, IMainDonationsRepository
+{
+    public MainDonationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/MainPageLocalizations/Create/CreateMainPageLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/MainPageLocalizations/Create/CreateMainPageLocalizationTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.MainPageLocalizations.Create;
+
+public class CreateMainPageLocalizationTests : BaseTestClass
+{
+    private readonly Uri _endpointUri = new("/api/MainPageLocalizations", UriKind.Relative);
+
+    public CreateMainPageLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreateMainPageLocalization_ShouldReturnOk()
+    {
+        var (mainPage, languageId) = await CreateMainPageForLocalizationAsync();
+        await RemoveExistingLocalizationsAsync(mainPage, languageId);
+
+        var dto = new CreateMainPageLocalizationDto
+        {
+            EntityId = mainPage.Id,
+            LanguageId = languageId,
+            Title = "Created main page title",
+            Description = "Created main page description",
+            MainAboutUs = new CreateMainAboutUsLocalizationDto
+            {
+                EntityId = mainPage.MainAboutUs!.Id,
+                Title = "Created about us title",
+                Description = "Created about us description"
+            },
+            MainPartners = new CreateMainPartnersLocalizationDto
+            {
+                EntityId = mainPage.MainPartners!.Id,
+                Title = "Created partners title",
+                Description = "Created partners description"
+            },
+            MainDonations = new CreateMainDonationsLocalizationDto
+            {
+                EntityId = mainPage.MainDonations!.Id,
+                Title = "Created donations title",
+                Description = "Created donations description"
+            }
+        };
+
+        var response = await Fixture.HttpClient.PostAsync(_endpointUri, Serialize(dto));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(await Fixture.DbContext.MainDonationsLocalizations
+            .AnyAsync(l => l.EntityId == mainPage.MainDonations!.Id && l.LanguageId == languageId));
+    }
+
+    [Fact]
+    public async Task CreateMainPageLocalization_ShouldReturnBadRequest_WhenMainDonationsIsInvalid()
+    {
+        var (mainPage, languageId) = await CreateMainPageForLocalizationAsync();
+        await RemoveExistingLocalizationsAsync(mainPage, languageId);
+
+        var dto = new CreateMainPageLocalizationDto
+        {
+            EntityId = mainPage.Id,
+            LanguageId = languageId,
+            MainDonations = new CreateMainDonationsLocalizationDto
+            {
+                EntityId = 0,
+                Title = "Created donations title",
+                Description = "Created donations description"
+            }
+        };
+
+        var response = await Fixture.HttpClient.PostAsync(_endpointUri, Serialize(dto));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateMainPageLocalization_ShouldReturnNotFound()
+    {
+        var languageId = await GetExistingLanguageIdAsync();
+        var dto = new CreateMainPageLocalizationDto
+        {
+            EntityId = 99999,
+            LanguageId = languageId,
+            Title = "Created main page title",
+            Description = "Created main page description"
+        };
+
+        var response = await Fixture.HttpClient.PostAsync(_endpointUri, Serialize(dto));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private static StringContent Serialize(object obj) =>
+        new(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json");
+
+    private async Task<(MainPageEntity mainPage, long languageId)> CreateMainPageForLocalizationAsync()
+    {
+        var languageId = await GetExistingLanguageIdAsync();
+        var mainPage = new MainPageEntity
+        {
+            Title = "Seed MainPage localization title",
+            Description = "Seed MainPage localization description",
+            MainAboutUs = new MainAboutUs
+            {
+                Title = "Seed About Us title",
+                Description = "Seed About Us description"
+            },
+            MainPartners = new MainPartners
+            {
+                Title = "Seed Partners title",
+                Description = "Seed Partners description"
+            },
+            MainDonations = new MainDonations
+            {
+                Title = "Seed Donations title",
+                Description = "Seed Donations description"
+            }
+        };
+
+        await Fixture.DbContext.MainPages.AddAsync(mainPage);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        mainPage = await Fixture.DbContext.MainPages
+            .Include(m => m.MainAboutUs)
+            .Include(m => m.MainPartners)
+            .Include(m => m.MainDonations)
+            .SingleAsync(m => m.Id == mainPage.Id);
+
+        return (mainPage, languageId);
+    }
+
+    private async Task<long> GetExistingLanguageIdAsync()
+    {
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        return language.Id;
+    }
+
+    private async Task RemoveExistingLocalizationsAsync(MainPageEntity mainPage, long languageId)
+    {
+        Fixture.DbContext.MainPageLocalizations.RemoveRange(
+            Fixture.DbContext.MainPageLocalizations.Where(l => l.EntityId == mainPage.Id && l.LanguageId == languageId));
+        Fixture.DbContext.MainAboutUsLocalizations.RemoveRange(
+            Fixture.DbContext.MainAboutUsLocalizations.Where(l => l.EntityId == mainPage.MainAboutUs!.Id && l.LanguageId == languageId));
+        Fixture.DbContext.MainPartnersLocalizations.RemoveRange(
+            Fixture.DbContext.MainPartnersLocalizations.Where(l => l.EntityId == mainPage.MainPartners!.Id && l.LanguageId == languageId));
+        Fixture.DbContext.MainDonationsLocalizations.RemoveRange(
+            Fixture.DbContext.MainDonationsLocalizations.Where(l => l.EntityId == mainPage.MainDonations!.Id && l.LanguageId == languageId));
+
+        await Fixture.DbContext.SaveChangesAsync();
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/MainPageLocalizations/Update/UpdateMainPageLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/MainPageLocalizations/Update/UpdateMainPageLocalizationTests.cs
@@ -35,6 +35,11 @@ public class UpdateMainPageLocalizationTests : BaseTestClass
             {
                 Title = "Updated partners title",
                 Description = "Updated partners description"
+            },
+            MainDonations = new UpdateMainDonationsLocalizationDto
+            {
+                Title = "Updated donations title",
+                Description = "Updated donations description"
             }
         };
 
@@ -80,6 +85,45 @@ public class UpdateMainPageLocalizationTests : BaseTestClass
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [Fact]
+    public async Task UpdateMainPageLocalization_ShouldReturnNotFound_WhenMainDonationsIsMissing()
+    {
+        var languageId = await GetExistingLanguageIdAsync();
+        var mainPage = new MainPageEntity
+        {
+            Title = "Seed MainPage without donations title",
+            Description = "Seed MainPage without donations description",
+            MainAboutUs = new MainAboutUs
+            {
+                Title = "Seed About Us title",
+                Description = "Seed About Us description"
+            },
+            MainPartners = new MainPartners
+            {
+                Title = "Seed Partners title",
+                Description = "Seed Partners description"
+            }
+        };
+
+        await Fixture.DbContext.MainPages.AddAsync(mainPage);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var dto = new UpdateMainPageLocalizationDto
+        {
+            MainDonations = new UpdateMainDonationsLocalizationDto
+            {
+                Title = "Updated donations title",
+                Description = "Updated donations description"
+            }
+        };
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/MainPageLocalizations/{mainPage.Id}/{languageId}",
+            Serialize(dto));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     private static StringContent Serialize(object obj) =>
         new(JsonConvert.SerializeObject(obj), Encoding.UTF8, "application/json");
 
@@ -90,6 +134,7 @@ public class UpdateMainPageLocalizationTests : BaseTestClass
         var mainPage = await Fixture.DbContext.MainPages
             .Include(m => m.MainAboutUs)
             .Include(m => m.MainPartners)
+            .Include(m => m.MainDonations)
             .FirstOrDefaultAsync();
 
         if (mainPage is null)
@@ -107,6 +152,11 @@ public class UpdateMainPageLocalizationTests : BaseTestClass
                 {
                     Title = "Seed Partners title",
                     Description = "Seed Partners description"
+                },
+                MainDonations = new MainDonations
+                {
+                    Title = "Seed Donations title",
+                    Description = "Seed Donations description"
                 }
             };
 
@@ -140,9 +190,23 @@ public class UpdateMainPageLocalizationTests : BaseTestClass
             await Fixture.DbContext.SaveChangesAsync();
         }
 
+        if (mainPage.MainDonations is null)
+        {
+            mainPage.MainDonations = new MainDonations
+            {
+                Title = "Seed Donations title",
+                Description = "Seed Donations description",
+                MainPageId = mainPage.Id
+            };
+
+            await Fixture.DbContext.MainDonations.AddAsync(mainPage.MainDonations);
+            await Fixture.DbContext.SaveChangesAsync();
+        }
+
         await EnsureLocalizationExistsAsync(mainPage.Id, languageId);
         await EnsureAboutUsLocalizationExistsAsync(mainPage.MainAboutUs.Id, languageId);
         await EnsurePartnersLocalizationExistsAsync(mainPage.MainPartners.Id, languageId);
+        await EnsureDonationsLocalizationExistsAsync(mainPage.MainDonations.Id, languageId);
 
         return (mainPage, languageId);
     }
@@ -214,6 +278,27 @@ public class UpdateMainPageLocalizationTests : BaseTestClass
             LanguageId = languageId,
             Title = "Seed partners localized title",
             Description = "Seed partners localized description"
+        });
+
+        await Fixture.DbContext.SaveChangesAsync();
+    }
+
+    private async Task EnsureDonationsLocalizationExistsAsync(long entityId, long languageId)
+    {
+        var existing = await Fixture.DbContext.MainDonationsLocalizations
+            .FirstOrDefaultAsync(l => l.EntityId == entityId && l.LanguageId == languageId);
+
+        if (existing is not null)
+        {
+            return;
+        }
+
+        Fixture.DbContext.MainDonationsLocalizations.Add(new MainDonationsLocalization
+        {
+            EntityId = entityId,
+            LanguageId = languageId,
+            Title = "Seed donations localized title",
+            Description = "Seed donations localized description"
         });
 
         await Fixture.DbContext.SaveChangesAsync();

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.DAL.Entities;
@@ -46,6 +47,12 @@ public class CreateMainPageTests : BaseTestClass
                 Title = "New Partners title",
                 Description = "New Partners description",
             },
+            MainDonations = new CreateMainDonationsDto
+            {
+                Title = "New Donations title",
+                Description = "New Donations description",
+                ImageId = image.Id,
+            },
             ImpactStatistics = new CreateImpactStatisticDto
             {
                 Title = "New stat",
@@ -72,6 +79,7 @@ public class CreateMainPageTests : BaseTestClass
         var createdMainPage = await Fixture.DbContext.MainPages
             .Include(m => m.MainAboutUs)
             .Include(m => m.MainPartners)
+            .Include(m => m.MainDonations)
             .Include(m => m.ImpactStatistics)
             .FirstOrDefaultAsync(m => m.Title == createDto.Title);
 
@@ -80,6 +88,8 @@ public class CreateMainPageTests : BaseTestClass
         Assert.Equal(createDto.ImageId, createdMainPage.ImageId);
         Assert.NotNull(createdMainPage.MainAboutUs);
         Assert.NotNull(createdMainPage.MainPartners);
+        Assert.NotNull(createdMainPage.MainDonations);
+        Assert.Equal(createDto.MainDonations.ImageId, createdMainPage.MainDonations.ImageId);
         Assert.NotNull(createdMainPage.ImpactStatistics);
     }
 
@@ -113,6 +123,58 @@ public class CreateMainPageTests : BaseTestClass
             Title = "Valid title",
             Description = "Valid description",
             ImageId = nonExistentImageId,
+        };
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(createDto),
+            Encoding.UTF8,
+            "application/json");
+
+        var response = await Fixture.HttpClient.PostAsync(_endpointUri, content);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateMainPage_WithInvalidMainDonations_ShouldReturnBadRequest()
+    {
+        var createDto = new CreateMainPageDto
+        {
+            Title = "Valid title",
+            Description = "Valid description",
+            MainDonations = new CreateMainDonationsDto
+            {
+                Title = string.Empty,
+                Description = "Valid donations description",
+            },
+        };
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(createDto),
+            Encoding.UTF8,
+            "application/json");
+
+        var response = await Fixture.HttpClient.PostAsync(_endpointUri, content);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateMainPage_WithNonExistentMainDonationsImageId_ShouldReturnNotFound()
+    {
+        var maxImageId = await Fixture.DbContext.Images.MaxAsync(i => (long?)i.Id) ?? 0;
+        var nonExistentImageId = maxImageId + 1000;
+
+        var createDto = new CreateMainPageDto
+        {
+            Title = "Valid title",
+            Description = "Valid description",
+            MainDonations = new CreateMainDonationsDto
+            {
+                Title = "Valid donations title",
+                Description = "Valid donations description",
+                ImageId = nonExistentImageId,
+            },
         };
 
         var content = new StringContent(

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
@@ -33,6 +33,8 @@ public class GetMainPageTests : BaseTestClass
         Assert.NotNull(result);
         Assert.Equal(expected.Title, result.Title);
         Assert.Equal(expected.Description, result.Description);
+        Assert.NotNull(result.MainDonations);
+        Assert.Equal(expected.MainDonations!.Title, result.MainDonations.Title);
     }
 
     [Fact]
@@ -48,9 +50,27 @@ public class GetMainPageTests : BaseTestClass
 
     private async Task<EntityMainPage> EnsureMainPageExistsAsync()
     {
-        var existing = await Fixture.DbContext.MainPages.FirstOrDefaultAsync();
+        var existing = await Fixture.DbContext.MainPages
+            .Include(m => m.MainDonations)
+            .FirstOrDefaultAsync();
+        if (existing?.MainDonations is not null)
+        {
+            return existing;
+        }
+
         if (existing is not null)
         {
+            existing.MainDonations = new MainDonations
+            {
+                Title = "Seed Donations Title",
+                Description = "Seed Donations Description",
+                MainPageId = existing.Id,
+            };
+
+            await Fixture.DbContext.MainDonations.AddAsync(existing.MainDonations);
+            await Fixture.DbContext.SaveChangesAsync();
+            Fixture.DbContext.ChangeTracker.Clear();
+
             return existing;
         }
 
@@ -61,6 +81,12 @@ public class GetMainPageTests : BaseTestClass
             Title = "Seed MainPage Title",
             Description = "Seed MainPage Description",
             ImageId = image.Id,
+            MainDonations = new MainDonations
+            {
+                Title = "Seed Donations Title",
+                Description = "Seed Donations Description",
+                ImageId = image.Id,
+            },
         };
 
         await Fixture.DbContext.MainPages.AddAsync(mainPage);

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.DAL.Entities;
@@ -50,12 +51,15 @@ public class UpdateMainPageTests : BaseTestClass
         var updated = await Fixture.DbContext.MainPages
             .Include(m => m.MainAboutUs)
             .Include(m => m.MainPartners)
+            .Include(m => m.MainDonations)
             .Include(m => m.ImpactStatistics)
             .SingleAsync(m => m.Id == mainPage.Id);
 
         Assert.Equal(updateDto.Title, updated.Title);
         Assert.NotNull(updated.MainAboutUs);
         Assert.NotNull(updated.MainPartners);
+        Assert.NotNull(updated.MainDonations);
+        Assert.Equal(updateDto.MainDonations!.Title, updated.MainDonations.Title);
         Assert.NotNull(updated.ImpactStatistics);
         Assert.Equal("Updated existing stat", updated.ImpactStatistics.Title);
     }
@@ -99,6 +103,34 @@ public class UpdateMainPageTests : BaseTestClass
         var response = await PutRaw(updateDto);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_InvalidMainDonations_ShouldReturnBadRequest()
+    {
+        var mainPage = await EnsureMainPageExistsAsync();
+        var image = await EnsureImageExistsAsync();
+        var existingStat = mainPage.ImpactStatistics;
+        var existingMetric = existingStat?.Metrics.FirstOrDefault();
+
+        var updateDto = CreateUpdateDto(
+            title: "Updated title",
+            mainImageId: image.Id,
+            statImageId: image.Id,
+            statId: existingStat?.Id,
+            metricId: existingMetric?.Id) with
+        {
+            MainDonations = new UpdateMainDonationsDto
+            {
+                Title = string.Empty,
+                Description = "Updated Donations description",
+                ImageId = image.Id,
+            },
+        };
+
+        var response = await PutRaw(updateDto);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
@@ -167,6 +199,12 @@ public class UpdateMainPageTests : BaseTestClass
             ImageId = mainImageId,
             MainAboutUs = new UpdateMainAboutUsDto { Title = "Updated About Us title", Description = "Updated About Us description" },
             MainPartners = new UpdateMainPartnersDto { Title = "Updated Partners title", Description = "Updated Partners description" },
+            MainDonations = new UpdateMainDonationsDto
+            {
+                Title = "Updated Donations title",
+                Description = "Updated Donations description",
+                ImageId = mainImageId,
+            },
             ImpactStatistics = new UpdateImpactStatisticDto
             {
                 Id = statId,
@@ -186,6 +224,7 @@ public class UpdateMainPageTests : BaseTestClass
         var existing = await Fixture.DbContext.MainPages
             .Include(m => m.MainAboutUs)
             .Include(m => m.MainPartners)
+            .Include(m => m.MainDonations)
             .Include(m => m.ImpactStatistics)
                 .ThenInclude(s => s!.Metrics)
             .FirstOrDefaultAsync();
@@ -203,6 +242,12 @@ public class UpdateMainPageTests : BaseTestClass
             ImageId = image.Id,
             MainAboutUs = new MainAboutUs { Title = "Seed About Us", Description = "Seed Desc" },
             MainPartners = new MainPartners { Title = "Seed Partners", Description = "Seed Desc" },
+            MainDonations = new MainDonations
+            {
+                Title = "Seed Donations",
+                Description = "Seed Desc",
+                ImageId = image.Id,
+            },
             ImpactStatistics = new ImpactStatistics
             {
                 Title = "Seed Stat",

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/MainPage/CreateMainPageLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/MainPage/CreateMainPageLocalizationHandlerTests.cs
@@ -24,6 +24,7 @@ public class CreateMainPageLocalizationHandlerTests
     private readonly Mock<ILocalizationService<MainPageEntity, MainPageLocalization>> _mockMainPageService;
     private readonly Mock<ILocalizationService<MainAboutUs, MainAboutUsLocalization>> _mockMainAboutUsService;
     private readonly Mock<ILocalizationService<MainPartners, MainPartnersLocalization>> _mockMainPartnersService;
+    private readonly Mock<ILocalizationService<MainDonations, MainDonationsLocalization>> _mockMainDonationsService;
     private readonly IValidator<CreateMainPageLocalizationCommand> _validator;
 
     private readonly MainPageLocalization _mainPageLocalization = new()
@@ -48,6 +49,14 @@ public class CreateMainPageLocalizationHandlerTests
         EntityId = 3,
         LanguageId = 1,
         Title = "Partners title",
+        TranslationStatus = TranslationStatus.Relevant
+    };
+
+    private readonly MainDonationsLocalization _mainDonationsLocalization = new()
+    {
+        EntityId = 4,
+        LanguageId = 1,
+        Title = "Donations title",
         TranslationStatus = TranslationStatus.Relevant
     };
 
@@ -76,6 +85,14 @@ public class CreateMainPageLocalizationHandlerTests
         TranslationStatus = TranslationStatus.Relevant
     };
 
+    private readonly MainDonationsLocalizationDto _mainDonationsLocalizationDto = new()
+    {
+        EntityId = 4,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 1, Code = "en" },
+        Title = "Donations title",
+        TranslationStatus = TranslationStatus.Relevant
+    };
+
     public CreateMainPageLocalizationHandlerTests()
     {
         _mockMapper = new Mock<IMapper>();
@@ -83,11 +100,17 @@ public class CreateMainPageLocalizationHandlerTests
         _mockMainPageService = new Mock<ILocalizationService<MainPageEntity, MainPageLocalization>>();
         _mockMainAboutUsService = new Mock<ILocalizationService<MainAboutUs, MainAboutUsLocalization>>();
         _mockMainPartnersService = new Mock<ILocalizationService<MainPartners, MainPartnersLocalization>>();
+        _mockMainDonationsService = new Mock<ILocalizationService<MainDonations, MainDonationsLocalization>>();
 
         var baseValidator = new BaseMainPageLocalizationDtoValidator();
         var mainAboutUsValidator = new CreateMainAboutUsLocalizationDtoValidator(baseValidator);
         var mainPartnersValidator = new CreateMainPartnersLocalizationDtoValidator(baseValidator);
-        var dtoValidator = new CreateMainPageLocalizationDtoValidator(baseValidator, mainAboutUsValidator, mainPartnersValidator);
+        var mainDonationsValidator = new CreateMainDonationsLocalizationDtoValidator(baseValidator);
+        var dtoValidator = new CreateMainPageLocalizationDtoValidator(
+            baseValidator,
+            mainAboutUsValidator,
+            mainPartnersValidator,
+            mainDonationsValidator);
         _validator = new CreateMainPageLocalizationCommandValidator(dtoValidator);
 
         _mockRepositoryWrapper
@@ -110,6 +133,7 @@ public class CreateMainPageLocalizationHandlerTests
         Assert.Equal(_mainPageLocalizationDto.EntityId, result.Value.EntityId);
         Assert.NotNull(result.Value.MainAboutUs);
         Assert.NotNull(result.Value.MainPartners);
+        Assert.NotNull(result.Value.MainDonations);
     }
 
     [Fact]
@@ -120,7 +144,8 @@ public class CreateMainPageLocalizationHandlerTests
             EntityId = 1,
             LanguageId = 1,
             MainAboutUs = null,
-            MainPartners = null
+            MainPartners = null,
+            MainDonations = null
         };
         var command = BuildCommand(dto);
 
@@ -135,9 +160,11 @@ public class CreateMainPageLocalizationHandlerTests
         Assert.True(result.IsSuccess);
         Assert.Null(result.Value.MainAboutUs);
         Assert.Null(result.Value.MainPartners);
+        Assert.Null(result.Value.MainDonations);
 
         _mockMainAboutUsService.Verify(s => s.CreateEntityLocalizationAsync(It.IsAny<MainAboutUsLocalization>()), Times.Never);
         _mockMainPartnersService.Verify(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()), Times.Never);
+        _mockMainDonationsService.Verify(s => s.CreateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()), Times.Never);
     }
 
     [Fact]
@@ -150,14 +177,20 @@ public class CreateMainPageLocalizationHandlerTests
             .Returns(_mainPageLocalization);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalization>(It.IsAny<CreateMainPartnersLocalizationDto>()))
             .Returns(_mainPartnersLocalization);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalization>(It.IsAny<CreateMainDonationsLocalizationDto>()))
+            .Returns(_mainDonationsLocalization);
         _mockMainPageService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPageLocalization>()))
             .ReturnsAsync(_mainPageLocalization);
         _mockMainPartnersService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()))
             .ReturnsAsync(_mainPartnersLocalization);
+        _mockMainDonationsService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()))
+            .ReturnsAsync(_mainDonationsLocalization);
         _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>()))
             .Returns(_mainPageLocalizationDto);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalizationDto>(It.IsAny<MainPartnersLocalization>()))
             .Returns(_mainPartnersLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalizationDto>(It.IsAny<MainDonationsLocalization>()))
+            .Returns(_mainDonationsLocalizationDto);
 
         await CreateHandler().Handle(command, CancellationToken.None);
 
@@ -174,18 +207,54 @@ public class CreateMainPageLocalizationHandlerTests
             .Returns(_mainPageLocalization);
         _mockMapper.Setup(m => m.Map<MainAboutUsLocalization>(It.IsAny<CreateMainAboutUsLocalizationDto>()))
             .Returns(_mainAboutUsLocalization);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalization>(It.IsAny<CreateMainDonationsLocalizationDto>()))
+            .Returns(_mainDonationsLocalization);
         _mockMainPageService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPageLocalization>()))
             .ReturnsAsync(_mainPageLocalization);
         _mockMainAboutUsService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainAboutUsLocalization>()))
             .ReturnsAsync(_mainAboutUsLocalization);
+        _mockMainDonationsService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()))
+            .ReturnsAsync(_mainDonationsLocalization);
         _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>()))
             .Returns(_mainPageLocalizationDto);
         _mockMapper.Setup(m => m.Map<MainAboutUsLocalizationDto>(It.IsAny<MainAboutUsLocalization>()))
             .Returns(_mainAboutUsLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalizationDto>(It.IsAny<MainDonationsLocalization>()))
+            .Returns(_mainDonationsLocalizationDto);
 
         await CreateHandler().Handle(command, CancellationToken.None);
 
         _mockMainPartnersService.Verify(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotCallMainDonationsService_WhenMainDonationsIsNull()
+    {
+        var dto = GetValidDto() with { MainDonations = null };
+        var command = BuildCommand(dto);
+
+        _mockMapper.Setup(m => m.Map<MainPageLocalization>(It.IsAny<CreateMainPageLocalizationDto>()))
+            .Returns(_mainPageLocalization);
+        _mockMapper.Setup(m => m.Map<MainAboutUsLocalization>(It.IsAny<CreateMainAboutUsLocalizationDto>()))
+            .Returns(_mainAboutUsLocalization);
+        _mockMapper.Setup(m => m.Map<MainPartnersLocalization>(It.IsAny<CreateMainPartnersLocalizationDto>()))
+            .Returns(_mainPartnersLocalization);
+        _mockMainPageService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPageLocalization>()))
+            .ReturnsAsync(_mainPageLocalization);
+        _mockMainAboutUsService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainAboutUsLocalization>()))
+            .ReturnsAsync(_mainAboutUsLocalization);
+        _mockMainPartnersService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()))
+            .ReturnsAsync(_mainPartnersLocalization);
+        _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>()))
+            .Returns(_mainPageLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainAboutUsLocalizationDto>(It.IsAny<MainAboutUsLocalization>()))
+            .Returns(_mainAboutUsLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainPartnersLocalizationDto>(It.IsAny<MainPartnersLocalization>()))
+            .Returns(_mainPartnersLocalizationDto);
+
+        await CreateHandler().Handle(command, CancellationToken.None);
+
+        _mockMainDonationsService.Verify(s => s.CreateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()), Times.Never);
     }
 
     [Fact]
@@ -197,6 +266,7 @@ public class CreateMainPageLocalizationHandlerTests
 
         var capturedAboutUs = new MainAboutUsLocalization { EntityId = 2, LanguageId = 0 };
         var capturedPartners = new MainPartnersLocalization { EntityId = 3, LanguageId = 0 };
+        var capturedDonations = new MainDonationsLocalization { EntityId = 4, LanguageId = 0 };
 
         _mockMapper.Setup(m => m.Map<MainPageLocalization>(It.IsAny<CreateMainPageLocalizationDto>()))
             .Returns(_mainPageLocalization);
@@ -204,6 +274,8 @@ public class CreateMainPageLocalizationHandlerTests
             .Returns(capturedAboutUs);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalization>(It.IsAny<CreateMainPartnersLocalizationDto>()))
             .Returns(capturedPartners);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalization>(It.IsAny<CreateMainDonationsLocalizationDto>()))
+            .Returns(capturedDonations);
 
         _mockMainPageService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPageLocalization>()))
             .ReturnsAsync(_mainPageLocalization);
@@ -211,6 +283,8 @@ public class CreateMainPageLocalizationHandlerTests
             .ReturnsAsync(_mainAboutUsLocalization);
         _mockMainPartnersService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()))
             .ReturnsAsync(_mainPartnersLocalization);
+        _mockMainDonationsService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()))
+            .ReturnsAsync(_mainDonationsLocalization);
 
         _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>()))
             .Returns(_mainPageLocalizationDto);
@@ -218,11 +292,14 @@ public class CreateMainPageLocalizationHandlerTests
             .Returns(_mainAboutUsLocalizationDto);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalizationDto>(It.IsAny<MainPartnersLocalization>()))
             .Returns(_mainPartnersLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalizationDto>(It.IsAny<MainDonationsLocalization>()))
+            .Returns(_mainDonationsLocalizationDto);
 
         await CreateHandler().Handle(command, CancellationToken.None);
 
         Assert.Equal(languageId, capturedAboutUs.LanguageId);
         Assert.Equal(languageId, capturedPartners.LanguageId);
+        Assert.Equal(languageId, capturedDonations.LanguageId);
     }
 
     // ── Failure paths ───────────────────────────────────────────────────────
@@ -300,7 +377,8 @@ public class CreateMainPageLocalizationHandlerTests
 
     private CreateMainPageLocalizationHandler CreateHandler() =>
         new(_mockMapper.Object, _validator, _mockRepositoryWrapper.Object,
-            _mockMainPageService.Object, _mockMainAboutUsService.Object, _mockMainPartnersService.Object);
+            _mockMainPageService.Object, _mockMainAboutUsService.Object, _mockMainPartnersService.Object,
+            _mockMainDonationsService.Object);
 
     private void SetupDependencies()
     {
@@ -310,6 +388,8 @@ public class CreateMainPageLocalizationHandlerTests
             .Returns(_mainAboutUsLocalization);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalization>(It.IsAny<CreateMainPartnersLocalizationDto>()))
             .Returns(_mainPartnersLocalization);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalization>(It.IsAny<CreateMainDonationsLocalizationDto>()))
+            .Returns(_mainDonationsLocalization);
 
         _mockMainPageService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPageLocalization>()))
             .ReturnsAsync(_mainPageLocalization);
@@ -317,6 +397,8 @@ public class CreateMainPageLocalizationHandlerTests
             .ReturnsAsync(_mainAboutUsLocalization);
         _mockMainPartnersService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()))
             .ReturnsAsync(_mainPartnersLocalization);
+        _mockMainDonationsService.Setup(s => s.CreateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()))
+            .ReturnsAsync(_mainDonationsLocalization);
 
         _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>()))
             .Returns(_mainPageLocalizationDto);
@@ -324,6 +406,8 @@ public class CreateMainPageLocalizationHandlerTests
             .Returns(_mainAboutUsLocalizationDto);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalizationDto>(It.IsAny<MainPartnersLocalization>()))
             .Returns(_mainPartnersLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalizationDto>(It.IsAny<MainDonationsLocalization>()))
+            .Returns(_mainDonationsLocalizationDto);
     }
 
     private static CreateMainPageLocalizationDto GetValidDto() => new()
@@ -331,7 +415,8 @@ public class CreateMainPageLocalizationHandlerTests
         EntityId = 1,
         LanguageId = 1,
         MainAboutUs = new CreateMainAboutUsLocalizationDto { EntityId = 2 },
-        MainPartners = new CreateMainPartnersLocalizationDto { EntityId = 3 }
+        MainPartners = new CreateMainPartnersLocalizationDto { EntityId = 3 },
+        MainDonations = new CreateMainDonationsLocalizationDto { EntityId = 4 }
     };
 
     private static CreateMainPageLocalizationCommand BuildCommand(CreateMainPageLocalizationDto dto) =>

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/MainPage/UpdateMainPageLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/MainPage/UpdateMainPageLocalizationHandlerTests.cs
@@ -25,6 +25,7 @@ public class UpdateMainPageLocalizationHandlerTests
     private readonly Mock<ILocalizationService<MainPageEntity, MainPageLocalization>> _mockMainPageService;
     private readonly Mock<ILocalizationService<MainAboutUs, MainAboutUsLocalization>> _mockMainAboutUsService;
     private readonly Mock<ILocalizationService<MainPartners, MainPartnersLocalization>> _mockMainPartnersService;
+    private readonly Mock<ILocalizationService<MainDonations, MainDonationsLocalization>> _mockMainDonationsService;
     private readonly Mock<IValidator<UpdateMainPageLocalizationCommand>> _mockValidator;
 
     private readonly long _entityId = 1;
@@ -34,7 +35,8 @@ public class UpdateMainPageLocalizationHandlerTests
     {
         Id = 1,
         MainAboutUs = new MainAboutUs { Id = 101 },
-        MainPartners = new MainPartners { Id = 102 }
+        MainPartners = new MainPartners { Id = 102 },
+        MainDonations = new MainDonations { Id = 103 }
     };
 
     private readonly MainPageLocalization _mainPageLocalization = new()
@@ -59,6 +61,14 @@ public class UpdateMainPageLocalizationHandlerTests
         EntityId = 102,
         LanguageId = 2,
         Title = "Upd Partners title",
+        TranslationStatus = TranslationStatus.Relevant
+    };
+
+    private readonly MainDonationsLocalization _mainDonationsLocalization = new()
+    {
+        EntityId = 103,
+        LanguageId = 2,
+        Title = "Upd Donations title",
         TranslationStatus = TranslationStatus.Relevant
     };
 
@@ -87,6 +97,14 @@ public class UpdateMainPageLocalizationHandlerTests
         TranslationStatus = TranslationStatus.Relevant
     };
 
+    private readonly MainDonationsLocalizationDto _mainDonationsLocalizationDto = new()
+    {
+        EntityId = 103,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        Title = "Upd Donations title",
+        TranslationStatus = TranslationStatus.Relevant
+    };
+
     public UpdateMainPageLocalizationHandlerTests()
     {
         _mockMapper = new Mock<IMapper>();
@@ -94,6 +112,7 @@ public class UpdateMainPageLocalizationHandlerTests
         _mockMainPageService = new Mock<ILocalizationService<MainPageEntity, MainPageLocalization>>();
         _mockMainAboutUsService = new Mock<ILocalizationService<MainAboutUs, MainAboutUsLocalization>>();
         _mockMainPartnersService = new Mock<ILocalizationService<MainPartners, MainPartnersLocalization>>();
+        _mockMainDonationsService = new Mock<ILocalizationService<MainDonations, MainDonationsLocalization>>();
         _mockValidator = new Mock<IValidator<UpdateMainPageLocalizationCommand>>();
 
         _mockRepositoryWrapper
@@ -122,6 +141,7 @@ public class UpdateMainPageLocalizationHandlerTests
         Assert.Equal(_mainPageLocalizationDto.EntityId, result.Value.EntityId);
         Assert.NotNull(result.Value.MainAboutUs);
         Assert.NotNull(result.Value.MainPartners);
+        Assert.NotNull(result.Value.MainDonations);
     }
 
     [Fact]
@@ -130,7 +150,8 @@ public class UpdateMainPageLocalizationHandlerTests
         var dto = new UpdateMainPageLocalizationDto
         {
             MainAboutUs = null,
-            MainPartners = null
+            MainPartners = null,
+            MainDonations = null
         };
         var command = BuildCommand(dto);
 
@@ -145,9 +166,11 @@ public class UpdateMainPageLocalizationHandlerTests
         Assert.True(result.IsSuccess);
         Assert.Null(result.Value.MainAboutUs);
         Assert.Null(result.Value.MainPartners);
+        Assert.Null(result.Value.MainDonations);
 
         _mockMainAboutUsService.Verify(s => s.UpdateEntityLocalizationAsync(It.IsAny<MainAboutUsLocalization>()), Times.Never);
         _mockMainPartnersService.Verify(s => s.UpdateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()), Times.Never);
+        _mockMainDonationsService.Verify(s => s.UpdateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()), Times.Never);
     }
 
     [Fact]
@@ -159,14 +182,17 @@ public class UpdateMainPageLocalizationHandlerTests
         var capturedMainPage = new MainPageLocalization();
         var capturedAboutUs = new MainAboutUsLocalization();
         var capturedPartners = new MainPartnersLocalization();
+        var capturedDonations = new MainDonationsLocalization();
 
         _mockMapper.Setup(m => m.Map<MainPageLocalization>(dto)).Returns(capturedMainPage);
         _mockMapper.Setup(m => m.Map<MainAboutUsLocalization>(dto.MainAboutUs)).Returns(capturedAboutUs);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalization>(dto.MainPartners)).Returns(capturedPartners);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalization>(dto.MainDonations)).Returns(capturedDonations);
 
         _mockMainPageService.Setup(s => s.UpdateEntityLocalizationAsync(capturedMainPage)).ReturnsAsync(capturedMainPage);
         _mockMainAboutUsService.Setup(s => s.UpdateEntityLocalizationAsync(capturedAboutUs)).ReturnsAsync(capturedAboutUs);
         _mockMainPartnersService.Setup(s => s.UpdateEntityLocalizationAsync(capturedPartners)).ReturnsAsync(capturedPartners);
+        _mockMainDonationsService.Setup(s => s.UpdateEntityLocalizationAsync(capturedDonations)).ReturnsAsync(capturedDonations);
 
         _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>())).Returns(_mainPageLocalizationDto);
 
@@ -180,6 +206,9 @@ public class UpdateMainPageLocalizationHandlerTests
 
         Assert.Equal(_mainPageEntity.MainPartners.Id, capturedPartners.EntityId);
         Assert.Equal(_languageId, capturedPartners.LanguageId);
+
+        Assert.Equal(_mainPageEntity.MainDonations.Id, capturedDonations.EntityId);
+        Assert.Equal(_languageId, capturedDonations.LanguageId);
     }
 
     [Fact]
@@ -200,7 +229,13 @@ public class UpdateMainPageLocalizationHandlerTests
     public async Task Handle_ShouldFail_WhenMainAboutUsIsNullInDb_ButProvidedInDto()
     {
         SetupDependencies();
-        var invalidMainPage = new MainPageEntity { Id = 1, MainAboutUs = null, MainPartners = new MainPartners() };
+        var invalidMainPage = new MainPageEntity
+        {
+            Id = 1,
+            MainAboutUs = null,
+            MainPartners = new MainPartners(),
+            MainDonations = new MainDonations()
+        };
         _mockRepositoryWrapper
             .Setup(r => r.MainPageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<MainPageEntity>>()))
             .ReturnsAsync(invalidMainPage);
@@ -216,7 +251,35 @@ public class UpdateMainPageLocalizationHandlerTests
     public async Task Handle_ShouldFail_WhenMainPartnersIsNullInDb_ButProvidedInDto()
     {
         SetupDependencies();
-        var invalidMainPage = new MainPageEntity { Id = 1, MainAboutUs = new MainAboutUs(), MainPartners = null };
+        var invalidMainPage = new MainPageEntity
+        {
+            Id = 1,
+            MainAboutUs = new MainAboutUs(),
+            MainPartners = null,
+            MainDonations = new MainDonations()
+        };
+        _mockRepositoryWrapper
+            .Setup(r => r.MainPageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<MainPageEntity>>()))
+            .ReturnsAsync(invalidMainPage);
+
+        var command = BuildCommand(GetValidDto());
+        var result = await CreateHandler().Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ErrorMessagesConstants.NotFound(), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenMainDonationsIsNullInDb_ButProvidedInDto()
+    {
+        SetupDependencies();
+        var invalidMainPage = new MainPageEntity
+        {
+            Id = 1,
+            MainAboutUs = new MainAboutUs(),
+            MainPartners = new MainPartners(),
+            MainDonations = null
+        };
         _mockRepositoryWrapper
             .Setup(r => r.MainPageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<MainPageEntity>>()))
             .ReturnsAsync(invalidMainPage);
@@ -290,7 +353,8 @@ public class UpdateMainPageLocalizationHandlerTests
 
     private UpdateMainPageLocalizationHandler CreateHandler() =>
         new(_mockMapper.Object, _mockRepositoryWrapper.Object, _mockValidator.Object,
-            _mockMainPageService.Object, _mockMainAboutUsService.Object, _mockMainPartnersService.Object);
+            _mockMainPageService.Object, _mockMainAboutUsService.Object, _mockMainPartnersService.Object,
+            _mockMainDonationsService.Object);
 
     private void SetupDependencies()
     {
@@ -300,6 +364,8 @@ public class UpdateMainPageLocalizationHandlerTests
             .Returns(_mainAboutUsLocalization);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalization>(It.IsAny<UpdateMainPartnersLocalizationDto>()))
             .Returns(_mainPartnersLocalization);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalization>(It.IsAny<UpdateMainDonationsLocalizationDto>()))
+            .Returns(_mainDonationsLocalization);
 
         _mockMainPageService.Setup(s => s.UpdateEntityLocalizationAsync(It.IsAny<MainPageLocalization>()))
             .ReturnsAsync(_mainPageLocalization);
@@ -307,6 +373,8 @@ public class UpdateMainPageLocalizationHandlerTests
             .ReturnsAsync(_mainAboutUsLocalization);
         _mockMainPartnersService.Setup(s => s.UpdateEntityLocalizationAsync(It.IsAny<MainPartnersLocalization>()))
             .ReturnsAsync(_mainPartnersLocalization);
+        _mockMainDonationsService.Setup(s => s.UpdateEntityLocalizationAsync(It.IsAny<MainDonationsLocalization>()))
+            .ReturnsAsync(_mainDonationsLocalization);
 
         _mockMapper.Setup(m => m.Map<MainPageLocalizationDto>(It.IsAny<MainPageLocalization>()))
             .Returns(_mainPageLocalizationDto);
@@ -314,12 +382,15 @@ public class UpdateMainPageLocalizationHandlerTests
             .Returns(_mainAboutUsLocalizationDto);
         _mockMapper.Setup(m => m.Map<MainPartnersLocalizationDto>(It.IsAny<MainPartnersLocalization>()))
             .Returns(_mainPartnersLocalizationDto);
+        _mockMapper.Setup(m => m.Map<MainDonationsLocalizationDto>(It.IsAny<MainDonationsLocalization>()))
+            .Returns(_mainDonationsLocalizationDto);
     }
 
     private static UpdateMainPageLocalizationDto GetValidDto() => new()
     {
         MainAboutUs = new UpdateMainAboutUsLocalizationDto(),
-        MainPartners = new UpdateMainPartnersLocalizationDto()
+        MainPartners = new UpdateMainPartnersLocalizationDto(),
+        MainDonations = new UpdateMainDonationsLocalizationDto()
     };
 
     private UpdateMainPageLocalizationCommand BuildCommand(UpdateMainPageLocalizationDto dto) =>

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/CreateMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/CreateMainPageHandlerTests.cs
@@ -11,6 +11,7 @@ using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
 using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.DAL.Entities;
@@ -63,7 +64,7 @@ public class CreateMainPageHandlerTests
 
         _imageRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
-            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }, new Image { Id = 7 }]);
 
         _mapperMock
             .Setup(x => x.Map<CreateMainPageDto, DAL.Entities.MainPage>(command.CreateMainPageDto))
@@ -171,7 +172,7 @@ public class CreateMainPageHandlerTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Equal(
-            ErrorMessagesConstants.NotFound(new[] { 6L }, typeof(Image)),
+            ErrorMessagesConstants.NotFound(new[] { 6L, 7L }, typeof(Image)),
             result.Errors[0].Message);
 
         _mainPageRepositoryMock.Verify(x => x.CreateAsync(It.IsAny<DAL.Entities.MainPage>()), Times.Never);
@@ -186,6 +187,7 @@ public class CreateMainPageHandlerTests
         dtoWithoutImages = dtoWithoutImages with
         {
             ImageId = null,
+            MainDonations = dtoWithoutImages.MainDonations! with { ImageId = null },
             ImpactStatistics = new CreateImpactStatisticDto
             {
                 Title = "Impact statistic title",
@@ -254,7 +256,7 @@ public class CreateMainPageHandlerTests
 
         _imageRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
-            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }, new Image { Id = 7 }]);
 
         _mapperMock
             .Setup(x => x.Map<CreateMainPageDto, DAL.Entities.MainPage>(command.CreateMainPageDto))
@@ -284,7 +286,13 @@ public class CreateMainPageHandlerTests
     public async Task Handle_ShouldCreateMainPage_WhenImpactStatisticsIsNull()
     {
         // Arrange
-        var dto = GetValidCreateDto() with { ImageId = null, ImpactStatistics = null };
+        var validDto = GetValidCreateDto();
+        var dto = validDto with
+        {
+            ImageId = null,
+            MainDonations = validDto.MainDonations! with { ImageId = null },
+            ImpactStatistics = null,
+        };
         var command = new CreateMainPageCommand(dto);
         var entity = GetMainPageEntity(20);
         entity.ImpactStatistics = null;
@@ -345,6 +353,7 @@ public class CreateMainPageHandlerTests
         var dto = GetValidCreateDto() with
         {
             ImageId = null,
+            MainDonations = GetValidCreateDto().MainDonations! with { ImageId = null },
             ImpactStatistics = new CreateImpactStatisticDto
             {
                 Title = "Impact title",
@@ -480,6 +489,12 @@ public class CreateMainPageHandlerTests
             Title = "Partners title",
             Description = "Partners description that is long enough",
         },
+        MainDonations = new CreateMainDonationsDto
+        {
+            Title = "Donations title",
+            Description = "Donations description that is long enough",
+            ImageId = 7,
+        },
         ImpactStatistics = new CreateImpactStatisticDto
         {
             Title = "Impact statistic title",
@@ -512,6 +527,13 @@ public class CreateMainPageHandlerTests
             Title = "Partners title",
             Description = "Partners description",
         },
+        MainDonations = new MainDonations
+        {
+            Id = 18,
+            Title = "Donations title",
+            Description = "Donations description",
+            ImageId = 7,
+        },
         ImpactStatistics = new ImpactStatistics
         {
             Id = 13,
@@ -543,6 +565,12 @@ public class CreateMainPageHandlerTests
             Id = 12,
             Title = "Partners title",
             Description = "Partners description",
+        },
+        MainDonations = new MainDonationsDto
+        {
+            Id = 18,
+            Title = "Donations title",
+            Description = "Donations description",
         },
         ImpactStatistics = new ImpactStatisticDto
         {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/GetMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/GetMainPageHandlerTests.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Moq;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.Queries.Public.MainPage.GetMainPage;
@@ -33,6 +34,12 @@ public class GetMainPageHandlerTests
             Id = 1,
             Title = "Main page",
             Description = "Main page description",
+            MainDonations = new DAL.Entities.MainDonations
+            {
+                Id = 2,
+                Title = "Donations title",
+                Description = "Donations description",
+            },
         };
 
         var dto = new MainPageDto
@@ -40,6 +47,12 @@ public class GetMainPageHandlerTests
             Id = 1,
             Title = "Main page",
             Description = "Main page description",
+            MainDonations = new MainDonationsDto
+            {
+                Id = 2,
+                Title = "Donations title",
+                Description = "Donations description",
+            },
         };
 
         _mainPageRepositoryMock
@@ -59,6 +72,8 @@ public class GetMainPageHandlerTests
         // Assert
         Assert.True(result.IsSuccess);
         Assert.Equal(dto.Id, result.Value.Id);
+        Assert.NotNull(result.Value.MainDonations);
+        Assert.Equal(dto.MainDonations.Title, result.Value.MainDonations.Title);
         Assert.NotNull(passedQueryOptions);
         Assert.True(passedQueryOptions!.AsNoTracking);
         Assert.NotNull(passedQueryOptions.Include);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/UpdateMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/UpdateMainPageHandlerTests.cs
@@ -10,6 +10,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.BLL.Notifications.ReportFunds;
@@ -67,6 +68,7 @@ public class UpdateMainPageHandlerTests
             {
                 new() { Id = 5 },
                 new() { Id = 6 },
+                new() { Id = 7 },
             });
 
         _mapperMock
@@ -74,6 +76,9 @@ public class UpdateMainPageHandlerTests
             .Verifiable();
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, existingEntity.MainPartners))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainDonations, existingEntity.MainDonations))
             .Verifiable();
 
         var expectedDto = new MainPageDto
@@ -107,6 +112,7 @@ public class UpdateMainPageHandlerTests
         Assert.Equal(command.UpdateMainPageDto.ImpactStatistics!.Metrics.Single().Value, updatedMetric.Value);
         Assert.Equal(command.UpdateMainPageDto.ImpactStatistics!.Metrics.Single().Name, updatedMetric.Name);
 
+        _mapperMock.Verify(x => x.Map(command.UpdateMainPageDto.MainDonations, existingEntity.MainDonations), Times.Once);
         _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
         _imageRepositoryMock.Verify(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()), Times.Once);
         _validatorMock.Verify(
@@ -132,6 +138,67 @@ public class UpdateMainPageHandlerTests
 
         _repositoryWrapperMock.Verify(x => x.BeginTransaction(), Times.Never);
         _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateMainDonations_WhenMainDonationsDoesNotExist()
+    {
+        // Arrange
+        var existingEntity = GetExistingMainPageEntity(1);
+        existingEntity.MainDonations = null;
+
+        var command = new UpdateMainPageCommand(GetValidUpdateDto(existingEntity));
+        var mappedDonations = new MainDonations
+        {
+            Title = command.UpdateMainPageDto.MainDonations!.Title,
+            Description = command.UpdateMainPageDto.MainDonations.Description,
+            ImageId = command.UpdateMainPageDto.MainDonations.ImageId,
+        };
+
+        SetupValidationSuccess();
+
+        _mainPageRepositoryMock
+            .SetupSequence(x => x.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<DAL.Entities.MainPage>?>()))
+            .ReturnsAsync(existingEntity)
+            .ReturnsAsync(existingEntity);
+
+        _imageRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
+            .ReturnsAsync(new List<Image>
+            {
+                new() { Id = 5 },
+                new() { Id = 6 },
+                new() { Id = 7 },
+            });
+
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainAboutUs, existingEntity.MainAboutUs))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, existingEntity.MainPartners))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map<MainDonations>(command.UpdateMainPageDto.MainDonations))
+            .Returns(mappedDonations);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mapperMock
+            .Setup(x => x.Map<DAL.Entities.MainPage, MainPageDto>(existingEntity))
+            .Returns(new MainPageDto { Id = existingEntity.Id });
+
+        var handler = CreateHandler();
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(existingEntity.MainDonations);
+        Assert.Equal(command.UpdateMainPageDto.MainDonations!.Title, existingEntity.MainDonations!.Title);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
     }
 
     [Fact]
@@ -183,7 +250,7 @@ public class UpdateMainPageHandlerTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Equal(
-            ErrorMessagesConstants.NotFound(new[] { 6L }, typeof(Image)),
+            ErrorMessagesConstants.NotFound(new[] { 6L, 7L }, typeof(Image)),
             result.Errors[0].Message);
 
         _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Never);
@@ -212,6 +279,7 @@ public class UpdateMainPageHandlerTests
             .ReturnsAsync(new List<Image>
             {
                 new() { Id = 6 },
+                new() { Id = 7 },
             });
 
         var handler = CreateHandler();
@@ -245,6 +313,7 @@ public class UpdateMainPageHandlerTests
             {
                 new() { Id = 5 },
                 new() { Id = 6 },
+                new() { Id = 7 },
             });
 
         _repositoryWrapperMock
@@ -317,13 +386,16 @@ public class UpdateMainPageHandlerTests
 
         _imageRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
-            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }, new Image { Id = 7 }]);
 
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainAboutUs, entity.MainAboutUs))
             .Verifiable();
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, entity.MainPartners))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainDonations, entity.MainDonations))
             .Verifiable();
         _mapperMock
             .Setup(x => x.Map<Metric>(It.IsAny<UpdateMetricDto>()))
@@ -385,13 +457,16 @@ public class UpdateMainPageHandlerTests
 
         _imageRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
-            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }, new Image { Id = 7 }]);
 
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainAboutUs, entity.MainAboutUs))
             .Verifiable();
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, entity.MainPartners))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainDonations, entity.MainDonations))
             .Verifiable();
 
         _repositoryWrapperMock
@@ -457,13 +532,16 @@ public class UpdateMainPageHandlerTests
 
         _imageRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<QueryOptions<Image>?>()))
-            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }]);
+            .ReturnsAsync([new Image { Id = 5 }, new Image { Id = 6 }, new Image { Id = 7 }]);
 
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainAboutUs, entity.MainAboutUs))
             .Verifiable();
         _mapperMock
             .Setup(x => x.Map(command.UpdateMainPageDto.MainPartners, entity.MainPartners))
+            .Verifiable();
+        _mapperMock
+            .Setup(x => x.Map(command.UpdateMainPageDto.MainDonations, entity.MainDonations))
             .Verifiable();
 
         _repositoryWrapperMock
@@ -527,6 +605,12 @@ public class UpdateMainPageHandlerTests
             Title = "Updated partners title",
             Description = "Updated partners description long enough",
         },
+        MainDonations = new UpdateMainDonationsDto
+        {
+            Title = "Updated donations title",
+            Description = "Updated donations description long enough",
+            ImageId = 7,
+        },
         ImpactStatistics = new UpdateImpactStatisticDto
         {
             Title = "Updated impact statistic title",
@@ -552,6 +636,12 @@ public class UpdateMainPageHandlerTests
         {
             Title = "Updated partners title",
             Description = "Updated partners description long enough",
+        },
+        MainDonations = new UpdateMainDonationsDto
+        {
+            Title = "Updated donations title",
+            Description = "Updated donations description long enough",
+            ImageId = 7,
         },
         ImpactStatistics = new UpdateImpactStatisticDto
         {
@@ -588,6 +678,13 @@ public class UpdateMainPageHandlerTests
             Id = 12,
             Title = "Old partners title",
             Description = "Old partners description",
+        },
+        MainDonations = new MainDonations
+        {
+            Id = 15,
+            Title = "Old donations title",
+            Description = "Old donations description",
+            ImageId = 3,
         },
         ImpactStatistics = new ImpactStatistics
         {

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainDonationsLocalizationDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainDonationsLocalizationDtoValidatorTests.cs
@@ -1,0 +1,102 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+using VictoryCenter.BLL.Validators.Localization.MainPage;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.MainPage;
+
+public class CreateMainDonationsLocalizationDtoValidatorTests
+{
+    private readonly CreateMainDonationsLocalizationDtoValidator _validator = new(new BaseMainPageLocalizationDtoValidator());
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenOptionalFieldsAreNull()
+    {
+        var dto = GetValidDto() with
+        {
+            Title = null,
+            Description = null,
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_ShouldHaveError_WhenEntityIdIsNotPositive(long entityId)
+    {
+        var dto = GetValidDto() with { EntityId = entityId };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.EntityId)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(CreateMainDonationsLocalizationDto.EntityId)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    private static CreateMainDonationsLocalizationDto GetValidDto() => new()
+    {
+        EntityId = 1,
+        Title = new string('a', MainPageConstants.Title.MinLength),
+        Description = new string('a', MainPageConstants.Description.MinLength),
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainPageLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainPageLocalizationValidatorTests.cs
@@ -16,7 +16,12 @@ public class CreateMainPageLocalizationValidatorTests
         var baseValidator = new BaseMainPageLocalizationDtoValidator();
         var mainAboutUsValidator = new CreateMainAboutUsLocalizationDtoValidator(baseValidator);
         var mainPartnersValidator = new CreateMainPartnersLocalizationDtoValidator(baseValidator);
-        var dtoValidator = new CreateMainPageLocalizationDtoValidator(baseValidator, mainAboutUsValidator, mainPartnersValidator);
+        var mainDonationsValidator = new CreateMainDonationsLocalizationDtoValidator(baseValidator);
+        var dtoValidator = new CreateMainPageLocalizationDtoValidator(
+            baseValidator,
+            mainAboutUsValidator,
+            mainPartnersValidator,
+            mainDonationsValidator);
         _validator = new CreateMainPageLocalizationCommandValidator(dtoValidator);
     }
 
@@ -40,7 +45,8 @@ public class CreateMainPageLocalizationValidatorTests
             Title = null,
             Description = null,
             MainAboutUs = null,
-            MainPartners = null
+            MainPartners = null,
+            MainDonations = null
         });
 
         _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
@@ -56,7 +62,8 @@ public class CreateMainPageLocalizationValidatorTests
             Title = new string('a', MainPageConstants.Title.MinLength),
             Description = new string('a', MainPageConstants.Description.MinLength),
             MainAboutUs = null,
-            MainPartners = null
+            MainPartners = null,
+            MainDonations = null
         });
 
         _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
@@ -330,6 +337,87 @@ public class CreateMainPageLocalizationValidatorTests
         _validator.TestValidate(BuildCommand(dto)).ShouldNotHaveAnyValidationErrors();
     }
 
+    // ── MainDonations ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_ShouldHaveError_WhenMainDonationsEntityIdIsNotPositive(long entityId)
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new CreateMainDonationsLocalizationDto { EntityId = entityId }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainDonations.EntityId");
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainDonationsTitleIsTooShort()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new CreateMainDonationsLocalizationDto
+            {
+                EntityId = 1,
+                Title = new string('a', MainPageConstants.Title.MinLength - 1)
+            }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainDonations.Title")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainDonationsTitleIsTooLong()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new CreateMainDonationsLocalizationDto
+            {
+                EntityId = 1,
+                Title = new string('a', MainPageConstants.Title.MaxLength + 1)
+            }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainDonations.Title")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainDonationsDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new CreateMainDonationsLocalizationDto
+            {
+                EntityId = 1,
+                Description = new string('a', MainPageConstants.Description.MinLength - 1)
+            }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainDonations.Description")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenMainDonationsHasOnlyEntityId()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new CreateMainDonationsLocalizationDto { EntityId = 1 }
+        };
+
+        _validator.TestValidate(BuildCommand(dto)).ShouldNotHaveAnyValidationErrors();
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static CreateMainPageLocalizationDto GetValidDto() => new()
@@ -345,6 +433,12 @@ public class CreateMainPageLocalizationValidatorTests
             Description = new string('a', MainPageConstants.Description.MinLength)
         },
         MainPartners = new CreateMainPartnersLocalizationDto
+        {
+            EntityId = 1,
+            Title = new string('a', MainPageConstants.Title.MinLength),
+            Description = new string('a', MainPageConstants.Description.MinLength)
+        },
+        MainDonations = new CreateMainDonationsLocalizationDto
         {
             EntityId = 1,
             Title = new string('a', MainPageConstants.Title.MinLength),

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidatorTests.cs
@@ -1,0 +1,87 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+using VictoryCenter.BLL.Validators.Localization.MainPage;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.MainPage;
+
+public class UpdateMainDonationsLocalizationDtoValidatorTests
+{
+    private readonly UpdateMainDonationsLocalizationDtoValidator _validator = new(new BaseMainPageLocalizationDtoValidator());
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenOptionalFieldsAreNull()
+    {
+        var dto = GetValidDto() with
+        {
+            Title = null,
+            Description = null,
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateMainDonationsLocalizationDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateMainDonationsLocalizationDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateMainDonationsLocalizationDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateMainDonationsLocalizationDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    private static UpdateMainDonationsLocalizationDto GetValidDto() => new()
+    {
+        Title = new string('a', MainPageConstants.Title.MinLength),
+        Description = new string('a', MainPageConstants.Description.MinLength),
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainPageLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainPageLocalizationValidatorTests.cs
@@ -1,0 +1,146 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.Localization.MainPage.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.MainPage;
+using VictoryCenter.BLL.Validators.Localization.MainPage;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.MainPage;
+
+public class UpdateMainPageLocalizationValidatorTests
+{
+    private readonly UpdateMainPageLocalizationCommandValidator _validator;
+
+    public UpdateMainPageLocalizationValidatorTests()
+    {
+        var baseValidator = new BaseMainPageLocalizationDtoValidator();
+        var mainAboutUsValidator = new UpdateMainAboutUsLocalizationDtoValidator(baseValidator);
+        var mainPartnersValidator = new UpdateMainPartnersLocalizationDtoValidator(baseValidator);
+        var mainDonationsValidator = new UpdateMainDonationsLocalizationDtoValidator(baseValidator);
+        var dtoValidator = new UpdateMainPageLocalizationDtoValidator(
+            baseValidator,
+            mainAboutUsValidator,
+            mainPartnersValidator,
+            mainDonationsValidator);
+        _validator = new UpdateMainPageLocalizationCommandValidator(dtoValidator);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenAllFieldsAreValid()
+    {
+        var command = BuildCommand(GetValidDto());
+
+        _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenOptionalFieldsAreNull()
+    {
+        var command = BuildCommand(new UpdateMainPageLocalizationDto
+        {
+            Title = null,
+            Description = null,
+            MainAboutUs = null,
+            MainPartners = null,
+            MainDonations = null
+        });
+
+        _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with
+        {
+            Title = new string('a', MainPageConstants.Title.MinLength - 1)
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor(x => x.Dto.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateMainPageLocalizationDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with
+        {
+            Description = new string('a', MainPageConstants.Description.MaxLength + 1)
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor(x => x.Dto.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateMainPageLocalizationDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainAboutUsIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainAboutUs = new UpdateMainAboutUsLocalizationDto
+            {
+                Title = new string('a', MainPageConstants.Title.MinLength - 1)
+            }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainAboutUs.Title");
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainPartnersIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainPartners = new UpdateMainPartnersLocalizationDto
+            {
+                Title = new string('a', MainPageConstants.Title.MinLength - 1)
+            }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainPartners.Title");
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenMainDonationsIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new UpdateMainDonationsLocalizationDto
+            {
+                Title = new string('a', MainPageConstants.Title.MinLength - 1)
+            }
+        };
+
+        _validator.TestValidate(BuildCommand(dto))
+            .ShouldHaveValidationErrorFor("Dto.MainDonations.Title");
+    }
+
+    private static UpdateMainPageLocalizationDto GetValidDto() => new()
+    {
+        Title = new string('a', MainPageConstants.Title.MinLength),
+        Description = new string('a', MainPageConstants.Description.MinLength),
+        MainAboutUs = new UpdateMainAboutUsLocalizationDto
+        {
+            Title = new string('a', MainPageConstants.Title.MinLength),
+            Description = new string('a', MainPageConstants.Description.MinLength)
+        },
+        MainPartners = new UpdateMainPartnersLocalizationDto
+        {
+            Title = new string('a', MainPageConstants.Title.MinLength),
+            Description = new string('a', MainPageConstants.Description.MinLength)
+        },
+        MainDonations = new UpdateMainDonationsLocalizationDto
+        {
+            Title = new string('a', MainPageConstants.Title.MinLength),
+            Description = new string('a', MainPageConstants.Description.MinLength)
+        }
+    };
+
+    private static UpdateMainPageLocalizationCommand BuildCommand(UpdateMainPageLocalizationDto dto)
+        => new(dto, 1, 1);
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainDonationsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainDonationsDtoValidatorTests.cs
@@ -1,0 +1,124 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class CreateMainDonationsDtoValidatorTests
+{
+    private readonly CreateMainDonationsDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenImageIdIsNull()
+    {
+        var dto = GetValidDto() with { ImageId = null };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenTitleIsEmpty(string? title)
+    {
+        var dto = GetValidDto() with { Title = title! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Title)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenDescriptionIsEmpty(string? description)
+    {
+        var dto = GetValidDto() with { Description = description! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_ShouldHaveError_WhenImageIdIsNotPositive(long imageId)
+    {
+        var dto = GetValidDto() with { ImageId = imageId };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.ImageId)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(BaseMainDonationsDto.ImageId)));
+    }
+
+    private static CreateMainDonationsDto GetValidDto() => new()
+    {
+        Title = "Donations title",
+        Description = "Donations description",
+        ImageId = 1,
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
@@ -3,6 +3,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.BLL.Validators.MainPage.Dto;
@@ -133,6 +134,23 @@ public class CreateMainPageDtoValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldHaveError_WhenMainDonationsIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new CreateMainDonationsDto
+            {
+                Title = string.Empty,
+                Description = "Valid description",
+            },
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("MainDonations.Title");
+    }
+
+    [Fact]
     public void Validate_ShouldHaveError_WhenImpactStatisticsIsInvalid()
     {
         var dto = GetValidDto() with
@@ -162,6 +180,7 @@ public class CreateMainPageDtoValidatorTests
         {
             MainAboutUs = null,
             MainPartners = null,
+            MainDonations = null,
             ImpactStatistics = null,
         };
 
@@ -184,6 +203,11 @@ public class CreateMainPageDtoValidatorTests
         {
             Title = "Partners title",
             Description = "Partners description",
+        },
+        MainDonations = new CreateMainDonationsDto
+        {
+            Title = "Donations title",
+            Description = "Donations description",
         },
         ImpactStatistics = GetValidImpactStatisticDto(),
     };

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainDonationsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainDonationsDtoValidatorTests.cs
@@ -1,0 +1,124 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
+using VictoryCenter.BLL.Validators.MainPage.Dto;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.MainPage;
+
+public class UpdateMainDonationsDtoValidatorTests
+{
+    private readonly UpdateMainDonationsDtoValidator _validator = new();
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
+    {
+        var result = _validator.TestValidate(GetValidDto());
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenImageIdIsNull()
+    {
+        var dto = GetValidDto() with { ImageId = null };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenTitleIsEmpty(string? title)
+    {
+        var dto = GetValidDto() with { Title = title! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Title)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooShort()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_ShouldHaveError_WhenDescriptionIsEmpty(string? description)
+    {
+        var dto = GetValidDto() with { Description = description! };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MinLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
+    {
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.Description)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MaxLength));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_ShouldHaveError_WhenImageIdIsNotPositive(long imageId)
+    {
+        var dto = GetValidDto() with { ImageId = imageId };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor(x => x.ImageId)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(BaseMainDonationsDto.ImageId)));
+    }
+
+    private static UpdateMainDonationsDto GetValidDto() => new()
+    {
+        Title = "Donations title",
+        Description = "Donations description",
+        ImageId = 1,
+    };
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainPageDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainPageDtoValidatorTests.cs
@@ -3,6 +3,7 @@ using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.BLL.Validators.MainPage.Dto;
@@ -132,6 +133,23 @@ public class UpdateMainPageDtoValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldHaveError_WhenMainDonationsIsInvalid()
+    {
+        var dto = GetValidDto() with
+        {
+            MainDonations = new UpdateMainDonationsDto
+            {
+                Title = string.Empty,
+                Description = "Valid description",
+            },
+        };
+
+        var result = _validator.TestValidate(dto);
+
+        result.ShouldHaveValidationErrorFor("MainDonations.Title");
+    }
+
+    [Fact]
     public void Validate_ShouldHaveError_WhenNestedImpactStatisticIsInvalid()
     {
         var dto = GetValidDto() with
@@ -155,6 +173,7 @@ public class UpdateMainPageDtoValidatorTests
         {
             MainAboutUs = null,
             MainPartners = null,
+            MainDonations = null,
             ImpactStatistics = null,
         };
 
@@ -177,6 +196,11 @@ public class UpdateMainPageDtoValidatorTests
         {
             Title = "Partners title",
             Description = "Partners description",
+        },
+        MainDonations = new UpdateMainDonationsDto
+        {
+            Title = "Donations title",
+            Description = "Donations description",
         },
         ImpactStatistics = GetValidImpactStatisticDto(),
     };


### PR DESCRIPTION
dev
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2524

## Summary of issue

Main Page needs backend support for the Donations block so admins can create, update, localize, and retrieve donations content together with the rest of the Main Page data.

## Summary of change

### DAL
* Added MainDonations entity with Title, Description, optional ImageId, MainPageId, image navigation, main page navigation, and localizations.
* Added MainDonationsLocalization entity with localized Title and Description.
* Added EF configurations for MainDonations and MainDonationsLocalization.
* Extended MainPage with MainDonations one-to-one navigation.
* Added DbSet entries for MainDonations and MainDonationsLocalizations.
* Added repositories and repository wrapper wiring for donations and donations localizations.
* Added AddMainDonations EF migration and updated the model snapshot.

### BLL
* Added admin request/response DTOs for MainDonations.
* Added localization DTOs for MainDonationsLocalization.
* Extended Main Page create/update/response DTOs with optional MainDonations.
* Extended Main Page localization create/update/response DTOs with optional MainDonations.
* Added FluentValidation validators for donations create/update DTOs and donations localization DTOs.
* Wired nested donations validation into Main Page and Main Page localization validators.
* Updated Main Page AutoMapper profile for donations create/update/entity response mappings.
* Updated Main Page localization AutoMapper profile for donations localization mappings.
* Updated Main Page create/update/get handlers to include MainDonations, validate donations image ids, persist donations content, and load donations image/localizations.
* Updated Main Page localization create/update handlers to use ILocalizationService<MainDonations, MainDonationsLocalization> and return donations localization data.

### WebAPI
* No new WebAPI controllers or endpoints.
* Existing Main Page and Main Page localization endpoints now support the extended DTOs with MainDonations.

## Testing approach

* Added unit tests for CreateMainDonationsDtoValidator and UpdateMainDonationsDtoValidator.
* Added unit tests for donations localization validators.
* Updated Main Page DTO validator tests to cover nested donations validation.
* Updated Main Page localization validator tests to cover nested donations localization validation.
* Updated Main Page handler unit tests for donations image id validation, create/update behavior, get behavior, and notification-related setup.
* Updated Main Page localization handler unit tests for donations localization create/update flows and NotFound cases.
* Updated Main Page integration tests for create, update, and get flows with donations.
* Added Main Page localization create integration tests and updated localization update integration tests for donations.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full "Donations" section to the main page: create, update, fetch, and per-language localizations (title, description, image).
  * API responses and admin DTOs now include Donations data so UIs can display and edit it.
  * Image validation applied to Donations images to surface bad/missing image errors.
* **Tests**
  * Integration and unit tests expanded to cover Donations flows and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->