### PR TITLE
[Feature/issue-1399] Added localization to PdfRepots

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
@@ -57,6 +57,7 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
                 BlobName = blobName,
                 FileSizeBytes = dto.File.Length,
                 Priority = nextPriority,
+                LanguageId = dto.LanguageId,
                 CreatedAt = DateTimeOffset.UtcNow
             };
 

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/CreatePdfReportDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/CreatePdfReportDto.cs
@@ -5,4 +5,5 @@ namespace VictoryCenter.BLL.DTOs.Admin.PdfReports;
 public record CreatePdfReportDto
 {
     public required IFormFile File { get; init; }
+    public required long LanguageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/PdfReportDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/PdfReportDto.cs
@@ -8,4 +8,6 @@ public record PdfReportDto
     public long FileSizeBytes { get; init; }
     public DateTimeOffset CreatedAt { get; init; }
     public long Priority { get; init; }
+    public long? LanguageId { get; init; }
+    public string? LanguageCode { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/PdfReportFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/PdfReports/PdfReportFilterDto.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.BLL.DTOs.Admin.Common;
+
+namespace VictoryCenter.BLL.DTOs.Admin.PdfReports;
+
+public record PdfReportFilterDto : BaseFilterDto
+{
+    public long? LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/PdfReports/PdfReportProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/PdfReports/PdfReportProfile.cs
@@ -8,6 +8,9 @@ public class PdfReportProfile : Profile
 {
     public PdfReportProfile()
     {
-        CreateMap<PdfReport, PdfReportDto>();
+        CreateMap<PdfReport, PdfReportDto>()
+            .ForMember(
+                dest => dest.LanguageCode,
+                opt => opt.MapFrom(src => src.Language != null ? src.Language.Code : null));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/PdfReports/GetAll/GetAllPdfReportsQuery.cs
@@ -1,10 +1,9 @@
 using FluentResults;
 using MediatR;
-using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.DTOs.Common;
 
 namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
 
-public record GetAllPdfReportsQuery(BaseFilterDto FilterDto)
+public record GetAllPdfReportsQuery(PdfReportFilterDto FilterDto)
     : IRequest<Result<PaginationResult<PdfReportDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/PdfReports/GetByLanguageId/GetPublicPdfReportsByLanguageIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/PdfReports/GetByLanguageId/GetPublicPdfReportsByLanguageIdHandler.cs
@@ -8,37 +8,37 @@ using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
-namespace VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
+namespace VictoryCenter.BLL.Queries.Public.PdfReports.GetByLanguageId;
 
-public class GetAllPdfReportsHandler : IRequestHandler<GetAllPdfReportsQuery, Result<PaginationResult<PdfReportDto>>>
+public class GetPublicPdfReportsByLanguageIdHandler
+    : IRequestHandler<GetPublicPdfReportsByLanguageIdQuery, Result<PaginationResult<PdfReportDto>>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IMapper _mapper;
 
-    public GetAllPdfReportsHandler(
-        IRepositoryWrapper repositoryWrapper,
-        IMapper mapper)
+    public GetPublicPdfReportsByLanguageIdHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
     {
         _repositoryWrapper = repositoryWrapper;
         _mapper = mapper;
     }
 
-    public async Task<Result<PaginationResult<PdfReportDto>>> Handle(GetAllPdfReportsQuery request, CancellationToken cancellationToken)
+    public async Task<Result<PaginationResult<PdfReportDto>>> Handle(
+        GetPublicPdfReportsByLanguageIdQuery request, CancellationToken cancellationToken)
     {
-        var languageId = request.FilterDto.LanguageId;
-
         var queryOptions = new QueryOptions<PdfReport>
         {
-            Filter = languageId.HasValue ? p => p.LanguageId == languageId.Value : null,
+            Filter = p => p.LanguageId == request.LanguageId,
             Include = q => q.Include(p => p.Language),
-            Offset = request.FilterDto.Offset ?? 0,
-            Limit = request.FilterDto.Limit ?? 20,
-            OrderByASC = p => p.Priority
+            Offset = request.Filter.Offset ?? 0,
+            Limit = request.Filter.Limit ?? 20,
+            OrderByASC = p => p.Priority,
+            AsNoTracking = true
         };
 
         var countOptions = new QueryOptions<PdfReport>
         {
-            Filter = languageId.HasValue ? p => p.LanguageId == languageId.Value : null
+            Filter = p => p.LanguageId == request.LanguageId,
+            AsNoTracking = true
         };
 
         var pdfReports = await _repositoryWrapper.PdfReportRepository.GetAllAsync(queryOptions);

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/PdfReports/GetByLanguageId/GetPublicPdfReportsByLanguageIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/PdfReports/GetByLanguageId/GetPublicPdfReportsByLanguageIdQuery.cs
@@ -1,0 +1,10 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.Queries.Public.PdfReports.GetByLanguageId;
+
+public record GetPublicPdfReportsByLanguageIdQuery(long LanguageId, BaseFilterDto Filter)
+    : IRequest<Result<PaginationResult<PdfReportDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/PdfReports/CreatePdfReportValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 
 namespace VictoryCenter.BLL.Validators.PdfReports;
 
@@ -15,14 +16,18 @@ public class CreatePdfReportValidator : AbstractValidator<CreatePdfReportCommand
         When(x => x.CreatePdfReportDto != null, () =>
         {
             RuleFor(x => x.CreatePdfReportDto.File)
-            .NotNull()
-            .WithMessage(ErrorMessagesConstants.PropertyIsRequired("File"))
-            .Must(file => file?.Length > 0)
-            .WithMessage(PdfReportConstants.FileCannotBeEmpty)
-            .Must(file => file?.Length <= PdfReportConstants.MaxPdfSizeInBytes)
-            .WithMessage(string.Format(PdfReportConstants.FileTooLarge, PdfReportConstants.MaxPdfSizeInMb))
-            .Must(file => file?.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase) == true)
-            .WithMessage(PdfReportConstants.FileMustBePdf);
+                .NotNull()
+                .WithMessage(ErrorMessagesConstants.PropertyIsRequired("File"))
+                .Must(file => file?.Length > 0)
+                .WithMessage(PdfReportConstants.FileCannotBeEmpty)
+                .Must(file => file?.Length <= PdfReportConstants.MaxPdfSizeInBytes)
+                .WithMessage(string.Format(PdfReportConstants.FileTooLarge, PdfReportConstants.MaxPdfSizeInMb))
+                .Must(file => file?.ContentType.Equals(PdfReportConstants.PdfMimeType, StringComparison.OrdinalIgnoreCase) == true)
+                .WithMessage(PdfReportConstants.FileMustBePdf);
+
+            RuleFor(x => x.CreatePdfReportDto.LanguageId)
+                .GreaterThan(0)
+                .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreatePdfReportDto.LanguageId)));
         });
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/PdfReportConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/PdfReportConfig.cs
@@ -34,5 +34,13 @@ public class PdfReportConfig : IEntityTypeConfiguration<PdfReport>
 
         entity.HasIndex(e => e.Priority)
             .IsUnique();
+
+        entity.HasOne(e => e.Language)
+            .WithMany()
+            .HasForeignKey(e => e.LanguageId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        entity.HasIndex(e => e.LanguageId);
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/PdfReport.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/PdfReport.cs
@@ -1,5 +1,6 @@
 using VictoryCenter.DAL.Data.BaseEntity;
 using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 
 namespace VictoryCenter.DAL.Entities;
 
@@ -9,4 +10,6 @@ public class PdfReport : BaseEntity, IOrderableEntity
     public string BlobName { get; set; } = null!;
     public long FileSizeBytes { get; set; }
     public long Priority { get; set; }
+    public long? LanguageId { get; set; }
+    public LocalizationLanguage? Language { get; set; }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260609211541_AddLanguageIdToPdfReport.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260609211541_AddLanguageIdToPdfReport.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609211541_AddLanguageIdToPdfReport")]
+    partial class AddLanguageIdToPdfReport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260609211541_AddLanguageIdToPdfReport.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260609211541_AddLanguageIdToPdfReport.cs
@@ -24,6 +24,13 @@ namespace VictoryCenter.DAL.Migrations
                 table: "PdfReports",
                 column: "LanguageId");
 
+            migrationBuilder.Sql(@"
+                UPDATE [media].[PdfReports]
+                SET LanguageId = (SELECT Id FROM LocalizationLanguages WHERE Code = 'uk')
+                WHERE LanguageId IS NULL
+                    AND EXISTS (SELECT 1 FROM LocalizationLanguages WHERE Code = 'uk')
+            ");
+
             migrationBuilder.AddForeignKey(
                 name: "FK_PdfReports_LocalizationLanguages_LanguageId",
                 schema: "media",

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260609211541_AddLanguageIdToPdfReport.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260609211541_AddLanguageIdToPdfReport.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLanguageIdToPdfReport : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "LanguageId",
+                schema: "media",
+                table: "PdfReports",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PdfReports_LanguageId",
+                schema: "media",
+                table: "PdfReports",
+                column: "LanguageId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PdfReports_LocalizationLanguages_LanguageId",
+                schema: "media",
+                table: "PdfReports",
+                column: "LanguageId",
+                principalTable: "LocalizationLanguages",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PdfReports_LocalizationLanguages_LanguageId",
+                schema: "media",
+                table: "PdfReports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PdfReports_LanguageId",
+                schema: "media",
+                table: "PdfReports");
+
+            migrationBuilder.DropColumn(
+                name: "LanguageId",
+                schema: "media",
+                table: "PdfReports");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -222,6 +222,7 @@ public class CreatePdfReportTests : BaseTestClass
         var fileContent = new ByteArrayContent(pdfContent);
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
         form.Add(fileContent, "File", fileName);
+        form.Add(new StringContent("1"), "LanguageId");
         return form;
     }
 

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Public/PublicPdfReportsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Public/PublicPdfReportsTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.PdfReports.Public;
+
+public class PublicPdfReportsTests : BaseTestClass
+{
+    private static readonly byte[] PdfSignatureBytes =
+        [0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34];
+
+    public PublicPdfReportsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetPdfReportsByLanguageId_ShouldReturnPaginatedList()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        await SeedPdfReportsAsync(languageId: 1, count: 3, priorityBase: 10);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports/languageId/1?Offset=0&Limit=20");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Items.Length);
+        Assert.Equal(3, result.TotalItemsCount);
+    }
+
+    [Fact]
+    public async Task GetPdfReportsByLanguageId_ShouldFilterByLanguageId()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        await SeedPdfReportsAsync(languageId: 1, count: 2, priorityBase: 10);
+        await SeedPdfReportsAsync(languageId: 2, count: 3, priorityBase: 100);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports/languageId/1?Offset=0&Limit=20");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Items.Length);
+        Assert.Equal(2, result.TotalItemsCount);
+        Assert.All(result.Items, item => Assert.Equal((long?)1, item.LanguageId));
+    }
+
+    [Fact]
+    public async Task GetPdfReportsByLanguageId_NoReportsForLanguage_ShouldReturnEmptyList()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports/languageId/999?Offset=0&Limit=20");
+        var responseString = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<PaginationResult<PdfReportDto>>(responseString, JsonOptions);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(result);
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalItemsCount);
+    }
+
+    [Fact]
+    public async Task GetPdfFile_ValidId_ShouldReturnPdfFile()
+    {
+        // Arrange
+        await ClearPdfReportsAsync();
+        var report = await CreateReportWithFileAsync("public-pdf-valid", 1);
+
+        // Act
+        var response = await Fixture.HttpClient.GetAsync($"api/PdfReports/{report.Id}/file");
+        var responseBytes = await response.Content.ReadAsByteArrayAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/pdf", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(PdfSignatureBytes, responseBytes);
+    }
+
+    [Fact]
+    public async Task GetPdfFile_InvalidId_ShouldReturnNotFound()
+    {
+        // Act
+        var response = await Fixture.HttpClient.GetAsync("api/PdfReports/999999/file");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task ClearPdfReportsAsync()
+    {
+        var all = await Fixture.DbContext.PdfReports.ToListAsync();
+
+        foreach (var r in all)
+        {
+            var fp = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, r.BlobName);
+            if (File.Exists(fp))
+            {
+                File.Delete(fp);
+            }
+        }
+
+        Fixture.DbContext.PdfReports.RemoveRange(all);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+    }
+
+    private async Task SeedPdfReportsAsync(long languageId, int count, int priorityBase)
+    {
+        var reports = Enumerable.Range(1, count).Select(i => new PdfReport
+        {
+            Name = $"Звіт lang{languageId} №{i}",
+            BlobName = $"{Guid.NewGuid():N}.pdf",
+            FileSizeBytes = 1024 * i,
+            Priority = priorityBase + i,
+            CreatedAt = DateTimeOffset.UtcNow,
+            LanguageId = languageId
+        });
+
+        await Fixture.DbContext.PdfReports.AddRangeAsync(reports);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+    }
+
+    private async Task<PdfReport> CreateReportWithFileAsync(
+        string baseName,
+        int priority,
+        byte[] fileBytes = null!)
+    {
+        var blobName = $"{baseName}.pdf";
+        var filePath = Path.Combine(Fixture.PdfEnvironmentVariables.FullPath, blobName);
+
+        Directory.CreateDirectory(Fixture.PdfEnvironmentVariables.FullPath);
+
+        var content = fileBytes ?? PdfSignatureBytes;
+        await File.WriteAllBytesAsync(filePath, content);
+
+        var report = new PdfReport
+        {
+            Name = baseName,
+            BlobName = blobName,
+            FileSizeBytes = content.Length,
+            Priority = priority,
+            CreatedAt = DateTimeOffset.UtcNow,
+            LanguageId = 1
+        };
+
+        Fixture.DbContext.PdfReports.Add(report);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        return report;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Update/UpdatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Update/UpdatePdfReportTests.cs
@@ -241,6 +241,7 @@ public class UpdatePdfReportTests : BaseTestClass
         var fileContent = new ByteArrayContent(pdfContent);
         fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
         form.Add(fileContent, "File", fileName);
+        form.Add(new StringContent("1"), "LanguageId");
         return form;
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/CreatePdfReportHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/CreatePdfReportHandlerTests.cs
@@ -84,7 +84,7 @@ public class CreatePdfReportHandlerTests
         _mockMapper.Setup(x => x.Map<PdfReportDto>(It.IsAny<PdfReport>()))
             .Returns(_testPdfReportDto);
 
-        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile });
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile, LanguageId = 1 });
 
         // Act
         var result = await CreateHandler().Handle(command, CancellationToken.None);
@@ -106,7 +106,7 @@ public class CreatePdfReportHandlerTests
     public async Task Handle_NullFile_ShouldReturnValidationError()
     {
         // Arrange
-        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = null! });
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = null!, LanguageId = 1 });
 
         // Act
         var result = await CreateHandler().Handle(command, CancellationToken.None);
@@ -135,7 +135,7 @@ public class CreatePdfReportHandlerTests
         _mockRepositoryWrapper.Setup(x => x.BeginTransaction())
             .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
 
-        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile });
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile, LanguageId = 1 });
 
         // Act
         var result = await CreateHandler().Handle(command, CancellationToken.None);
@@ -155,7 +155,7 @@ public class CreatePdfReportHandlerTests
         _mockRepositoryWrapper.Setup(x => x.BeginTransaction())
             .Returns(new TransactionScope(TransactionScopeAsyncFlowOption.Enabled));
 
-        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile });
+        var command = new CreatePdfReportCommand(new CreatePdfReportDto { File = _testFile, LanguageId = 1 });
 
         // Act
         var result = await CreateHandler().Handle(command, CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetAllPdfReportsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetAllPdfReportsHandlerTests.cs
@@ -1,6 +1,5 @@
 using AutoMapper;
 using Moq;
-using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
 using VictoryCenter.DAL.Entities;
@@ -48,7 +47,7 @@ public class GetAllPdfReportsHandlerTests
         _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
             .Returns(_testPdfReportDtos);
 
-        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = 0, Limit = 20 });
+        var query = new GetAllPdfReportsQuery(new PdfReportFilterDto { Offset = 0, Limit = 20 });
 
         // Act
         var result = await CreateHandler().Handle(query, CancellationToken.None);
@@ -76,7 +75,7 @@ public class GetAllPdfReportsHandlerTests
         _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
             .Returns([]);
 
-        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = 0, Limit = 20 });
+        var query = new GetAllPdfReportsQuery(new PdfReportFilterDto { Offset = 0, Limit = 20 });
 
         // Act
         var result = await CreateHandler().Handle(query, CancellationToken.None);
@@ -100,7 +99,7 @@ public class GetAllPdfReportsHandlerTests
         _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
             .Returns([_testPdfReportDtos[0]]);
 
-        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = 1, Limit = 1 });
+        var query = new GetAllPdfReportsQuery(new PdfReportFilterDto { Offset = 1, Limit = 1 });
 
         // Act
         var result = await CreateHandler().Handle(query, CancellationToken.None);
@@ -129,7 +128,7 @@ public class GetAllPdfReportsHandlerTests
         _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
             .Returns(_testPdfReportDtos);
 
-        var query = new GetAllPdfReportsQuery(new BaseFilterDto { Offset = null, Limit = null });
+        var query = new GetAllPdfReportsQuery(new PdfReportFilterDto { Offset = null, Limit = null });
 
         // Act
         var result = await CreateHandler().Handle(query, CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPublicPdfReportsByLanguageIdHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/PdfReports/GetPublicPdfReportsByLanguageIdHandlerTests.cs
@@ -1,0 +1,149 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.Queries.Public.PdfReports.GetByLanguageId;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.PdfReports;
+
+public class GetPublicPdfReportsByLanguageIdHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly Mock<IMapper> _mockMapper;
+
+    private readonly List<PdfReport> _testPdfReports;
+    private readonly List<PdfReportDto> _testPdfReportDtos;
+
+    public GetPublicPdfReportsByLanguageIdHandlerTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _mockMapper = new Mock<IMapper>();
+
+        _testPdfReports =
+        [
+            new PdfReport { Id = 1, Name = "Звіт 2024", BlobName = "abc.pdf", Priority = 1, FileSizeBytes = 1024, CreatedAt = DateTimeOffset.UtcNow, LanguageId = 1 },
+            new PdfReport { Id = 2, Name = "Звіт 2025", BlobName = "def.pdf", Priority = 2, FileSizeBytes = 2048, CreatedAt = DateTimeOffset.UtcNow, LanguageId = 1 },
+        ];
+
+        _testPdfReportDtos =
+        [
+            new PdfReportDto { Id = 1, Name = "Звіт 2024", BlobName = "abc.pdf", Priority = 1, FileSizeBytes = 1024, CreatedAt = DateTimeOffset.UtcNow, LanguageId = 1 },
+            new PdfReportDto { Id = 2, Name = "Звіт 2025", BlobName = "def.pdf", Priority = 2, FileSizeBytes = 2048, CreatedAt = DateTimeOffset.UtcNow, LanguageId = 1 },
+        ];
+    }
+
+    [Fact]
+    public async Task Handle_ValidLanguageId_ShouldReturnPdfReports()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReports);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(2);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns(_testPdfReportDtos);
+
+        var query = new GetPublicPdfReportsByLanguageIdQuery(1, new BaseFilterDto { Offset = 0, Limit = 20 });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Items.Length);
+        Assert.Equal(2, result.Value.TotalItemsCount);
+
+        _mockRepositoryWrapper.Verify(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()), Times.Once);
+        _mockRepositoryWrapper.Verify(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()), Times.Once);
+        _mockMapper.Verify(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ShouldReturnEmptyPaginationResult()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync([]);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(0);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns([]);
+
+        var query = new GetPublicPdfReportsByLanguageIdQuery(999, new BaseFilterDto { Offset = 0, Limit = 20 });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value.Items);
+        Assert.Equal(0, result.Value.TotalItemsCount);
+    }
+
+    [Fact]
+    public async Task Handle_WithPagination_ShouldPassCorrectOptionsToRepository()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync([_testPdfReports[0]]);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(2);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns([_testPdfReportDtos[0]]);
+
+        var query = new GetPublicPdfReportsByLanguageIdQuery(1, new BaseFilterDto { Offset = 1, Limit = 1 });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value.Items);
+        Assert.Equal(2, result.Value.TotalItemsCount);
+
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetAllAsync(
+            It.Is<QueryOptions<PdfReport>>(o => o.Offset == 1 && o.Limit == 1)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullOffsetAndLimit_ShouldUseDefaultValues()
+    {
+        // Arrange
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.GetAllAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(_testPdfReports);
+
+        _mockRepositoryWrapper.Setup(x => x.PdfReportRepository.CountAsync(It.IsAny<QueryOptions<PdfReport>>()))
+            .ReturnsAsync(2);
+
+        _mockMapper.Setup(x => x.Map<List<PdfReportDto>>(It.IsAny<IEnumerable<PdfReport>>()))
+            .Returns(_testPdfReportDtos);
+
+        var query = new GetPublicPdfReportsByLanguageIdQuery(1, new BaseFilterDto { Offset = null, Limit = null });
+
+        // Act
+        var result = await CreateHandler().Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        _mockRepositoryWrapper.Verify(
+            x => x.PdfReportRepository.GetAllAsync(
+            It.Is<QueryOptions<PdfReport>>(o => o.Offset == 0 && o.Limit == 20)),
+            Times.Once);
+    }
+
+    private GetPublicPdfReportsByLanguageIdHandler CreateHandler() =>
+        new(
+            _mockRepositoryWrapper.Object,
+            _mockMapper.Object);
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/PdfReports/CreatePdfReportValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/PdfReports/CreatePdfReportValidatorTests.cs
@@ -120,7 +120,8 @@ public class CreatePdfReportValidatorTests
     {
         return new CreatePdfReportCommand(new CreatePdfReportDto
         {
-            File = file!
+            File = file!,
+            LanguageId = 1
         });
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/PdfReportsController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Create;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Delete;
 using VictoryCenter.BLL.Commands.Admin.PdfReports.Update;
-using VictoryCenter.BLL.DTOs.Admin.Common;
 using VictoryCenter.BLL.DTOs.Admin.PdfReports;
 using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Queries.Admin.PdfReports.GetAll;
@@ -23,7 +22,7 @@ public class PdfReportsController : AuthorizedApiController
 
     [HttpGet]
     [ProducesResponseType(typeof(PaginationResult<PdfReportDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetAllPdfReports([FromQuery] BaseFilterDto filter)
+    public async Task<IActionResult> GetAllPdfReports([FromQuery] PdfReportFilterDto filter)
     {
         return HandleResult(await Mediator.Send(new GetAllPdfReportsQuery(filter)));
     }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/PdfReportsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/PdfReportsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.DTOs.Admin.Common;
+using VictoryCenter.BLL.DTOs.Admin.PdfReports;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.PdfReports.GetById;
+using VictoryCenter.BLL.Queries.Public.PdfReports.GetByLanguageId;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Public;
+
+public class PdfReportsController : BaseApiController
+{
+    [HttpGet("languageId/{id:long}")]
+    [ProducesResponseType(typeof(PaginationResult<PdfReportDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPdfReportsByLanguageId(long id, [FromQuery] BaseFilterDto filter)
+    {
+        return HandleResult(await Mediator.Send(new GetPublicPdfReportsByLanguageIdQuery(id, filter)));
+    }
+
+    [HttpGet("{id:long}/file")]
+    [Produces("application/pdf")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPdfFile(long id)
+    {
+        var result = await Mediator.Send(new GetPdfReportByIdQuery(id));
+
+        if (!result.IsSuccess)
+        {
+            return HandleResult(result);
+        }
+
+        return File(result.Value, "application/pdf", fileDownloadName: null);
+    }
+}


### PR DESCRIPTION
## GitHub

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1399)

## Summary of issue

PDF reports had no language association, so it was impossible to separate EN and UK reports on the admin panel or serve language-specific reports on the public "Звітність" page. The frontend needed separate tabs for EN/UK uploads, but the backend had no way to distinguish them.

## Summary of change

- Added nullable `LanguageId` FK to `PdfReport` entity with EF config (Restrict delete) and a migration that backfills existing rows to the `uk` language
- Added `PdfReportFilterDto` with optional `LanguageId` filter; updated admin `GET /api/PdfReports` to filter by language and include the `Language` navigation property
- `CreatePdfReportDto` now requires `LanguageId` (validated > 0); handler passes it to the new entity
- Added two public (no auth) endpoints via a new `Public/PdfReportsController`:
  - `GET /api/PdfReports/languageId/{id}` — returns paginated list filtered by language
  - `GET /api/PdfReports/{id}/file` — streams the PDF file
- Added unit tests for `GetPublicPdfReportsByLanguageIdHandler` and integration tests for both public endpoints


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDF reports now support language association; admin create accepts a language and public API can list reports by language and download PDF files. Responses include language code when available.

* **Refactor**
  * Admin listing and queries updated to accept and filter by a PDF-specific language filter.

* **Tests**
  * Unit and integration tests added/updated to cover language selection, public listing by language, and file download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->