### PR TITLE
Fix/issue-2595 [Programs] Partial search by program name does not work for substrings within the title

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyPrograms/Search/SearchHippotherapyProgramsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyPrograms/Search/SearchHippotherapyProgramsHandler.cs
@@ -44,7 +44,7 @@ public class SearchHippotherapyProgramsHandler : IRequestHandler<SearchHippother
             {
                 TermSelector = hp => hp.Name.ToLower(),
                 TermValue = dto.SearchQuery.ToLower(),
-                SearchLogic = SearchLogic.Prefix,
+                SearchLogic = SearchLogic.Contains,
             };
 
             var searchExpression = _searchService.CreateSearchExpression(searchByNameTerm);

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/SearchServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/SearchServiceTests.cs
@@ -184,4 +184,50 @@ public class SearchServiceTests
         // Assert
         Assert.Empty(actualResult);
     }
+
+    [Theory]
+    [InlineData("Name1")]
+    [InlineData("Suname1")]
+    [InlineData("stName1 TestSu")]
+    [InlineData("TestName1 TestSuname1")]
+    public void SearchOneTermByContains_ShouldReturnNonEmpty_WhenExists(string term)
+    {
+        // Arrange
+        List<TeamMember> expectedResult = [_teamMembers[0]];
+        var searchTerm = new SearchTerm<TeamMember>
+        {
+            SearchLogic = SearchLogic.Contains,
+            TermSelector = tm => tm.FullName,
+            TermValue = term,
+        };
+
+        // Act
+        var expression = _searchService.CreateSearchExpression(searchTerm);
+        var actualResult = _teamMembers.AsQueryable().Where(expression).ToList();
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Theory]
+    [InlineData("Name12")]
+    [InlineData("Suname12")]
+    [InlineData("Random")]
+    public void SearchOneTermByContains_ShouldReturnEmpty_WhenNotExists(string term)
+    {
+        // Arrange
+        var searchTerm = new SearchTerm<TeamMember>
+        {
+            SearchLogic = SearchLogic.Contains,
+            TermSelector = tm => tm.FullName,
+            TermValue = term,
+        };
+
+        // Act
+        var expression = _searchService.CreateSearchExpression(searchTerm);
+        var actualResult = _teamMembers.AsQueryable().Where(expression).ToList();
+
+        // Assert
+        Assert.Empty(actualResult);
+    }
 }


### PR DESCRIPTION
## Ticket
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2595

## Description
This PR fixes a bug in the Programs search functionality where partial matches (substrings) within the program title were not returning results. This was primarily caused by
  an inconsistent API parameter name and a lack of explicit client-side prioritization for substring matches.

 ## How it looks
 - Searching for "лікують" now correctly displays "Коні лікують".
 - Searching for "програ" now correctly displays "Сімейна програма".
 - Results are prioritized: names starting with the search term appear first, followed by substring matches, then alphabetically.

 ## Summary of change
 - **API Alignment**: Updated the search query parameter name from `SearchQuery` to `searchQuery` in `fetchProgramSearchItems` to match backend expectations and other search
  endpoints (like FAQ).
 - **Prioritization Logic**: Implemented client-side sorting in the `ProgramsApi` to ensure optimal result ordering:
      1. Prefix Matches: Titles starting with the search term.
      2. Substring Matches: Titles containing the search term anywhere else.
      3. Alphabetical: Fallback sorting for equal priority matches.
 - **Test Coverage**: Updated programs-api.test.ts to reflect the parameter change and added a new test suite specifically verifying the prioritization logic (Prefix > Substring > Alphabetical).
 - **Backend Search Query Logic**: Changed the search logic from `SearchLogic.Prefix` to `SearchLogic.Contains` in SearchHippotherapyProgramsHandler.cs to query programs whose
title contains the
  search query anywhere (beginning, middle, and end).
 - **Backend Tests**: Added new test cases for `SearchLogic.Contains` in SearchServiceTests.cs to verify that substring search logic executes as expected.

 ## How to recreate changes
 1. Log in as Admin.
 2. Navigate to the Programs ('Програми') section.
 4. Ensure you have programs with names like "Коні лікують" and "Сімейна програма".
 5. Type "лікують" in the search bar.
    - Before: No results found.
    - After: "Коні лікують" appears in the suggestions.
 7. Run unit tests: `npm test src/services/api/admin/programs/programs-api.test.ts` to verify the logic programmatically.

 ## CHECK LIST
 - [x] New tests was added or existing was modified
 - [ ] Changes has severe impact on users
 - [ ] Changes has medium impact on users
 - [x] Changes has light impact on users
- [x]  Test covetage was updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hippotherapy program searches now find matches anywhere in the program name, not just at the beginning.

* **Tests**
  * Added validation tests for substring matching in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->