### PR TITLE
Feature/issue-2185: [Reports] Add editable reporting year for program expenses record

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsHandler.cs
@@ -19,16 +19,19 @@ public class UpdateReportFundsExpendituresSettingsHandler
 {
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly TimeProvider _timeProvider;
     private readonly IValidator<UpdateReportFundsExpendituresSettingsCommand> _validator;
 
     public UpdateReportFundsExpendituresSettingsHandler(
         IMapper mapper,
         IRepositoryWrapper repositoryWrapper,
-        IValidator<UpdateReportFundsExpendituresSettingsCommand> validator)
+        IValidator<UpdateReportFundsExpendituresSettingsCommand> validator,
+        TimeProvider timeProvider)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Result<ReportFundsExpendituresSettingsDto>> Handle(
@@ -39,7 +42,7 @@ public class UpdateReportFundsExpendituresSettingsHandler
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var settingsResult = await ReportFundsExpendituresSettingsHelper.GetOrCreateSettingsAsync(_repositoryWrapper);
+            var settingsResult = await ReportFundsExpendituresSettingsHelper.GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider);
             if (settingsResult.IsFailed)
             {
                 return Result.Fail<ReportFundsExpendituresSettingsDto>(settingsResult.Errors);

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsDto.cs
@@ -4,4 +4,5 @@ public abstract record BaseReportFundsExpendituresSettingsDto
 {
     public string DisclaimerTitle { get; init; } = null!;
     public decimal ExchangeRate { get; init; }
+    public int ProgramExpendituresReportingYear { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsDto.cs
@@ -5,4 +5,5 @@ public record ReportFundsExpendituresSettingsDto
     public long Id { get; init; }
     public string DisclaimerTitle { get; init; } = null!;
     public decimal ExchangeRate { get; init; }
+    public int ProgramExpendituresReportingYear { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
@@ -50,6 +50,7 @@ public static class ReportFundsExpendituresSettingsHelper
             Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
             DisclaimerTitle = string.Empty,
             ExchangeRate = 1m,
+            ProgramExpendituresReportingYear = DateTime.UtcNow.Year,
             CreatedAt = DateTimeOffset.UtcNow
         };
     }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
@@ -50,7 +50,7 @@ public static class ReportFundsExpendituresSettingsHelper
             Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
             DisclaimerTitle = string.Empty,
             ExchangeRate = 1m,
-            ProgramExpendituresReportingYear = DateTime.UtcNow.Year,
+            ProgramExpendituresReportingYear = DateTimeOffset.UtcNow.Year,
             CreatedAt = DateTimeOffset.UtcNow
         };
     }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
@@ -53,7 +53,7 @@ public static class ReportFundsExpendituresSettingsHelper
             Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
             DisclaimerTitle = string.Empty,
             ExchangeRate = 1m,
-            ProgramExpendituresReportingYear = now.Year,
+            ProgramExpendituresReportingYear = Math.Clamp(now.Year, 2010, 2050),
             CreatedAt = now
         };
     }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
@@ -10,7 +10,8 @@ namespace VictoryCenter.BLL.Helpers;
 public static class ReportFundsExpendituresSettingsHelper
 {
     public static async Task<Result<ReportFundsExpendituresSettingsEntity>> GetOrCreateSettingsAsync(
-        IRepositoryWrapper repositoryWrapper)
+        IRepositoryWrapper repositoryWrapper,
+        TimeProvider timeProvider)
     {
         var settings = await repositoryWrapper.ReportFundsExpendituresSettingsRepository
             .GetFirstOrDefaultAsync(new QueryOptions<ReportFundsExpendituresSettingsEntity>
@@ -23,7 +24,7 @@ public static class ReportFundsExpendituresSettingsHelper
             return Result.Ok(settings);
         }
 
-        settings = CreateDefaultSettings();
+        settings = CreateDefaultSettings(timeProvider);
         await repositoryWrapper.ReportFundsExpendituresSettingsRepository.CreateAsync(settings);
 
         try
@@ -43,15 +44,17 @@ public static class ReportFundsExpendituresSettingsHelper
         return Result.Ok(settings);
     }
 
-    private static ReportFundsExpendituresSettingsEntity CreateDefaultSettings()
+    private static ReportFundsExpendituresSettingsEntity CreateDefaultSettings(TimeProvider timeProvider)
     {
+        var now = timeProvider.GetUtcNow();
+
         return new ReportFundsExpendituresSettingsEntity
         {
             Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
             DisclaimerTitle = string.Empty,
             ExchangeRate = 1m,
-            ProgramExpendituresReportingYear = DateTimeOffset.UtcNow.Year,
-            CreatedAt = DateTimeOffset.UtcNow
+            ProgramExpendituresReportingYear = now.Year,
+            CreatedAt = now
         };
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportFundsExpendituresSettings/Get/GetReportFundsExpendituresSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/ReportFundsExpendituresSettings/Get/GetReportFundsExpendituresSettingsHandler.cs
@@ -12,20 +12,23 @@ public class GetReportFundsExpendituresSettingsHandler
 {
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly TimeProvider _timeProvider;
 
     public GetReportFundsExpendituresSettingsHandler(
         IMapper mapper,
-        IRepositoryWrapper repositoryWrapper)
+        IRepositoryWrapper repositoryWrapper,
+        TimeProvider timeProvider)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Result<ReportFundsExpendituresSettingsDto>> Handle(
         GetReportFundsExpendituresSettingsQuery request,
         CancellationToken cancellationToken)
     {
-        var settingsResult = await ReportFundsExpendituresSettingsHelper.GetOrCreateSettingsAsync(_repositoryWrapper);
+        var settingsResult = await ReportFundsExpendituresSettingsHelper.GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider);
         if (settingsResult.IsFailed)
         {
             return Result.Fail<ReportFundsExpendituresSettingsDto>(settingsResult.Errors);

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresSettings;
+using VictoryCenter.BLL.Validators.ReportProgramExpendituresRecords;
 
 namespace VictoryCenter.BLL.Validators.ReportFundsExpendituresSettings;
 
@@ -30,5 +31,8 @@ public class BaseReportFundsExpendituresSettingsValidator : AbstractValidator<Ba
             .WithMessage(ErrorMessagesConstants.PropertyMustBeInAValidFormat(
                 nameof(ReportFundsExpendituresSettingsDto.ExchangeRate),
                 ReportFundsExpendituresSettingsConstants.ExchangeRateFormat));
+
+        RuleFor(dto => dto.ProgramExpendituresReportingYear)
+            .MustBeValidReportingYear(nameof(ReportFundsExpendituresSettingsDto.ProgramExpendituresReportingYear));
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresSettings.cs
@@ -8,6 +8,7 @@ public class ReportFundsExpendituresSettings : BaseEntity, ITranslatedEntity<Rep
 {
     public string DisclaimerTitle { get; set; } = "";
     public decimal ExchangeRate { get; set; }
+    public int ProgramExpendituresReportingYear { get; set; }
 
     public ICollection<ReportFundsExpendituresSettingsLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260617082213_AddProgramExpendituresReportingYearToReportFundsExpendituresSettings.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260617082213_AddProgramExpendituresReportingYearToReportFundsExpendituresSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617082213_AddProgramExpendituresReportingYearToReportFundsExpendituresSettings")]
+    partial class AddProgramExpendituresReportingYearToReportFundsExpendituresSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260617082213_AddProgramExpendituresReportingYearToReportFundsExpendituresSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260617082213_AddProgramExpendituresReportingYearToReportFundsExpendituresSettings.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProgramExpendituresReportingYearToReportFundsExpendituresSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ProgramExpendituresReportingYear",
+                table: "ReportFundsExpendituresSettings",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProgramExpendituresReportingYear",
+                table: "ReportFundsExpendituresSettings");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsTests.cs
@@ -25,7 +25,8 @@ public class UpdateReportFundsExpendituresSettingsTests : BaseTestClass
         var updateDto = new UpdateReportFundsExpendituresSettingsDto
         {
             DisclaimerTitle = "Updated disclaimer",
-            ExchangeRate = 41.654321m
+            ExchangeRate = 41.654321m,
+            ProgramExpendituresReportingYear = 2024
         };
         var serializedDto = JsonConvert.SerializeObject(updateDto);
 
@@ -41,6 +42,7 @@ public class UpdateReportFundsExpendituresSettingsTests : BaseTestClass
         Assert.NotNull(responseContent);
         Assert.Equal(updateDto.DisclaimerTitle, responseContent.DisclaimerTitle);
         Assert.Equal(updateDto.ExchangeRate, responseContent.ExchangeRate);
+        Assert.Equal(updateDto.ProgramExpendituresReportingYear, responseContent.ProgramExpendituresReportingYear);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/GetReportFundsExpendituresSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/GetReportFundsExpendituresSettingsTests.cs
@@ -45,7 +45,8 @@ public class GetReportFundsExpendituresSettingsTests
         SetupDependencies(_settingsEntity, saveResult: 1);
         var handler = new GetReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
-            _repositoryWrapperMock.Object);
+            _repositoryWrapperMock.Object,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(new GetReportFundsExpendituresSettingsQuery(), CancellationToken.None);
@@ -63,7 +64,8 @@ public class GetReportFundsExpendituresSettingsTests
         SetupDependencies(null, saveResult: 1);
         var handler = new GetReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
-            _repositoryWrapperMock.Object);
+            _repositoryWrapperMock.Object,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(new GetReportFundsExpendituresSettingsQuery(), CancellationToken.None);
@@ -82,7 +84,8 @@ public class GetReportFundsExpendituresSettingsTests
         SetupDependencies(null, saveResult: 0);
         var handler = new GetReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
-            _repositoryWrapperMock.Object);
+            _repositoryWrapperMock.Object,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(new GetReportFundsExpendituresSettingsQuery(), CancellationToken.None);
@@ -101,7 +104,8 @@ public class GetReportFundsExpendituresSettingsTests
         SetupDependencies(null, saveResult: 1, saveException: new DbUpdateException());
         var handler = new GetReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
-            _repositoryWrapperMock.Object);
+            _repositoryWrapperMock.Object,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(new GetReportFundsExpendituresSettingsQuery(), CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
@@ -26,21 +26,24 @@ public class UpdateReportFundsExpendituresSettingsTests
     private readonly UpdateReportFundsExpendituresSettingsDto _updateDto = new()
     {
         DisclaimerTitle = "Updated disclaimer",
-        ExchangeRate = 40.123456m
+        ExchangeRate = 40.123456m,
+        ProgramExpendituresReportingYear = 2024
     };
 
     private readonly ReportFundsExpendituresSettingsEntity _settingsEntity = new()
     {
         Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
         DisclaimerTitle = "Old disclaimer",
-        ExchangeRate = 38.123456m
+        ExchangeRate = 38.123456m,
+        ProgramExpendituresReportingYear = 2023
     };
 
     private readonly ReportFundsExpendituresSettingsDto _settingsDto = new()
     {
         Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
         DisclaimerTitle = "Updated disclaimer",
-        ExchangeRate = 40.123456m
+        ExchangeRate = 40.123456m,
+        ProgramExpendituresReportingYear = 2024
     };
 
     public UpdateReportFundsExpendituresSettingsTests()
@@ -71,6 +74,7 @@ public class UpdateReportFundsExpendituresSettingsTests
         Assert.True(result.IsSuccess);
         Assert.Equal(_settingsDto.DisclaimerTitle, result.Value.DisclaimerTitle);
         Assert.Equal(_settingsDto.ExchangeRate, result.Value.ExchangeRate);
+        Assert.Equal(_settingsDto.ProgramExpendituresReportingYear, result.Value.ProgramExpendituresReportingYear);
     }
 
     [Theory]
@@ -196,6 +200,7 @@ public class UpdateReportFundsExpendituresSettingsTests
                 {
                     entity.DisclaimerTitle = dto.DisclaimerTitle;
                     entity.ExchangeRate = dto.ExchangeRate;
+                    entity.ProgramExpendituresReportingYear = dto.ProgramExpendituresReportingYear;
                 })
             .Returns((UpdateReportFundsExpendituresSettingsDto _, ReportFundsExpendituresSettingsEntity entity) => entity);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
@@ -63,7 +63,8 @@ public class UpdateReportFundsExpendituresSettingsTests
         var handler = new UpdateReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
-            _validator);
+            _validator,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(
@@ -88,7 +89,8 @@ public class UpdateReportFundsExpendituresSettingsTests
         var handler = new UpdateReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
-            _validator);
+            _validator,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(
@@ -108,7 +110,8 @@ public class UpdateReportFundsExpendituresSettingsTests
         var handler = new UpdateReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
-            _validator);
+            _validator,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(
@@ -132,7 +135,8 @@ public class UpdateReportFundsExpendituresSettingsTests
         var handler = new UpdateReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
-            _validator);
+            _validator,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(
@@ -156,7 +160,8 @@ public class UpdateReportFundsExpendituresSettingsTests
         var handler = new UpdateReportFundsExpendituresSettingsHandler(
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
-            _validator);
+            _validator,
+            TimeProvider.System);
 
         // Act
         var result = await handler.Handle(

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresSettings/BaseReportFundsExpendituresSettingsValidatorTests.cs
@@ -103,6 +103,21 @@ public class BaseReportFundsExpendituresSettingsValidatorTests
                 ReportFundsExpendituresSettingsConstants.ExchangeRateFormat));
     }
 
+    [Theory]
+    [InlineData(2009)]
+    [InlineData(2051)]
+    public void Validate_ShouldHaveError_WhenProgramExpendituresReportingYearIsOutOfRange(int year)
+    {
+        // Arrange
+        var dto = GetValidDto() with { ProgramExpendituresReportingYear = year };
+
+        // Act
+        var result = _validator.TestValidate(dto);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.ProgramExpendituresReportingYear);
+    }
+
     [Fact]
     public void Validate_ShouldNotHaveErrors_WhenDataIsValid()
     {
@@ -119,6 +134,7 @@ public class BaseReportFundsExpendituresSettingsValidatorTests
     private static UpdateReportFundsExpendituresSettingsDto GetValidDto() => new()
     {
         DisclaimerTitle = "Valid disclaimer",
-        ExchangeRate = 40.123456m
+        ExchangeRate = 40.123456m,
+        ProgramExpendituresReportingYear = 2024
     };
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsValidatorTests.cs
@@ -81,6 +81,7 @@ public class UpdateReportFundsExpendituresSettingsValidatorTests
     private static UpdateReportFundsExpendituresSettingsDto GetValidDto() => new()
     {
         DisclaimerTitle = "Valid disclaimer",
-        ExchangeRate = 40.123456m
+        ExchangeRate = 40.123456m,
+        ProgramExpendituresReportingYear = 2024
     };
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -571,7 +571,8 @@ public static class ServicesConfiguration
     {
         await using var asyncServiceScope = app.Services.CreateAsyncScope();
         var repositoryWrapper = asyncServiceScope.ServiceProvider.GetRequiredService<IRepositoryWrapper>();
-        var settingsResult = await ReportFundsExpendituresSettingsHelper.GetOrCreateSettingsAsync(repositoryWrapper);
+        var timeProvider = asyncServiceScope.ServiceProvider.GetRequiredService<TimeProvider>();
+        var settingsResult = await ReportFundsExpendituresSettingsHelper.GetOrCreateSettingsAsync(repositoryWrapper, timeProvider);
 
         if (settingsResult.IsFailed)
         {


### PR DESCRIPTION

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2185

## Summary of issue

The "Program Expenses" row in the Report Funds & Expenditures tab is a single static/aggregate entry: its amounts are derived from the Program Expenditures records, but its reporting year had nowhere to be stored. The row needs to always exist, never be deletable, and expose an editable reporting year - while the amounts continue to recalculate automatically as the Program Expenditures table changes.

## Summary of change

- Added an informational ProgramExpendituresReportingYear field to the existing ReportFundsExpendituresSettings singleton, with an EF migration for the new column.
- Exposed it through the settings Dtos and added year-range validation (2010-2050).
- Defaulted it to the current year in the singleton factory (no seeder needed); amounts stay live-computed and the row stays non-deletable.

## Testing approach

ToDo

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=95%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `Program Expenditures Reporting Year` to Report Funds Expenditures Settings, including API update/get support and validation for allowed reporting years.

* **Bug Fixes**
  * Improved initial settings seeding to consistently set the reporting year based on the current UTC year.

* **Tests**
  * Updated controller and unit tests to include, map, validate, and assert the new reporting year field, and adjusted handler wiring for time-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->