### PR TITLE
Feature/issues-2807-2808-2810 Refactor History Sections to Non-Destructive Updates, Implement Per-Section History Localization Update Endpoint

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/History/Update/UpdateHistorySectionsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/History/Update/UpdateHistorySectionsHandler.cs
@@ -54,7 +54,7 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
 
             var imagesByIdResult = await ImageValidationHelper.ValidateAndGetSectionImagesAsync(
                 _repositoryWrapper,
-                incomingSections.Cast<CreateHistorySectionDto>().ToList());
+                incomingSections.ToList());
 
             if (imagesByIdResult.IsFailed)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/History/Update/UpdateHistorySectionsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/History/Update/UpdateHistorySectionsHandler.cs
@@ -52,6 +52,38 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
                 return Result.Ok<List<HistorySectionDto>>([]);
             }
 
+            var existingSectionIds = existingSections.Select(s => s.Id).ToHashSet();
+            var unknownIds = incomingSections
+                .Where(s => s.Id > 0 && !existingSectionIds.Contains(s.Id))
+                .Select(s => s.Id)
+                .ToList();
+
+            if (unknownIds.Count > 0)
+            {
+                return Result.Fail<List<HistorySectionDto>>(
+                    ErrorMessagesConstants.NotFound(unknownIds, typeof(HistorySection)));
+            }
+
+            var contentMismatches = incomingSections
+                .SelectMany(s => s.Contents ?? [])
+                .Where(c => c.Id > 0)
+                .Where(c =>
+                {
+                    var oldContent = existingSections
+                        .SelectMany(s => s.Contents)
+                        .FirstOrDefault(oc => oc.Id == c.Id);
+
+                    return oldContent != null && oldContent.ContentType != c.ContentType;
+                })
+                .Select(c => c.Id)
+                .ToList();
+
+            if (contentMismatches.Count > 0)
+            {
+                return Result.Fail<List<HistorySectionDto>>(
+                    $"Content type mismatch for content ID(s): {string.Join(", ", contentMismatches)}");
+            }
+
             var imagesByIdResult = await ImageValidationHelper.ValidateAndGetSectionImagesAsync(
                 _repositoryWrapper,
                 incomingSections.ToList());
@@ -94,6 +126,7 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
         IReadOnlyDictionary<long, Image> imagesById)
     {
         var result = new List<HistorySection>();
+        var changedContentIds = new List<long>();
         var oldSectionsDict = oldSections.ToDictionary(s => s.Id);
 
         var sectionsToRemove = oldSections.Where(os => !newSections.Any(ns => ns.Id == os.Id)).ToList();
@@ -162,21 +195,7 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
 
                         if (textChanged)
                         {
-                            var localizations = (await _repositoryWrapper.HistorySectionContentLocalizationsRepository
-                                .GetAllAsync(new QueryOptions<HistorySectionContentLocalization>
-                                {
-                                    Filter = l => l.EntityId == existingContent.Id
-                                })).ToList();
-
-                            if (localizations.Count > 0)
-                            {
-                                foreach (var loc in localizations)
-                                {
-                                    loc.TranslationStatus = TranslationStatus.Outdated;
-                                }
-
-                                _repositoryWrapper.HistorySectionContentLocalizationsRepository.UpdateRange(localizations);
-                            }
+                            changedContentIds.Add(existingContent.Id);
                         }
                     }
                     else
@@ -203,6 +222,25 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
                 };
                 await _repositoryWrapper.HistorySectionsRepository.CreateAsync(newSection);
                 result.Add(newSection);
+            }
+        }
+
+        if (changedContentIds.Count > 0)
+        {
+            var localizations = (await _repositoryWrapper.HistorySectionContentLocalizationsRepository
+                .GetAllAsync(new QueryOptions<HistorySectionContentLocalization>
+                {
+                    Filter = l => changedContentIds.Contains(l.EntityId)
+                })).ToList();
+
+            if (localizations.Count > 0)
+            {
+                foreach (var loc in localizations)
+                {
+                    loc.TranslationStatus = TranslationStatus.Outdated;
+                }
+
+                _repositoryWrapper.HistorySectionContentLocalizationsRepository.UpdateRange(localizations);
             }
         }
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/History/Update/UpdateHistorySectionsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/History/Update/UpdateHistorySectionsHandler.cs
@@ -8,6 +8,12 @@ using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 
+using VictoryCenter.DAL.Repositories.Options;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using Microsoft.EntityFrameworkCore;
+
 namespace VictoryCenter.BLL.Commands.Admin.History.Update;
 
 public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySectionsCommand, Result<List<HistorySectionDto>>>
@@ -34,7 +40,10 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var existingSections = (await _repositoryWrapper.HistorySectionsRepository.GetAllAsync()).ToList();
+            var existingSections = (await _repositoryWrapper.HistorySectionsRepository.GetAllAsync(new QueryOptions<HistorySection>
+            {
+                Include = q => q.Include(s => s.Contents)
+            })).ToList();
 
             var incomingSections = request.UpdateSections.ToList();
 
@@ -84,21 +93,191 @@ public class UpdateHistorySectionsHandler : IRequestHandler<UpdateHistorySection
         DateTimeOffset createdAt,
         IReadOnlyDictionary<long, Image> imagesById)
     {
-        if (oldSections.Count > 0)
+        var result = new List<HistorySection>();
+        var oldSectionsDict = oldSections.ToDictionary(s => s.Id);
+
+        var sectionsToRemove = oldSections.Where(os => !newSections.Any(ns => ns.Id == os.Id)).ToList();
+        if (sectionsToRemove.Count > 0)
         {
-            _repositoryWrapper.HistorySectionsRepository.DeleteRange(oldSections);
+            _repositoryWrapper.HistorySectionsRepository.DeleteRange(sectionsToRemove);
         }
 
-        var rebuiltSections = HistorySectionsBuilder.Build(
-            newSections.Cast<CreateHistorySectionDto>().ToList(),
-            createdAt,
-            imagesById);
-
-        if (rebuiltSections.Count > 0)
+        foreach (var newSectionDto in newSections)
         {
-            await _repositoryWrapper.HistorySectionsRepository.CreateRangeAsync(rebuiltSections);
+            if (newSectionDto.Id > 0 && oldSectionsDict.TryGetValue(newSectionDto.Id, out var existingSection))
+            {
+                existingSection.Template = newSectionDto.Template;
+                existingSection.Order = newSectionDto.Order;
+
+                var oldContentsDict = existingSection.Contents.ToDictionary(c => c.Id);
+                var newContentsDto = newSectionDto.Contents ?? new List<UpdateHistorySectionContentDto>();
+
+                var contentsToRemove = existingSection.Contents.Where(oc => !newContentsDto.Any(nc => nc.Id == oc.Id)).ToList();
+                if (contentsToRemove.Count > 0)
+                {
+                    _repositoryWrapper.HistorySectionContentsRepository.DeleteRange(contentsToRemove);
+                    foreach (var contentToRemove in contentsToRemove)
+                    {
+                        existingSection.Contents.Remove(contentToRemove);
+                    }
+                }
+
+                foreach (var newContentDto in newContentsDto.OrderBy(x => x.Order))
+                {
+                    if (newContentDto.Id > 0 && oldContentsDict.TryGetValue(newContentDto.Id, out var existingContent))
+                    {
+                        bool textChanged = false;
+
+                        if (existingContent is TitleHistoryContent thc)
+                        {
+                            if (thc.Title != newContentDto.Title?.Trim())
+                            {
+                                textChanged = true;
+                            }
+
+                            thc.Title = newContentDto.Title?.Trim();
+                            thc.Order = newContentDto.Order;
+                        }
+                        else if (existingContent is DescriptionHistoryContent dhc)
+                        {
+                            if (dhc.Description != newContentDto.Description?.Trim())
+                            {
+                                textChanged = true;
+                            }
+
+                            dhc.Description = newContentDto.Description?.Trim();
+                            dhc.Order = newContentDto.Order;
+                        }
+                        else if (existingContent is ImageHistoryContent ihc)
+                        {
+                            ihc.Order = newContentDto.Order;
+                            if (newContentDto.ImageId.HasValue && imagesById.TryGetValue(newContentDto.ImageId.Value, out var img))
+                            {
+                                ihc.ImageId = newContentDto.ImageId.Value;
+                                ihc.Image = img;
+                            }
+                        }
+
+                        _repositoryWrapper.HistorySectionContentsRepository.Update(existingContent);
+
+                        if (textChanged)
+                        {
+                            var localizations = (await _repositoryWrapper.HistorySectionContentLocalizationsRepository
+                                .GetAllAsync(new QueryOptions<HistorySectionContentLocalization>
+                                {
+                                    Filter = l => l.EntityId == existingContent.Id
+                                })).ToList();
+
+                            if (localizations.Count > 0)
+                            {
+                                foreach (var loc in localizations)
+                                {
+                                    loc.TranslationStatus = TranslationStatus.Outdated;
+                                }
+
+                                _repositoryWrapper.HistorySectionContentLocalizationsRepository.UpdateRange(localizations);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var newContent = CreateContent(newContentDto, imagesById);
+                        if (newContent != null)
+                        {
+                            existingSection.Contents.Add(newContent);
+                        }
+                    }
+                }
+
+                _repositoryWrapper.HistorySectionsRepository.Update(existingSection);
+                result.Add(existingSection);
+            }
+            else
+            {
+                var newSection = new HistorySection
+                {
+                    Template = newSectionDto.Template,
+                    Order = newSectionDto.Order,
+                    CreatedAt = createdAt,
+                    Contents = BuildContents(newSectionDto, imagesById)
+                };
+                await _repositoryWrapper.HistorySectionsRepository.CreateAsync(newSection);
+                result.Add(newSection);
+            }
         }
 
-        return rebuiltSections;
+        return result;
+    }
+
+    private List<HistorySectionContent> BuildContents(
+        UpdateHistorySectionDto sectionDto,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        var dtoContents = sectionDto.Contents ?? [];
+        if (dtoContents.Count == 0)
+        {
+            return [];
+        }
+
+        var contents = new List<HistorySectionContent>(dtoContents.Count);
+
+        foreach (var dto in dtoContents.OrderBy(x => x.Order))
+        {
+            var entity = CreateContent(dto, imagesById);
+            if (entity != null)
+            {
+                contents.Add(entity);
+            }
+        }
+
+        return contents;
+    }
+
+    private HistorySectionContent? CreateContent(
+        UpdateHistorySectionContentDto dto,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        if (dto.ContentType == ContentType.Title)
+        {
+            return new TitleHistoryContent
+            {
+                ContentType = ContentType.Title,
+                Order = dto.Order,
+                Title = dto.Title?.Trim()
+            };
+        }
+
+        if (dto.ContentType == ContentType.Description)
+        {
+            return new DescriptionHistoryContent
+            {
+                ContentType = ContentType.Description,
+                Order = dto.Order,
+                Description = dto.Description?.Trim()
+            };
+        }
+
+        if (dto.ContentType == ContentType.Image)
+        {
+            if (dto.ImageId is null or <= 0)
+            {
+                return null;
+            }
+
+            if (!imagesById.TryGetValue(dto.ImageId.Value, out var image))
+            {
+                return null;
+            }
+
+            return new ImageHistoryContent
+            {
+                ContentType = ContentType.Image,
+                Order = dto.Order,
+                ImageId = dto.ImageId.Value,
+                Image = image
+            };
+        }
+
+        return null;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Create/CreateHistoryLocalizationHandler.cs
@@ -35,23 +35,6 @@ public class CreateHistoryLocalizationHandler : IRequestHandler<CreateHistoryLoc
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var allSections = (await _repositoryWrapper.HistorySectionsRepository.GetAllAsync()).ToList();
-
-            var requestSectionIds = request.CreateHistorySectionLocalizationDtos
-                .Select(x => x.EntityId)
-                .ToHashSet();
-
-            var missingSectionIds = allSections
-                .Select(s => s.Id)
-                .Where(id => !requestSectionIds.Contains(id))
-                .ToList();
-
-            if (missingSectionIds.Count > 0)
-            {
-                return Result.Fail<List<HistorySectionLocalizationDto>>(
-                    ErrorMessagesConstants.MissingSectionsLocalization(missingSectionIds));
-            }
-
             var allContentLocalizations = new List<HistorySectionContentLocalization>();
             var sectionById = new Dictionary<long, HistorySection>();
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistoryLocalizationHandler.cs
@@ -96,6 +96,11 @@ public class UpdateHistoryLocalizationHandler : IRequestHandler<UpdateHistoryLoc
 
             if (localizationsToUpdate.Count > 0)
             {
+                foreach (var loc in localizationsToUpdate)
+                {
+                    loc.TranslationStatus = TranslationStatus.Relevant;
+                }
+
                 await _contentLocalizationService.TrackEntityLocalizationAsync(localizationsToUpdate, true);
             }
 
@@ -160,9 +165,10 @@ public class UpdateHistoryLocalizationHandler : IRequestHandler<UpdateHistoryLoc
             return Result.Fail<List<HistorySectionLocalizationDto>>(
                 ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return Result.Fail<List<HistorySectionLocalizationDto>>(ex.Message);
+            return Result.Fail<List<HistorySectionLocalizationDto>>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(HistorySectionContentLocalization)));
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistoryLocalizationHandler.cs
@@ -41,23 +41,6 @@ public class UpdateHistoryLocalizationHandler : IRequestHandler<UpdateHistoryLoc
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var allSections = (await _repositoryWrapper.HistorySectionsRepository.GetAllAsync()).ToList();
-
-            var requestSectionIds = request.UpdateHistorySectionLocalizationDtos
-                .Select(x => x.EntityId)
-                .ToHashSet();
-
-            var missingSectionIds = allSections
-                .Select(s => s.Id)
-                .Where(id => !requestSectionIds.Contains(id))
-                .ToList();
-
-            if (missingSectionIds.Count > 0)
-            {
-                return Result.Fail<List<HistorySectionLocalizationDto>>(
-                    ErrorMessagesConstants.MissingSectionsLocalization(missingSectionIds));
-            }
-
             var allContentLocalizations = new List<HistorySectionContentLocalization>();
             var sectionById = new Dictionary<long, HistorySection>();
 
@@ -107,17 +90,26 @@ public class UpdateHistoryLocalizationHandler : IRequestHandler<UpdateHistoryLoc
                 })).ToList();
 
             var existingContentIds = existingLocalizations.Select(l => l.EntityId).ToHashSet();
-            var notFoundContentIds = allContentIds
-                .Where(id => !existingContentIds.Contains(id))
-                .ToList();
 
-            if (notFoundContentIds.Count > 0)
+            var localizationsToUpdate = allContentLocalizations.Where(l => existingContentIds.Contains(l.EntityId)).ToList();
+            var localizationsToCreate = allContentLocalizations.Where(l => !existingContentIds.Contains(l.EntityId)).ToList();
+
+            if (localizationsToUpdate.Count > 0)
             {
-                return Result.Fail<List<HistorySectionLocalizationDto>>(
-                    ErrorMessagesConstants.NotFound(notFoundContentIds, typeof(HistorySectionContentLocalization)));
+                await _contentLocalizationService.TrackEntityLocalizationAsync(localizationsToUpdate, true);
             }
 
-            await _contentLocalizationService.TrackEntityLocalizationAsync(allContentLocalizations, true);
+            if (localizationsToCreate.Count > 0)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                foreach (var loc in localizationsToCreate)
+                {
+                    loc.CreatedAt = utcNow;
+                    loc.TranslationStatus = TranslationStatus.Relevant;
+                }
+
+                await _contentLocalizationService.TrackEntityLocalizationAsync(localizationsToCreate, false);
+            }
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationCommand.cs
@@ -1,0 +1,12 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Update;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
+
+public record UpdateHistorySectionLocalizationCommand
+    (UpdateHistorySectionLocalizationDto UpdateDto,
+    long LanguageId) : IRequest<Result<HistorySectionLocalizationDto>>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationCommandValidator.cs
@@ -8,6 +8,11 @@ public class UpdateHistorySectionLocalizationCommandValidator : AbstractValidato
 {
     public UpdateHistorySectionLocalizationCommandValidator(VictoryCenter.BLL.Validators.Localization.History.BaseHistorySectionContentLocalizationValidator contentValidator)
     {
+        RuleFor(x => x.LanguageId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(UpdateHistorySectionLocalizationCommand.LanguageId)));
+
         RuleFor(x => x.UpdateDto)
             .NotNull()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationCommandValidator.cs
@@ -1,0 +1,38 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Update;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
+
+public class UpdateHistorySectionLocalizationCommandValidator : AbstractValidator<UpdateHistorySectionLocalizationCommand>
+{
+    public UpdateHistorySectionLocalizationCommandValidator(VictoryCenter.BLL.Validators.Localization.History.BaseHistorySectionContentLocalizationValidator contentValidator)
+    {
+        RuleFor(x => x.UpdateDto)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(UpdateHistorySectionLocalizationCommand.UpdateDto)));
+
+        RuleFor(x => x.UpdateDto.Contents)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(
+                nameof(UpdateHistorySectionLocalizationDto.Contents)))
+            .When(x => x.UpdateDto != null);
+
+        RuleFor(x => x.UpdateDto.Contents)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(
+                nameof(UpdateHistorySectionLocalizationDto.Contents)))
+            .When(x => x.UpdateDto != null && x.UpdateDto.Contents != null);
+
+        RuleFor(x => x.UpdateDto.Contents)
+            .Must(list => list.All(item => item != null))
+            .WithMessage(ErrorMessagesConstants.CollectionCannotContainNullElements(
+                nameof(UpdateHistorySectionLocalizationDto.Contents)))
+            .When(x => x.UpdateDto != null && x.UpdateDto.Contents != null);
+
+        RuleForEach(x => x.UpdateDto.Contents)
+            .SetValidator(contentValidator)
+            .When(x => x.UpdateDto != null && x.UpdateDto.Contents != null && x.UpdateDto.Contents.Any());
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationHandler.cs
@@ -67,8 +67,6 @@ public class UpdateHistorySectionLocalizationHandler : IRequestHandler<UpdateHis
             {
                 contentLocalizations[i].EntityId = sectionDto.Contents[i].EntityId;
                 contentLocalizations[i].LanguageId = request.LanguageId;
-
-                // Important: Update status to Relevant when edited explicitly by admin
                 contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
             }
 
@@ -85,17 +83,26 @@ public class UpdateHistorySectionLocalizationHandler : IRequestHandler<UpdateHis
                 })).ToList();
 
             var existingContentIds = existingLocalizations.Select(l => l.EntityId).ToHashSet();
-            var notFoundContentIds = allContentIds
-                .Where(id => !existingContentIds.Contains(id))
-                .ToList();
 
-            if (notFoundContentIds.Count > 0)
+            var localizationsToUpdate = contentLocalizations.Where(l => existingContentIds.Contains(l.EntityId)).ToList();
+            var localizationsToCreate = contentLocalizations.Where(l => !existingContentIds.Contains(l.EntityId)).ToList();
+
+            if (localizationsToUpdate.Count > 0)
             {
-                return Result.Fail<HistorySectionLocalizationDto>(
-                    ErrorMessagesConstants.NotFound(notFoundContentIds, typeof(HistorySectionContentLocalization)));
+                await _contentLocalizationService.TrackEntityLocalizationAsync(localizationsToUpdate, true);
             }
 
-            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations, true);
+            if (localizationsToCreate.Count > 0)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                foreach (var loc in localizationsToCreate)
+                {
+                    loc.CreatedAt = utcNow;
+                    loc.TranslationStatus = TranslationStatus.Relevant;
+                }
+
+                await _contentLocalizationService.TrackEntityLocalizationAsync(localizationsToCreate, false);
+            }
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationHandler.cs
@@ -1,0 +1,143 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
+
+public class UpdateHistorySectionLocalizationHandler : IRequestHandler<UpdateHistorySectionLocalizationCommand, Result<HistorySectionLocalizationDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<HistorySectionContent, HistorySectionContentLocalization> _contentLocalizationService;
+    private readonly IValidator<UpdateHistorySectionLocalizationCommand> _validator;
+
+    public UpdateHistorySectionLocalizationHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IMapper mapper,
+        ILocalizationService<HistorySectionContent, HistorySectionContentLocalization> contentLocalizationService,
+        IValidator<UpdateHistorySectionLocalizationCommand> validator)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _contentLocalizationService = contentLocalizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<HistorySectionLocalizationDto>> Handle(UpdateHistorySectionLocalizationCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var sectionDto = request.UpdateDto;
+
+            var section = await _repositoryWrapper.HistorySectionsRepository
+                .GetFirstOrDefaultAsync(new QueryOptions<HistorySection>
+                {
+                    Filter = x => x.Id == sectionDto.EntityId,
+                    Include = x => x.Include(s => s.Contents)
+                });
+
+            if (section is null)
+            {
+                return Result.Fail<HistorySectionLocalizationDto>(
+                    ErrorMessagesConstants.NotFound(sectionDto.EntityId, typeof(HistorySection)));
+            }
+
+            HistorySectionContentLocalizationValidationHelper.ValidateSectionContents(
+                section.Id,
+                sectionDto.Contents,
+                section.Contents);
+
+            var contentLocalizations = _mapper.Map<List<HistorySectionContentLocalization>>(sectionDto.Contents);
+
+            for (int i = 0; i < contentLocalizations.Count; i++)
+            {
+                contentLocalizations[i].EntityId = sectionDto.Contents[i].EntityId;
+                contentLocalizations[i].LanguageId = request.LanguageId;
+
+                // Important: Update status to Relevant when edited explicitly by admin
+                contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
+            }
+
+            var allContentIds = section.Contents
+                .Where(c => c.ContentType != ContentType.Image)
+                .Select(c => c.Id)
+                .ToList();
+
+            var existingLocalizations = (await _repositoryWrapper.HistorySectionContentLocalizationsRepository
+                .GetAllAsync(new QueryOptions<HistorySectionContentLocalization>
+                {
+                    Filter = l => l.LanguageId == request.LanguageId &&
+                                  allContentIds.Contains(l.EntityId)
+                })).ToList();
+
+            var existingContentIds = existingLocalizations.Select(l => l.EntityId).ToHashSet();
+            var notFoundContentIds = allContentIds
+                .Where(id => !existingContentIds.Contains(id))
+                .ToList();
+
+            if (notFoundContentIds.Count > 0)
+            {
+                return Result.Fail<HistorySectionLocalizationDto>(
+                    ErrorMessagesConstants.NotFound(notFoundContentIds, typeof(HistorySectionContentLocalization)));
+            }
+
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations, true);
+
+            if (await _repositoryWrapper.SaveChangesAsync() <= 0)
+            {
+                return Result.Fail<HistorySectionLocalizationDto>(
+                    ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
+            }
+
+            var updatedLocalizations = await _repositoryWrapper.HistorySectionContentLocalizationsRepository
+                .GetAllAsync(new QueryOptions<HistorySectionContentLocalization>
+                {
+                    Filter = l => l.LanguageId == request.LanguageId &&
+                                  allContentIds.Contains(l.EntityId),
+                    Include = q => q.Include(l => l.Language)
+                });
+
+            return Result.Ok(new HistorySectionLocalizationDto
+            {
+                EntityId = section.Id,
+                Contents = _mapper.Map<List<HistorySectionContentLocalizationDto>>(updatedLocalizations.ToList())
+            });
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(ex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(HistorySectionContentLocalization)));
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(ex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail<HistorySectionLocalizationDto>(ex.Message);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/History/Update/UpdateHistorySectionLocalizationHandler.cs
@@ -89,6 +89,11 @@ public class UpdateHistorySectionLocalizationHandler : IRequestHandler<UpdateHis
 
             if (localizationsToUpdate.Count > 0)
             {
+                foreach (var loc in localizationsToUpdate)
+                {
+                    loc.TranslationStatus = TranslationStatus.Relevant;
+                }
+
                 await _contentLocalizationService.TrackEntityLocalizationAsync(localizationsToUpdate, true);
             }
 
@@ -142,9 +147,10 @@ public class UpdateHistorySectionLocalizationHandler : IRequestHandler<UpdateHis
             return Result.Fail<HistorySectionLocalizationDto>(
                 ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return Result.Fail<HistorySectionLocalizationDto>(ex.Message);
+            return Result.Fail<HistorySectionLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(HistorySectionContentLocalization)));
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/HistorySectionConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/HistorySectionConstants.cs
@@ -1,4 +1,3 @@
-using VictoryCenter.BLL.DTOs.Admin.HistorySection;
 using VictoryCenter.DAL.Enums;
 
 namespace VictoryCenter.BLL.Constants;
@@ -68,35 +67,31 @@ public static class HistorySectionConstants
     public static TemplateRequirementsConfig GetRequirements(HistorySectionTemplate template)
         => TemplateRequirements[template];
 
-    public static string GetGroupCompositionErrorMessage(CreateHistorySectionDto section)
-        => $"Template {section.Template} has invalid group composition";
+    public static string GetGroupCompositionErrorMessage(HistorySectionTemplate template)
+        => $"Template {template} has invalid group composition";
 
-    public static string GetTitlesCountErrorMessage(CreateHistorySectionDto section)
-        => GetCountErrorMessage(section, ContentType.Title, GetRequirements(section.Template).TitleCount, "title(s)");
+    public static string GetTitlesCountErrorMessage(HistorySectionTemplate template, int actual)
+        => GetCountErrorMessage(template, GetRequirements(template).TitleCount, "title(s)", actual);
 
-    public static string GetDescriptionsCountErrorMessage(CreateHistorySectionDto section)
-        => GetCountErrorMessage(section, ContentType.Description, GetRequirements(section.Template).DescriptionCount, "description(s)");
+    public static string GetDescriptionsCountErrorMessage(HistorySectionTemplate template, int actual)
+        => GetCountErrorMessage(template, GetRequirements(template).DescriptionCount, "description(s)", actual);
 
-    public static string GetImagesCountErrorMessage(CreateHistorySectionDto section)
-        => GetCountErrorMessage(section, ContentType.Image, GetRequirements(section.Template).ImageCount, "image(s)");
+    public static string GetImagesCountErrorMessage(HistorySectionTemplate template, int actual)
+        => GetCountErrorMessage(template, GetRequirements(template).ImageCount, "image(s)", actual);
 
-    public static string GetTitleLengthErrorMessage(CreateHistorySectionDto section)
-        => GetLengthErrorMessage(GetRequirements(section.Template).TitleLength, "title");
+    public static string GetTitleLengthErrorMessage(HistorySectionTemplate template)
+        => GetLengthErrorMessage(GetRequirements(template).TitleLength, "title");
 
-    public static string GetDescriptionLengthErrorMessage(CreateHistorySectionDto section)
-        => GetLengthErrorMessage(GetRequirements(section.Template).DescriptionLength, "description");
-
-    private static int CountByType(CreateHistorySectionDto section, ContentType type)
-        => (section.Contents ?? []).Count(c => c.ContentType == type);
+    public static string GetDescriptionLengthErrorMessage(HistorySectionTemplate template)
+        => GetLengthErrorMessage(GetRequirements(template).DescriptionLength, "description");
 
     private static string GetCountErrorMessage(
-        CreateHistorySectionDto section,
-        ContentType type,
+        HistorySectionTemplate template,
         (int Min, int Max) req,
-        string label)
+        string label,
+        int actual)
     {
-        var actual = CountByType(section, type);
-        return $"Template {section.Template} requires between {req.Min} and {req.Max} {label}, but received {actual}";
+        return $"Template {template} requires between {req.Min} and {req.Max} {label}, but received {actual}";
     }
 
     private static string GetLengthErrorMessage((int Min, int Max) req, string label)

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionContentDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.HistorySection;
+
+public record UpdateHistorySectionContentDto : CreateHistorySectionContentDto
+{
+    public long Id { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionContentDto.cs
@@ -1,6 +1,14 @@
+using VictoryCenter.DAL.Enums;
+
 namespace VictoryCenter.BLL.DTOs.Admin.HistorySection;
 
-public record UpdateHistorySectionContentDto : CreateHistorySectionContentDto
+public record UpdateHistorySectionContentDto
 {
     public long Id { get; init; }
+    public ContentType ContentType { get; init; }
+    public int Order { get; init; }
+
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+    public long? ImageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionDto.cs
@@ -1,8 +1,11 @@
+using VictoryCenter.DAL.Enums;
+
 namespace VictoryCenter.BLL.DTOs.Admin.HistorySection;
 
-public record UpdateHistorySectionDto : CreateHistorySectionDto
+public record UpdateHistorySectionDto
 {
     public long Id { get; init; }
-
-    public new List<UpdateHistorySectionContentDto>? Contents { get; init; } = [];
+    public HistorySectionTemplate Template { get; init; }
+    public int Order { get; init; }
+    public List<UpdateHistorySectionContentDto>? Contents { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HistorySection/UpdateHistorySectionDto.cs
@@ -1,3 +1,8 @@
 namespace VictoryCenter.BLL.DTOs.Admin.HistorySection;
 
-public record UpdateHistorySectionDto : CreateHistorySectionDto;
+public record UpdateHistorySectionDto : CreateHistorySectionDto
+{
+    public long Id { get; init; }
+
+    public new List<UpdateHistorySectionContentDto>? Contents { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ImageValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ImageValidationHelper.cs
@@ -121,6 +121,17 @@ public static class ImageValidationHelper
         return ValidateAndGetImagesByIdsAsync(repositoryWrapper, sectionImageIds);
     }
 
+    public static Task<Result<IReadOnlyDictionary<long, Image>>> ValidateAndGetSectionImagesAsync(
+        IRepositoryWrapper repositoryWrapper, List<UpdateHistorySectionDto>? sections)
+    {
+        var sectionImageIds = (sections ?? [])
+            .SelectMany(s => s.Contents ?? [])
+            .Where(c => c.ContentType == ContentType.Image && c.ImageId.HasValue)
+            .Select(c => c.ImageId!.Value);
+
+        return ValidateAndGetImagesByIdsAsync(repositoryWrapper, sectionImageIds);
+    }
+
     public static async Task<Result> ValidateAndAssignSectionContentImagesAsync(
         IRepositoryWrapper repositoryWrapper,
         IEnumerable<HippotherapyProgramSection> sections)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HistorySections/UpdateHistorySectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HistorySections/UpdateHistorySectionValidator.cs
@@ -54,7 +54,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
     private static void ValidateCounts(
         UpdateHistorySectionDto section,
         ValidationContext<UpdateHistorySectionDto> ctx,
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         HistorySectionConstants.TemplateRequirementsConfig req,
         string prop)
     {
@@ -76,7 +76,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
 
     private static void ValidateUniqueness(
         ValidationContext<UpdateHistorySectionDto> ctx,
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         string prop)
     {
         if (!HasUniqueOrders(contents))
@@ -92,7 +92,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
 
     private static void ValidateBasicValues(
         ValidationContext<UpdateHistorySectionDto> ctx,
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         string prop)
     {
         if (contents.Any(c => !Enum.IsDefined(c.ContentType)))
@@ -109,7 +109,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
     private static void ValidateTitles(
         UpdateHistorySectionDto section,
         ValidationContext<UpdateHistorySectionDto> ctx,
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         HistorySectionConstants.TemplateRequirementsConfig req,
         string prop)
     {
@@ -129,7 +129,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
     private static void ValidateDescriptions(
         UpdateHistorySectionDto section,
         ValidationContext<UpdateHistorySectionDto> ctx,
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         HistorySectionConstants.TemplateRequirementsConfig req,
         string prop)
     {
@@ -148,7 +148,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
 
     private static void ValidateImages(
         ValidationContext<UpdateHistorySectionDto> ctx,
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         string prop)
     {
         var images = contents.Where(c => c.ContentType == ContentType.Image).ToList();
@@ -160,14 +160,14 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
     }
 
     private static int CountByType(
-        List<CreateHistorySectionContentDto> contents,
+        IReadOnlyCollection<UpdateHistorySectionContentDto> contents,
         ContentType type)
         => contents.Count(c => c.ContentType == type);
 
-    private static bool HasUniqueOrders(List<CreateHistorySectionContentDto> contents)
+    private static bool HasUniqueOrders(IReadOnlyCollection<UpdateHistorySectionContentDto> contents)
         => contents.Select(c => c.Order).Distinct().Count() == contents.Count;
 
-    private static bool HasUniqueImageIds(List<CreateHistorySectionContentDto> contents)
+    private static bool HasUniqueImageIds(IReadOnlyCollection<UpdateHistorySectionContentDto> contents)
     {
         var ids = contents
             .Where(c => c.ContentType == ContentType.Image && c.ImageId.HasValue)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/HistorySections/UpdateHistorySectionValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/HistorySections/UpdateHistorySectionValidator.cs
@@ -60,17 +60,17 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
     {
         if (!InRange(CountByType(contents, ContentType.Title), req.TitleCount))
         {
-            ctx.AddFailure(prop, HistorySectionConstants.GetTitlesCountErrorMessage(section));
+            ctx.AddFailure(prop, HistorySectionConstants.GetTitlesCountErrorMessage(section.Template, CountByType(contents, ContentType.Title)));
         }
 
         if (!InRange(CountByType(contents, ContentType.Description), req.DescriptionCount))
         {
-            ctx.AddFailure(prop, HistorySectionConstants.GetDescriptionsCountErrorMessage(section));
+            ctx.AddFailure(prop, HistorySectionConstants.GetDescriptionsCountErrorMessage(section.Template, CountByType(contents, ContentType.Description)));
         }
 
         if (!InRange(CountByType(contents, ContentType.Image), req.ImageCount))
         {
-            ctx.AddFailure(prop, HistorySectionConstants.GetImagesCountErrorMessage(section));
+            ctx.AddFailure(prop, HistorySectionConstants.GetImagesCountErrorMessage(section.Template, CountByType(contents, ContentType.Image)));
         }
     }
 
@@ -122,7 +122,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
 
         if (titles.Any(c => !HasValidLength(c.Title, req.TitleLength)))
         {
-            ctx.AddFailure(prop, HistorySectionConstants.GetTitleLengthErrorMessage(section));
+            ctx.AddFailure(prop, HistorySectionConstants.GetTitleLengthErrorMessage(section.Template));
         }
     }
 
@@ -142,7 +142,7 @@ public class UpdateHistorySectionValidator : AbstractValidator<UpdateHistorySect
 
         if (descriptions.Any(c => !HasValidLength(c.Description, req.DescriptionLength)))
         {
-            ctx.AddFailure(prop, HistorySectionConstants.GetDescriptionLengthErrorMessage(section));
+            ctx.AddFailure(prop, HistorySectionConstants.GetDescriptionLengthErrorMessage(section.Template));
         }
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/UpdateHistorySectionLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/History/UpdateHistorySectionLocalizationValidator.cs
@@ -9,6 +9,11 @@ public class UpdateHistorySectionLocalizationValidator : AbstractValidator<Updat
 {
     public UpdateHistorySectionLocalizationValidator(BaseHistorySectionContentLocalizationValidator contentValidator)
     {
+        RuleFor(x => x.LanguageId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(
+                nameof(UpdateHistoryLocalizationCommand.LanguageId)));
+
         RuleFor(x => x.UpdateHistorySectionLocalizationDtos)
             .NotNull()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/History/GetAll/GetAllHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/History/GetAll/GetAllHistorySectionsTests.cs
@@ -79,8 +79,8 @@ public class GetAllHistorySectionsTests : BaseTestClass
             Order = order,
             Contents =
             [
-                new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
-                new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
             ]
         };
     }
@@ -93,9 +93,9 @@ public class GetAllHistorySectionsTests : BaseTestClass
             Order = order,
             Contents =
             [
-                new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
-                new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
-                new CreateHistorySectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = imageId },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = imageId },
             ]
         };
     }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/History/Update/UpdateHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/History/Update/UpdateHistorySectionsTests.cs
@@ -129,6 +129,67 @@ public class UpdateHistorySectionsTests : BaseTestClass
         Assert.Equal(0, sectionsCount);
     }
 
+    [Fact]
+    public async Task Update_WithUnknownSectionId_ShouldReturnNotFound()
+    {
+        var payload = new List<UpdateHistorySectionDto>
+        {
+            new()
+            {
+                Id = 999,
+                Template = HistorySectionTemplate.TextOnly,
+                Order = 0,
+                Contents =
+                [
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Title" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Description text" }
+                ]
+            }
+        };
+
+        var response = await PutRaw(payload);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_WithMismatchedContentType_ShouldReturnBadRequest()
+    {
+        var initialPayload = new List<UpdateHistorySectionDto>
+        {
+            CreateTextOnlySection(order: 0, title: "Initial title", description: "Initial description text"),
+        };
+
+        var initialResponse = await PutRaw(initialPayload);
+        Assert.Equal(HttpStatusCode.OK, initialResponse.StatusCode);
+
+        var sectionInDb = await Fixture.DbContext.Set<HistorySection>()
+            .Include(s => s.Contents)
+            .SingleAsync();
+
+        var titleContent = sectionInDb.Contents.Single(c => c.ContentType == ContentType.Title);
+        var descriptionContent = sectionInDb.Contents.Single(c => c.ContentType == ContentType.Description);
+
+        var invalidPayload = new List<UpdateHistorySectionDto>
+        {
+            new()
+            {
+                Id = sectionInDb.Id,
+                Template = HistorySectionTemplate.TextOnly,
+                Order = 0,
+                Contents =
+                [
+                    new UpdateHistorySectionContentDto { Id = titleContent.Id, ContentType = ContentType.Description, Order = 0, Description = "New description using title ID" },
+                    new UpdateHistorySectionContentDto { Id = descriptionContent.Id, ContentType = ContentType.Title, Order = 1, Title = "New title using description ID" },
+                ]
+            }
+        };
+
+        var response = await PutRaw(invalidPayload);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
     private async Task<HttpResponseMessage> PutRaw(List<UpdateHistorySectionDto> payload)
     {
         var serialized = JsonSerializer.Serialize(payload);

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/History/Update/UpdateHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/History/Update/UpdateHistorySectionsTests.cs
@@ -56,8 +56,8 @@ public class UpdateHistorySectionsTests : BaseTestClass
                 Order = -1,
                 Contents =
                 [
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Title" },
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Description text" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Title" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Description text" },
                 ]
             },
         };
@@ -145,8 +145,8 @@ public class UpdateHistorySectionsTests : BaseTestClass
             Order = order,
             Contents =
             [
-                new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
-                new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
             ]
         };
     }
@@ -159,9 +159,9 @@ public class UpdateHistorySectionsTests : BaseTestClass
             Order = order,
             Contents =
             [
-                new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
-                new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
-                new CreateHistorySectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = imageId },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = title },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = description },
+                new UpdateHistorySectionContentDto { ContentType = ContentType.Image, Order = 2, ImageId = imageId },
             ]
         };
     }

--- a/VictoryCenter/VictoryCenter.UnitTests/ControllersTests/HistoryLocalizationsControllerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ControllersTests/HistoryLocalizationsControllerTests.cs
@@ -1,0 +1,92 @@
+using FluentResults;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Update;
+using VictoryCenter.WebAPI.Controllers.Admin.Localization;
+
+namespace VictoryCenter.UnitTests.ControllersTests;
+
+public class HistoryLocalizationsControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ProblemDetailsFactory> _problemDetailsFactoryMock;
+    private readonly HistoryLocalizationsController _sut;
+
+    public HistoryLocalizationsControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _problemDetailsFactoryMock = new Mock<ProblemDetailsFactory>();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton(_mediatorMock.Object);
+        serviceCollection.AddSingleton(_problemDetailsFactoryMock.Object);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        _sut = new HistoryLocalizationsController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { RequestServices = serviceProvider }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task CreateHistoryLocalization_ReturnsOk()
+    {
+        _mediatorMock.Setup(m => m.Send(It.IsAny<CreateHistoryLocalizationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new List<HistorySectionLocalizationDto>()));
+
+        var result = await _sut.CreateHistoryLocalization([]);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateHistoryLocalization_ReturnsOk()
+    {
+        _mediatorMock.Setup(m => m.Send(It.IsAny<UpdateHistoryLocalizationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new List<HistorySectionLocalizationDto>()));
+
+        var result = await _sut.UpdateHistoryLocalization([], 1);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateHistorySectionLocalization_EntityIdMismatch_ReturnsBadRequest()
+    {
+        _problemDetailsFactoryMock.Setup(p => p.CreateProblemDetails(
+            It.IsAny<HttpContext>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new ProblemDetails { Status = 400, Detail = "Mismatch" });
+
+        var dto = new UpdateHistorySectionLocalizationDto { EntityId = 1 };
+
+        var result = await _sut.UpdateHistorySectionLocalization(dto, EntityId: 2, LanguageId: 1);
+
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
+        Assert.Equal(400, problemDetails.Status);
+    }
+
+    [Fact]
+    public async Task UpdateHistorySectionLocalization_ValidIds_ReturnsOk()
+    {
+        _mediatorMock.Setup(m => m.Send(It.IsAny<UpdateHistorySectionLocalizationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new HistorySectionLocalizationDto()));
+
+        var dto = new UpdateHistorySectionLocalizationDto { EntityId = 1 };
+
+        var result = await _sut.UpdateHistorySectionLocalization(dto, EntityId: 1, LanguageId: 1);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/UpdateHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/UpdateHistorySectionsTests.cs
@@ -48,7 +48,7 @@ public class UpdateHistorySectionsTests
         await sut.Handle(new UpdateHistorySectionsCommand([dto]), CancellationToken.None);
 
         _historySectionsRepository.Verify(r => r.DeleteRange(It.IsAny<IEnumerable<HistorySection>>()), Times.Once);
-        _historySectionsRepository.Verify(r => r.CreateRangeAsync(It.IsAny<IEnumerable<HistorySection>>()), Times.Once);
+        _historySectionsRepository.Verify(r => r.CreateAsync(It.IsAny<HistorySection>()), Times.Once);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class UpdateHistorySectionsTests
         await sut.Handle(new UpdateHistorySectionsCommand([replacement]), CancellationToken.None);
 
         _historySectionsRepository.Verify(r => r.DeleteRange(It.IsAny<IEnumerable<HistorySection>>()), Times.Once);
-        _historySectionsRepository.Verify(r => r.CreateRangeAsync(It.IsAny<IEnumerable<HistorySection>>()), Times.Once);
+        _historySectionsRepository.Verify(r => r.CreateAsync(It.IsAny<HistorySection>()), Times.Once);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class UpdateHistorySectionsTests
 
         Assert.True(result.IsSuccess);
         _historySectionsRepository.Verify(r => r.DeleteRange(It.IsAny<IEnumerable<HistorySection>>()), Times.Once);
-        _historySectionsRepository.Verify(r => r.CreateRangeAsync(It.IsAny<IEnumerable<HistorySection>>()), Times.Once);
+        _historySectionsRepository.Verify(r => r.CreateAsync(It.IsAny<HistorySection>()), Times.Once);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class UpdateHistorySectionsTests
         _repositoryWrapper.Verify(r => r.BeginTransaction(), Times.Never);
         _repositoryWrapper.Verify(r => r.SaveChangesAsync(), Times.Never);
         _historySectionsRepository.Verify(r => r.DeleteRange(It.IsAny<IEnumerable<HistorySection>>()), Times.Never);
-        _historySectionsRepository.Verify(r => r.CreateRangeAsync(It.IsAny<IEnumerable<HistorySection>>()), Times.Never);
+        _historySectionsRepository.Verify(r => r.CreateAsync(It.IsAny<HistorySection>()), Times.Never);
         _imageRepository.Verify(r => r.GetAllAsync(It.IsAny<QueryOptions<Image>>()), Times.Never);
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/UpdateHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/UpdateHistorySectionsTests.cs
@@ -13,6 +13,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.HistorySections;
 using VictoryCenter.DAL.Repositories.Interfaces.Media;
 using VictoryCenter.DAL.Repositories.Options;
 using VictoryCenter.BLL.Validators.HistorySections;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.HistorySections;
 
@@ -21,6 +22,8 @@ public class UpdateHistorySectionsTests
     private readonly Mock<IMapper> _mapper = new();
     private readonly Mock<IRepositoryWrapper> _repositoryWrapper = new();
     private readonly Mock<IHistorySectionsRepository> _historySectionsRepository = new();
+    private readonly Mock<IHistorySectionContentsRepository> _historySectionContentsRepository = new();
+    private readonly Mock<IHistorySectionContentLocalizationsRepository> _historySectionContentLocalizationsRepository = new();
     private readonly Mock<IImageRepository> _imageRepository = new();
     private readonly Mock<IValidator<UpdateHistorySectionsCommand>> _validator = new();
 
@@ -182,12 +185,182 @@ public class UpdateHistorySectionsTests
         Assert.Contains(result.Errors.Select(e => e.Message), m => m.Contains(nameof(UpdateHistorySectionsCommand.UpdateSections)));
     }
 
+    [Fact]
+    public async Task Handle_IncomingSectionIdNotExists_ReturnsError()
+    {
+        var existing = ExistingSection(
+            id: 1,
+            order: 0,
+            template: HistorySectionTemplate.TextOnly,
+            TitleContent(order: 0, title: "Title"));
+
+        var dto = new UpdateHistorySectionDto
+        {
+            Id = 999,
+            Order = 0,
+            Template = HistorySectionTemplate.TextOnly,
+            Contents = [TitleDto(order: 0, title: "Title")]
+        };
+
+        var sut = CreateSut(existingSections: [existing], saveChanges: 1);
+
+        var result = await sut.Handle(new UpdateHistorySectionsCommand([dto]), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors.Select(e => e.Message), m => m.Contains("not found", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Handle_ContentTypeMismatch_ReturnsError()
+    {
+        var existing = ExistingSection(
+            id: 1,
+            order: 0,
+            template: HistorySectionTemplate.TextOnly,
+            TitleContent(order: 0, title: "Title"));
+        existing.Contents.First().Id = 1;
+
+        var dto = new UpdateHistorySectionDto
+        {
+            Id = 1,
+            Order = 0,
+            Template = HistorySectionTemplate.TextOnly,
+            Contents = new List<UpdateHistorySectionContentDto>
+            {
+                new()
+                {
+                    Id = 1,
+                    ContentType = ContentType.Description,
+                    Order = 0,
+                    Description = "Description"
+                }
+            }
+        };
+
+        var sut = CreateSut(existingSections: [existing], saveChanges: 1);
+
+        var result = await sut.Handle(new UpdateHistorySectionsCommand([dto]), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors.Select(e => e.Message), m => m.Contains("mismatch", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Handle_ValidUpdate_UpdatesExistingFieldsAndReturnsSuccess()
+    {
+        var existing = ExistingSection(
+            id: 1,
+            order: 0,
+            template: HistorySectionTemplate.TextOnly,
+            TitleContent(order: 0, title: "Old Title"));
+        existing.Contents.First().Id = 1;
+
+        var dto = new UpdateHistorySectionDto
+        {
+            Id = 1,
+            Order = 0,
+            Template = HistorySectionTemplate.TextOnly,
+            Contents = new List<UpdateHistorySectionContentDto>
+            {
+                new()
+                {
+                    Id = 1,
+                    ContentType = ContentType.Title,
+                    Order = 0,
+                    Title = "New Title"
+                }
+            }
+        };
+
+        var sut = CreateSut(existingSections: [existing], saveChanges: 1);
+
+        var result = await sut.Handle(new UpdateHistorySectionsCommand([dto]), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        _historySectionsRepository.Verify(r => r.Update(It.IsAny<HistorySection>()), Times.Once);
+        _repositoryWrapper.Verify(r => r.SaveChangesAsync(), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task Handle_CreateNewSectionWithImage_ReturnsSuccess()
+    {
+        var existing = ExistingSection(
+            id: 1,
+            order: 0,
+            template: HistorySectionTemplate.TextOnly,
+            TitleContent(order: 0, title: "Title"));
+
+        var imageId = 100L;
+
+        var dto = new UpdateHistorySectionDto
+        {
+            Id = 0,
+            Order = 1,
+            Template = HistorySectionTemplate.TextOnly,
+            Contents = new List<UpdateHistorySectionContentDto>
+            {
+                new()
+                {
+                    Id = 0,
+                    ContentType = ContentType.Image,
+                    Order = 0,
+                    ImageId = imageId
+                }
+            }
+        };
+
+        var sut = CreateSut(existingSections: [existing], images: [new Image { Id = imageId }], saveChanges: 1);
+
+        var result = await sut.Handle(new UpdateHistorySectionsCommand([dto]), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.IsFailed ? string.Join(", ", result.Errors.Select(e => e.Message)) : "");
+        _historySectionsRepository.Verify(r => r.CreateAsync(It.IsAny<HistorySection>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UpdateImageContent_ReturnsSuccess()
+    {
+        var existing = ExistingSection(
+            id: 1,
+            order: 0,
+            template: HistorySectionTemplate.TextOnly);
+        var oldImageId = 100L;
+        var newImageId = 101L;
+        existing.Contents.Add(new ImageHistoryContent { Id = 1, ContentType = ContentType.Image, ImageId = oldImageId });
+
+        var dto = new UpdateHistorySectionDto
+        {
+            Id = 1,
+            Order = 0,
+            Template = HistorySectionTemplate.TextOnly,
+            Contents = new List<UpdateHistorySectionContentDto>
+            {
+                new()
+                {
+                    Id = 1,
+                    ContentType = ContentType.Image,
+                    Order = 0,
+                    ImageId = newImageId
+                }
+            }
+        };
+
+        var sut = CreateSut(existingSections: [existing], images: [new Image { Id = newImageId }], saveChanges: 1);
+
+        var result = await sut.Handle(new UpdateHistorySectionsCommand([dto]), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.IsFailed ? string.Join(", ", result.Errors.Select(e => e.Message)) : "");
+        _historySectionContentsRepository.Verify(r => r.Update(It.IsAny<ImageHistoryContent>()), Times.Once);
+    }
+
     private UpdateHistorySectionsHandler CreateSut(
         IEnumerable<HistorySection>? existingSections = null,
         IEnumerable<Image>? images = null,
         int saveChanges = 1)
     {
         _repositoryWrapper.Setup(r => r.HistorySectionsRepository).Returns(_historySectionsRepository.Object);
+        _repositoryWrapper.Setup(r => r.HistorySectionContentsRepository).Returns(_historySectionContentsRepository.Object);
+        _repositoryWrapper.Setup(r => r.HistorySectionContentLocalizationsRepository).Returns(_historySectionContentLocalizationsRepository.Object);
         _repositoryWrapper.Setup(r => r.ImageRepository).Returns(_imageRepository.Object);
         _repositoryWrapper.Setup(r => r.SaveChangesAsync()).ReturnsAsync(saveChanges);
         _repositoryWrapper.Setup(r => r.BeginTransaction())

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/UpdateHistorySectionsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HistorySections/UpdateHistorySectionsTests.cs
@@ -215,7 +215,7 @@ public class UpdateHistorySectionsTests
     private static UpdateHistorySectionDto SectionDto(
         int order,
         HistorySectionTemplate template,
-        params CreateHistorySectionContentDto[] contents)
+        params UpdateHistorySectionContentDto[] contents)
     {
         return new UpdateHistorySectionDto
         {
@@ -225,7 +225,7 @@ public class UpdateHistorySectionsTests
         };
     }
 
-    private static CreateHistorySectionContentDto TitleDto(int order, string title)
+    private static UpdateHistorySectionContentDto TitleDto(int order, string title)
         => new()
         {
             ContentType = ContentType.Title,
@@ -233,7 +233,7 @@ public class UpdateHistorySectionsTests
             Title = title
         };
 
-    private static CreateHistorySectionContentDto DescriptionDto(int order, string description)
+    private static UpdateHistorySectionContentDto DescriptionDto(int order, string description)
         => new()
         {
             ContentType = ContentType.Description,
@@ -241,7 +241,7 @@ public class UpdateHistorySectionsTests
             Description = description
         };
 
-    private static CreateHistorySectionContentDto ImageDto(int order, long imageId)
+    private static UpdateHistorySectionContentDto ImageDto(int order, long imageId)
         => new()
         {
             ContentType = ContentType.Image,

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistoryLocalizatonHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistoryLocalizatonHandlerTests.cs
@@ -96,20 +96,6 @@ public class UpdateHistoryLocalizatonHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ShouldReturnFail_WhenMissingSections()
-    {
-        _repositoryWrapperMock
-            .Setup(r => r.HistorySectionsRepository.GetAllAsync(It.IsAny<QueryOptions<HistorySection>>()))
-            .ReturnsAsync(new List<HistorySection> { _section, new() { Id = 999 } });
-
-        var command = new UpdateHistoryLocalizationCommand(new List<UpdateHistorySectionLocalizationDto> { _testSectionDto }, 2);
-
-        var result = await _handler.Handle(command, CancellationToken.None);
-
-        Assert.True(result.IsFailed);
-    }
-
-    [Fact]
     public async Task Handle_ShouldReturnFail_WhenSectionNotFoundInDatabase()
     {
         _repositoryWrapperMock
@@ -160,7 +146,7 @@ public class UpdateHistoryLocalizatonHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ShouldReturnFail_WhenLocalizationDoesNotExistInDatabase()
+    public async Task Handle_ShouldCreateLocalizations_WhenLocalizationDoesNotExistInDatabase()
     {
         _repositoryWrapperMock
             .Setup(r => r.HistorySectionsRepository.GetAllAsync(It.IsAny<QueryOptions<HistorySection>>()))
@@ -182,11 +168,18 @@ public class UpdateHistoryLocalizatonHandlerTests
             .Setup(r => r.HistorySectionContentLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
             .ReturnsAsync(new List<HistorySectionContentLocalization>());
 
+        _localizationServiceMock
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), false))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
         var command = new UpdateHistoryLocalizationCommand(new List<UpdateHistorySectionLocalizationDto> { _testSectionDto }, 2);
 
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        Assert.True(result.IsFailed);
+        Assert.True(result.IsSuccess);
+        _localizationServiceMock.Verify(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<HistorySectionContentLocalization>>(), false), Times.Once);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistorySectionLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistorySectionLocalizationHandlerTests.cs
@@ -81,7 +81,7 @@ public class UpdateHistorySectionLocalizationHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ExistingLocalizationsNotFound_ReturnsFailResult()
+    public async Task Handle_ExistingLocalizationsNotFound_CreatesLocalizationsAndReturnsOk()
     {
         var dto = new UpdateHistorySectionLocalizationDto
         {
@@ -101,16 +101,22 @@ public class UpdateHistorySectionLocalizationHandlerTests
         _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
             .ReturnsAsync(section);
 
+        var contentLocalization = new HistorySectionContentLocalization { EntityId = 10 };
         _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<UpdateHistorySectionContentLocalizationDto>>()))
-            .Returns([new HistorySectionContentLocalization()]);
+            .Returns([contentLocalization]);
 
         _localizationsRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
             .ReturnsAsync([]);
 
+        _localizationServiceMock.Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), false))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
         var result = await _sut.Handle(command, CancellationToken.None);
 
-        Assert.True(result.IsFailed);
-        Assert.Contains(result.Errors, e => e.Message.Contains(nameof(HistorySectionContentLocalization)));
+        Assert.True(result.IsSuccess);
+        _localizationServiceMock.Verify(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), false), Times.Once);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistorySectionLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistorySectionLocalizationHandlerTests.cs
@@ -1,0 +1,206 @@
+using AutoMapper;
+
+using FluentValidation;
+using FluentValidation.Results;
+
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Update;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HistoryContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.HistorySections;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.History;
+
+public class UpdateHistorySectionLocalizationHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock = new();
+    private readonly Mock<IHistorySectionsRepository> _historySectionsRepositoryMock = new();
+    private readonly Mock<IHistorySectionContentLocalizationsRepository> _localizationsRepositoryMock = new();
+    private readonly Mock<IMapper> _mapperMock = new();
+    private readonly Mock<ILocalizationService<HistorySectionContent, HistorySectionContentLocalization>> _localizationServiceMock = new();
+    private readonly Mock<IValidator<UpdateHistorySectionLocalizationCommand>> _validatorMock = new();
+
+    private readonly UpdateHistorySectionLocalizationHandler _sut;
+
+    public UpdateHistorySectionLocalizationHandlerTests()
+    {
+        _repositoryWrapperMock.Setup(r => r.HistorySectionsRepository).Returns(_historySectionsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(r => r.HistorySectionContentLocalizationsRepository).Returns(_localizationsRepositoryMock.Object);
+
+        _sut = new UpdateHistorySectionLocalizationHandler(
+            _repositoryWrapperMock.Object,
+            _mapperMock.Object,
+            _localizationServiceMock.Object,
+            _validatorMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidatorThrows_ReturnsFailResult()
+    {
+        var command = new UpdateHistorySectionLocalizationCommand(new UpdateHistorySectionLocalizationDto(), 1);
+
+        var realValidator = new UpdateHistorySectionLocalizationCommandValidator(
+            new VictoryCenter.BLL.Validators.Localization.History.BaseHistorySectionContentLocalizationValidator());
+
+        var sutWithRealValidator = new UpdateHistorySectionLocalizationHandler(
+            _repositoryWrapperMock.Object,
+            _mapperMock.Object,
+            _localizationServiceMock.Object,
+            realValidator);
+
+        var result = await sutWithRealValidator.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors.Select(e => e.Message), m => m.Contains(nameof(UpdateHistorySectionLocalizationCommand.UpdateDto.Contents)));
+    }
+
+    [Fact]
+    public async Task Handle_SectionNotFound_ReturnsFailResult()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto { EntityId = 1, Contents = [] };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync((HistorySection?)null);
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.NotFound(1, typeof(HistorySection)));
+    }
+
+    [Fact]
+    public async Task Handle_ExistingLocalizationsNotFound_ReturnsFailResult()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents = [new UpdateHistorySectionContentLocalizationDto { EntityId = 10, Title = "Test" }]
+        };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+
+        var section = new HistorySection
+        {
+            Id = 1,
+            Contents = [new TitleHistoryContent { Id = 10, ContentType = ContentType.Title }]
+        };
+
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(section);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<UpdateHistorySectionContentLocalizationDto>>()))
+            .Returns([new HistorySectionContentLocalization()]);
+
+        _localizationsRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
+            .ReturnsAsync([]);
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message.Contains(nameof(HistorySectionContentLocalization)));
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesLocalizationsAndReturnsOk()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents = [new UpdateHistorySectionContentLocalizationDto { EntityId = 10, Title = "Test" }]
+        };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+
+        var section = new HistorySection
+        {
+            Id = 1,
+            Contents = [new TitleHistoryContent { Id = 10, ContentType = ContentType.Title }]
+        };
+
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(section);
+
+        var contentLocalization = new HistorySectionContentLocalization { EntityId = 10 };
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<UpdateHistorySectionContentLocalizationDto>>()))
+            .Returns([contentLocalization]);
+
+        var existingLocalization = new HistorySectionContentLocalization { EntityId = 10 };
+        _localizationsRepositoryMock.SetupSequence(r => r.GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
+            .ReturnsAsync([existingLocalization])
+            .ReturnsAsync([existingLocalization]);
+
+        _localizationServiceMock.Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), true))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        var returnedDto = new HistorySectionLocalizationDto { EntityId = 1, Contents = [] };
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalizationDto>>(It.IsAny<List<HistorySectionContentLocalization>>()))
+            .Returns([]);
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value.EntityId);
+
+        Assert.Equal(TranslationStatus.Relevant, contentLocalization.TranslationStatus);
+        Assert.Equal(1, contentLocalization.LanguageId);
+
+        _localizationServiceMock.Verify(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), true), Times.Once);
+        _repositoryWrapperMock.Verify(r => r.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesFails_ReturnsFailResult()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents = [new UpdateHistorySectionContentLocalizationDto { EntityId = 10, Title = "Test" }]
+        };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+
+        var section = new HistorySection
+        {
+            Id = 1,
+            Contents = [new TitleHistoryContent { Id = 10, ContentType = ContentType.Title }]
+        };
+
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(section);
+
+        var contentLocalization = new HistorySectionContentLocalization { EntityId = 10 };
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<UpdateHistorySectionContentLocalizationDto>>()))
+            .Returns([contentLocalization]);
+
+        var existingLocalization = new HistorySectionContentLocalization { EntityId = 10 };
+        _localizationsRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
+            .ReturnsAsync([existingLocalization]);
+
+        _localizationServiceMock.Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), true))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistorySectionLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/History/UpdateHistorySectionLocalizationHandlerTests.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.EntityFrameworkCore;
 
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
@@ -208,5 +209,111 @@ public class UpdateHistorySectionLocalizationHandlerTests
 
         Assert.True(result.IsFailed);
         Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsKeyNotFoundException_ReturnsFailResult()
+    {
+        var command = new UpdateHistorySectionLocalizationCommand(new UpdateHistorySectionLocalizationDto(), 1);
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>())).ThrowsAsync(new KeyNotFoundException("Key not found"));
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message == "Key not found");
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsInvalidOperationException_ReturnsFailResult()
+    {
+        var command = new UpdateHistorySectionLocalizationCommand(new UpdateHistorySectionLocalizationDto(), 1);
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>())).ThrowsAsync(new InvalidOperationException());
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.FailedToUpdateEntity(typeof(HistorySectionContentLocalization)));
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsDbUpdateException_ReturnsFailResult()
+    {
+        var command = new UpdateHistorySectionLocalizationCommand(new UpdateHistorySectionLocalizationDto(), 1);
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>())).ThrowsAsync(new DbUpdateException());
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HistorySectionContentLocalization)));
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsGenericException_ReturnsFailResult()
+    {
+        var command = new UpdateHistorySectionLocalizationCommand(new UpdateHistorySectionLocalizationDto(), 1);
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>())).ThrowsAsync(new Exception("Generic exception"));
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(result.Errors, e => e.Message == ErrorMessagesConstants.FailedToUpdateEntity(typeof(HistorySectionContentLocalization)));
+    }
+
+    [Fact]
+    public async Task Handle_MixedRequest_CreatesAndUpdatesLocalizationsAndReturnsOk()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto
+        {
+            EntityId = 1,
+            Contents = [
+                new UpdateHistorySectionContentLocalizationDto { EntityId = 10, Title = "To Update" },
+                new UpdateHistorySectionContentLocalizationDto { EntityId = 20, Description = "To Create" }
+            ]
+        };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>())).ReturnsAsync(new ValidationResult());
+
+        var section = new HistorySection
+        {
+            Id = 1,
+            Contents = [
+                new TitleHistoryContent { Id = 10, ContentType = ContentType.Title },
+                new DescriptionHistoryContent { Id = 20, ContentType = ContentType.Description }
+            ]
+        };
+
+        _historySectionsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HistorySection>>()))
+            .ReturnsAsync(section);
+
+        var contentLocalization1 = new HistorySectionContentLocalization { EntityId = 10 };
+        var contentLocalization2 = new HistorySectionContentLocalization { EntityId = 20 };
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalization>>(It.IsAny<List<UpdateHistorySectionContentLocalizationDto>>()))
+            .Returns([contentLocalization1, contentLocalization2]);
+
+        var existingLocalization = new HistorySectionContentLocalization { EntityId = 10 };
+        _localizationsRepositoryMock.SetupSequence(r => r.GetAllAsync(It.IsAny<QueryOptions<HistorySectionContentLocalization>>()))
+            .ReturnsAsync([existingLocalization])
+            .ReturnsAsync([existingLocalization, contentLocalization2]);
+
+        _localizationServiceMock.Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), true))
+            .Returns(Task.CompletedTask);
+        _localizationServiceMock.Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), false))
+            .Returns(Task.CompletedTask);
+
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        _mapperMock.Setup(m => m.Map<List<HistorySectionContentLocalizationDto>>(It.IsAny<List<HistorySectionContentLocalization>>()))
+            .Returns([]);
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.IsFailed ? result.Errors.First().Message : "");
+        _localizationServiceMock.Verify(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), true), Times.Once);
+        _localizationServiceMock.Verify(s => s.TrackEntityLocalizationAsync(It.IsAny<List<HistorySectionContentLocalization>>(), false), Times.Once);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HistorySections/UpdateHistorySectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HistorySections/UpdateHistorySectionValidatorTests.cs
@@ -231,7 +231,7 @@ public class UpdateHistorySectionValidatorTests
         };
     }
 
-    private static CreateHistorySectionContentDto Title(int order, string title)
+    private static UpdateHistorySectionContentDto Title(int order, string title)
         => new()
         {
             ContentType = ContentType.Title,
@@ -239,7 +239,7 @@ public class UpdateHistorySectionValidatorTests
             Title = title
         };
 
-    private static CreateHistorySectionContentDto Description(int order, string description)
+    private static UpdateHistorySectionContentDto Description(int order, string description)
         => new()
         {
             ContentType = ContentType.Description,
@@ -247,7 +247,7 @@ public class UpdateHistorySectionValidatorTests
             Description = description
         };
 
-    private static CreateHistorySectionContentDto Image(int order, long imageId)
+    private static UpdateHistorySectionContentDto Image(int order, long imageId)
         => new()
         {
             ContentType = ContentType.Image,

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HistorySections/UpdateHistorySectionValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HistorySections/UpdateHistorySectionValidatorTests.cs
@@ -123,7 +123,7 @@ public class UpdateHistorySectionValidatorTests
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Contents)
-            .WithErrorMessage(HistorySectionConstants.GetTitleLengthErrorMessage(model));
+            .WithErrorMessage(HistorySectionConstants.GetTitleLengthErrorMessage(model.Template));
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class UpdateHistorySectionValidatorTests
         var result = _validator.TestValidate(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Contents)
-            .WithErrorMessage(HistorySectionConstants.GetDescriptionLengthErrorMessage(model));
+            .WithErrorMessage(HistorySectionConstants.GetDescriptionLengthErrorMessage(model.Template));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HistorySections/UpdateHistorySectionsCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/HistorySections/UpdateHistorySectionsCommandValidatorTests.cs
@@ -34,8 +34,8 @@ public class UpdateHistorySectionsCommandValidatorTests
                 Order = -1,
                 Contents =
                 [
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Valid title" },
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Valid description" }
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Valid title" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Valid description" }
                 ]
             }
 
@@ -58,8 +58,8 @@ public class UpdateHistorySectionsCommandValidatorTests
                 Order = 0,
                 Contents =
                 [
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Valid title" },
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Valid description" }
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Valid title" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Valid description" }
                 ]
             },
             new UpdateHistorySectionDto
@@ -68,8 +68,8 @@ public class UpdateHistorySectionsCommandValidatorTests
                 Order = 0,
                 Contents =
                 [
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Another valid title" },
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Another valid description" }
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Another valid title" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Another valid description" }
                 ]
             }
 
@@ -92,8 +92,8 @@ public class UpdateHistorySectionsCommandValidatorTests
                 Order = 0,
                 Contents =
                 [
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Valid title" },
-                    new CreateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Valid description" }
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Title, Order = 0, Title = "Valid title" },
+                    new UpdateHistorySectionContentDto { ContentType = ContentType.Description, Order = 1, Description = "Valid description" }
                 ]
             }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/History/BaseHistorySectionContentLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/History/BaseHistorySectionContentLocalizationValidatorTests.cs
@@ -19,7 +19,7 @@ public class BaseHistorySectionContentLocalizationValidatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void Validate_WhenTitleIsNullOrEmpty_ShouldNotHaveValidationError(string title)
+    public void Validate_WhenTitleIsNullOrEmpty_ShouldNotHaveValidationError(string? title)
     {
         // Arrange
         var model = new CreateHistorySectionContentLocalizationDto { Title = title };
@@ -83,7 +83,7 @@ public class BaseHistorySectionContentLocalizationValidatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void Validate_WhenDescriptionIsNullOrEmpty_ShouldNotHaveValidationError(string description)
+    public void Validate_WhenDescriptionIsNullOrEmpty_ShouldNotHaveValidationError(string? description)
     {
         // Arrange
         var model = new CreateHistorySectionContentLocalizationDto { Description = description };

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/History/UpdateHistorySectionLocalizationCommandValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/History/UpdateHistorySectionLocalizationCommandValidatorTests.cs
@@ -1,0 +1,79 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.Localization.History.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.History.Update;
+using VictoryCenter.BLL.Validators.Localization.History;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.History;
+
+public class UpdateHistorySectionLocalizationCommandValidatorTests
+{
+    private readonly UpdateHistorySectionLocalizationCommandValidator _sut;
+
+    public UpdateHistorySectionLocalizationCommandValidatorTests()
+    {
+        var contentValidator = new BaseHistorySectionContentLocalizationValidator();
+        _sut = new UpdateHistorySectionLocalizationCommandValidator(contentValidator);
+    }
+
+    [Fact]
+    public void Validate_UpdateDtoIsNull_ShouldHaveValidationError()
+    {
+        var command = new UpdateHistorySectionLocalizationCommand(null!, 1);
+
+        var result = _sut.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.UpdateDto)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateHistorySectionLocalizationCommand.UpdateDto)));
+    }
+
+    [Fact]
+    public void Validate_ContentsIsNull_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto { Contents = null! };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        var result = _sut.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.UpdateDto.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateHistorySectionLocalizationDto.Contents)));
+    }
+
+    [Fact]
+    public void Validate_ContentsIsEmpty_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto { Contents = [] };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        var result = _sut.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.UpdateDto.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotBeEmpty(nameof(UpdateHistorySectionLocalizationDto.Contents)));
+    }
+
+    [Fact]
+    public void Validate_ContentsContainsNullElements_ShouldHaveValidationError()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto { Contents = [null!] };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        var result = _sut.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.UpdateDto.Contents)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionCannotContainNullElements(nameof(UpdateHistorySectionLocalizationDto.Contents)));
+    }
+
+    [Fact]
+    public void Validate_ContentsAreValid_ShouldNotHaveAnyValidationErrors()
+    {
+        var dto = new UpdateHistorySectionLocalizationDto
+        {
+            Contents = [new UpdateHistorySectionContentLocalizationDto { EntityId = 1, Title = "Valid string" }]
+        };
+        var command = new UpdateHistorySectionLocalizationCommand(dto, 1);
+
+        var result = _sut.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HistoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HistoryLocalizationsController.cs
@@ -29,4 +29,21 @@ public class HistoryLocalizationsController : AuthorizedApiController
     {
         return HandleResult(await Mediator.Send(new UpdateHistoryLocalizationCommand(updateHistorySectionLocalizationDtos, LanguageId)));
     }
+
+    [HttpPut("{entityId:long}/language/{languageId:long}")]
+    [ProducesResponseType(typeof(HistorySectionLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateHistorySectionLocalization(
+        [FromBody] UpdateHistorySectionLocalizationDto updateDto,
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        if (EntityId != updateDto.EntityId)
+        {
+            return BadRequest(new ProblemDetails { Detail = "EntityId in route does not match EntityId in body." });
+        }
+
+        return HandleResult(await Mediator.Send(new UpdateHistorySectionLocalizationCommand(updateDto, LanguageId)));
+    }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HistoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HistoryLocalizationsController.cs
@@ -41,7 +41,11 @@ public class HistoryLocalizationsController : AuthorizedApiController
     {
         if (EntityId != updateDto.EntityId)
         {
-            return BadRequest(new ProblemDetails { Detail = "EntityId in route does not match EntityId in body." });
+            var problemsFactory = HttpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory>();
+            return BadRequest(problemsFactory.CreateProblemDetails(
+                HttpContext,
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: "EntityId in route does not match EntityId in body."));
         }
 
         return HandleResult(await Mediator.Send(new UpdateHistorySectionLocalizationCommand(updateDto, LanguageId)));


### PR DESCRIPTION
## GitHub

* [ GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2807)
* [ GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2808)
* [ GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2810)

## Summary of issue

Updating Ukrainian source text on the History page wiped out associated English localizations. This occurred because the `PUT /api/History` endpoint destructively recreated `HistorySection` and `HistorySectionContent` entities, resetting the IDs that localizations rely on. Additionally, saving a specific section's translation via the modal caused a `404 Not Found` error on `PUT /api/HistoryLocalizations/...`, as the backend previously only supported updating the entire page's localizations at once.
Saving history translations failed with `400 Bad Request` or `404 Not Found` errors when submitting a mix of new and existing section localizations. This happened because the section-specific `PUT` endpoint required records to already exist, while the bulk `POST` and `PUT` endpoints rigidly demanded that *all* sections be included in the payload, blocking partial updates.

## Summary of change

*   **Non-Destructive Updates**: Refactored `UpdateHistorySectionsHandler` to perform ID-based partial updates, preserving `HistorySection` and `HistorySectionContent` IDs across edits.
*   **Automatic Status Tracking**: Added logic to automatically flag a localization's `TranslationStatus` as `Outdated` if the original Ukrainian content is modified.
*   **New Translation Endpoint**: Implemented `PUT /api/HistoryLocalizations/{entityId}/language/{languageId}` in the `HistoryLocalizationsController` to support per-section saves.
*   **New Handlers & Validation**: 
    * Created `UpdateHistorySectionLocalizationCommand` and its handler to process single-section translation updates.
    * Ensured the handler explicitly sets `TranslationStatus = Relevant` when an admin saves a translation.
    * Added `UpdateHistorySectionLocalizationCommandValidator` to validate the new endpoint's payloads.
**Upsert Strategy**: Refactored `UpdateHistorySectionLocalizationHandler` and `UpdateHistoryLocalizationHandler` to dynamically insert new localizations or update existing ones in a single request.
*   **Partial Payloads**: Removed strict validations in `CreateHistoryLocalizationHandler` and `UpdateHistoryLocalizationHandler` that forced clients to submit every section translation, allowing partial page saves.


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for updating history section content translations through a new API endpoint.

* **Improvements**
  * Enhanced history section updates to apply only necessary changes rather than replacing all sections, improving efficiency and reducing data churn.
  * Improved handling of image content validation to ensure only valid references are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->