### PR TITLE
Feature/issue-2834: [Main] Refactor Main page validation limits for RichText payloads

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/MainPageConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/MainPageConstants.cs
@@ -2,56 +2,70 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class MainPageConstants
 {
-    public static class Title
-    {
-        public static int MinLength => 5;
-        public static int MaxLength => 150;
-    }
+    /// <summary>
+    /// Validation rules for common title content in main page sections.
+    /// </summary>
+    public static readonly (int MinLen, int MaxLen) ValidationTitleRules = new(10, CalculateHighestCharactersLimitForRichInput(50));
 
-    public static class Description
+    /// <summary>
+    /// Validation rules for common description content in main page sections.
+    /// </summary>
+    public static readonly (int MinLen, int MaxLen) ValidationDescriptionRules = new(10, CalculateHighestCharactersLimitForRichInput(300));
+
+    /// <summary>
+    /// Calculates the maximum allowed rich-text payload length for a given raw text limit.
+    /// </summary>
+    /// <param name="rawLimit">The raw character limit for plain user text.</param>
+    /// <returns>
+    /// The upper bound for serialized rich-text content, accounting for formatting tags.
+    /// Formula: <c>(rawLimit * 25) + 7</c>, where:
+    /// <list type="bullet">
+    /// <item><description><c>25</c> = 1 user character + up to 24 formatting characters (for example, <c>&lt;i&gt;&lt;strong&gt;a&lt;/strong&gt;&lt;/i&gt;</c>).</description></item>
+    /// <item><description><c>7</c> = paragraph wrapper <c>&lt;p&gt;&lt;/p&gt;</c>.</description></item>
+    /// </list>
+    /// Example: for <c>rawLimit = 1</c>, payload <c>&lt;p&gt;&lt;i&gt;&lt;strong&gt;a&lt;/strong&gt;&lt;/i&gt;&lt;/p&gt;</c> has length 32, which equals <c>(1 * 25) + 7</c>.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="rawLimit"/> is negative.</exception>
+    public static int CalculateHighestCharactersLimitForRichInput(int rawLimit)
     {
-        public static int MinLength => 10;
-        public static int MaxLength => 1000;
+        ArgumentOutOfRangeException.ThrowIfNegative(rawLimit);
+
+        return checked((rawLimit * 25) + 7);
     }
 
     public static class Localization
     {
-        public static class Title
-        {
-            public static int MinLength => 10;
-            public static int MaxLength => 50;
-        }
+        /// <summary>
+        /// Validation rules for localized title content in main page sections.
+        /// </summary>
+        public static readonly (int MinLen, int MaxLen) ValidationTitleRules = new(10, CalculateHighestCharactersLimitForRichInput(50));
 
-        public static class TitleBlockDescription
-        {
-            public static int MinLength => 10;
-            public static int MaxLength => 300;
-        }
+        /// <summary>
+        /// Validation rules for localized title block description content.
+        /// </summary>
+        public static readonly (int MinLen, int MaxLen) ValidationTitleBlockDescriptionRules = new(10, CalculateHighestCharactersLimitForRichInput(300));
 
-        public static class SectionDescription
-        {
-            public static int MinLength => 10;
-            public static int MaxLength => 1000;
-        }
+        /// <summary>
+        /// Validation rules for localized section description content.
+        /// </summary>
+        public static readonly (int MinLen, int MaxLen) ValidationSectionDescriptionRules = new(10, CalculateHighestCharactersLimitForRichInput(1000));
     }
 
     public static class ImpactStatistic
     {
-        public static int ExactMetricCount => 4;
+        /// <summary>
+        /// Validation rules for impact statistic title content.
+        /// </summary>
+        public static readonly (int MinLen, int MaxLen) ValidationTitleRules = new(5, CalculateHighestCharactersLimitForRichInput(100));
 
-        public static class TitleConstraints
-        {
-            public static int MinLength => 5;
-            public static int MaxLength => 500;
-        }
+        public static int ExactMetricCount => 4;
     }
 
     public static class Metric
     {
-        public static class Name
-        {
-            public static int MinLength => 1;
-            public static int MaxLength => 100;
-        }
+        /// <summary>
+        /// Validation rules for metric name content.
+        /// </summary>
+        public static readonly (int MinLen, int MaxLen) ValidationNameRules = new(2, CalculateHighestCharactersLimitForRichInput(20));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/BaseMainPageLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/BaseMainPageLocalizationDtoValidator.cs
@@ -8,6 +8,6 @@ public class BaseMainPageLocalizationDtoValidator : AbstractValidator<BaseMainPa
 {
     public BaseMainPageLocalizationDtoValidator()
     {
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.TitleBlockDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateImpactStatisticLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateImpactStatisticLocalizationValidator.cs
@@ -16,13 +16,13 @@ public class CreateImpactStatisticLocalizationValidator : AbstractValidator<Crea
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateImpactStatisticLocalizationDto.Title)))
-            .MinimumLength(MainPageConstants.ImpactStatistic.TitleConstraints.MinLength)
+            .MinimumLength(MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
                 nameof(CreateImpactStatisticLocalizationDto.Title),
-                MainPageConstants.ImpactStatistic.TitleConstraints.MinLength))
-            .MaximumLength(MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength)
+                MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(CreateImpactStatisticLocalizationDto.Title),
-                MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength));
+                MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainAboutUsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainAboutUsLocalizationDtoValidator.cs
@@ -12,6 +12,6 @@ public class CreateMainAboutUsLocalizationDtoValidator : AbstractValidator<Creat
             .GreaterThan(0)
             .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateMainAboutUsLocalizationDto.EntityId)));
 
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.SectionDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainDonationsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainDonationsLocalizationDtoValidator.cs
@@ -14,6 +14,6 @@ public class CreateMainDonationsLocalizationDtoValidator : AbstractValidator<Cre
             .GreaterThan(0)
             .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateMainDonationsLocalizationDto.EntityId)));
 
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.SectionDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainPartnersLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/CreateMainPartnersLocalizationDtoValidator.cs
@@ -12,6 +12,6 @@ public class CreateMainPartnersLocalizationDtoValidator : AbstractValidator<Crea
             .GreaterThan(0)
             .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateMainPartnersLocalizationDto.EntityId)));
 
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.SectionDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/MainPageLocalizationValidationRules.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/MainPageLocalizationValidationRules.cs
@@ -37,21 +37,21 @@ internal static class MainPageLocalizationValidationRules
             .Cascade(CascadeMode.Stop)
             .Must(value => !string.IsNullOrWhiteSpace(value))
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageLocalizationDto.Title)))
-            .MinimumLength(MainPageConstants.Localization.Title.MinLength)
+            .MinimumLength(MainPageConstants.Localization.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageLocalizationDto.Title), MainPageConstants.Localization.Title.MinLength))
-            .MaximumLength(MainPageConstants.Localization.Title.MaxLength)
+                nameof(BaseMainPageLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.Localization.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageLocalizationDto.Title), MainPageConstants.Localization.Title.MaxLength))
+                nameof(BaseMainPageLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MaxLen))
             .When(titleCondition);
 
         validator.RuleFor(x => x.Description)
             .Cascade(CascadeMode.Stop)
             .Must(value => !string.IsNullOrWhiteSpace(value))
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageLocalizationDto.Description)))
-            .MinimumLength(MainPageConstants.Localization.SectionDescription.MinLength)
+            .MinimumLength(MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageLocalizationDto.Description), MainPageConstants.Localization.SectionDescription.MinLength))
+                nameof(BaseMainPageLocalizationDto.Description), MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen))
             .MaximumLength(descriptionMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(BaseMainPageLocalizationDto.Description), descriptionMaxLength))

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainAboutUsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainAboutUsLocalizationDtoValidator.cs
@@ -8,6 +8,6 @@ public class UpdateMainAboutUsLocalizationDtoValidator : AbstractValidator<Updat
 {
     public UpdateMainAboutUsLocalizationDtoValidator(BaseMainPageLocalizationDtoValidator baseValidator)
     {
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.SectionDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidator.cs
@@ -11,6 +11,6 @@ public class UpdateMainDonationsLocalizationDtoValidator : AbstractValidator<Upd
         ArgumentNullException.ThrowIfNull(baseValidator);
 
         Include(baseValidator);
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.SectionDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainPageLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainPageLocalizationDtoValidator.cs
@@ -11,7 +11,7 @@ public class UpdateMainPageLocalizationDtoValidator : AbstractValidator<UpdateMa
         UpdateMainPartnersLocalizationDtoValidator mainPartnersValidator,
         UpdateMainDonationsLocalizationDtoValidator mainDonationsValidator)
     {
-        this.AddOptionalTitleAndDescriptionRules(MainPageConstants.Localization.TitleBlockDescription.MaxLength);
+        this.AddOptionalTitleAndDescriptionRules(MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MaxLen);
 
         RuleFor(x => x.MainAboutUs)
             .SetValidator(mainAboutUsValidator!)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainPartnersLocalizationDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/MainPage/UpdateMainPartnersLocalizationDtoValidator.cs
@@ -8,6 +8,6 @@ public class UpdateMainPartnersLocalizationDtoValidator : AbstractValidator<Upda
 {
     public UpdateMainPartnersLocalizationDtoValidator(BaseMainPageLocalizationDtoValidator baseValidator)
     {
-        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.SectionDescription.MaxLength);
+        this.AddTitleAndDescriptionRules(MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseImpactStatisticDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseImpactStatisticDtoValidator.cs
@@ -20,12 +20,12 @@ public abstract class BaseImpactStatisticDtoValidator<TDto, TMetric> : AbstractV
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired("Title"))
-            .MinimumLength(MainPageConstants.ImpactStatistic.TitleConstraints.MinLength)
+            .MinimumLength(MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                "Title", MainPageConstants.ImpactStatistic.TitleConstraints.MinLength))
-            .MaximumLength(MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength)
+                "Title", MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                "Title", MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength));
+                "Title", MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen));
 
         RuleFor(metricsSelector)
             .Cascade(CascadeMode.Stop)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainAboutUsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainAboutUsDtoValidator.cs
@@ -13,22 +13,22 @@ public abstract class BaseMainAboutUsDtoValidator<TDto> : AbstractValidator<TDto
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainAboutUsDto.Title)))
-            .MinimumLength(MainPageConstants.Title.MinLength)
+            .MinimumLength(MainPageConstants.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MinLength))
-            .MaximumLength(MainPageConstants.Title.MaxLength)
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
 
         RuleFor(x => x.Description)
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainAboutUsDto.Description)))
-            .MinimumLength(MainPageConstants.Description.MinLength)
+            .MinimumLength(MainPageConstants.ValidationDescriptionRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MinLength))
-            .MaximumLength(MainPageConstants.Description.MaxLength)
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationDescriptionRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainDonationsDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainDonationsDtoValidator.cs
@@ -13,23 +13,23 @@ public abstract class BaseMainDonationsDtoValidator<TDto> : AbstractValidator<TD
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Title)))
-            .MinimumLength(MainPageConstants.Title.MinLength)
+            .MinimumLength(MainPageConstants.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MinLength))
-            .MaximumLength(MainPageConstants.Title.MaxLength)
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
 
         RuleFor(x => x.Description)
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainDonationsDto.Description)))
-            .MinimumLength(MainPageConstants.Description.MinLength)
+            .MinimumLength(MainPageConstants.ValidationDescriptionRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MinLength))
-            .MaximumLength(MainPageConstants.Description.MaxLength)
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationDescriptionRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
 
         RuleFor(x => x.ImageId)
             .GreaterThan(0)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPageDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPageDtoValidator.cs
@@ -13,22 +13,22 @@ public abstract class BaseMainPageDtoValidator<TDto> : AbstractValidator<TDto>
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageDto.Title)))
-            .MinimumLength(MainPageConstants.Title.MinLength)
+            .MinimumLength(MainPageConstants.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MinLength))
-            .MaximumLength(MainPageConstants.Title.MaxLength)
+                nameof(BaseMainPageDto.Title), MainPageConstants.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainPageDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
 
         RuleFor(x => x.Description)
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPageDto.Description)))
-            .MinimumLength(MainPageConstants.Description.MinLength)
+            .MinimumLength(MainPageConstants.ValidationDescriptionRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MinLength))
-            .MaximumLength(MainPageConstants.Description.MaxLength)
+                nameof(BaseMainPageDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationDescriptionRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainPageDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPartnersDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMainPartnersDtoValidator.cs
@@ -13,22 +13,22 @@ public abstract class BaseMainPartnersDtoValidator<TDto> : AbstractValidator<TDt
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPartnersDto.Title)))
-            .MinimumLength(MainPageConstants.Title.MinLength)
+            .MinimumLength(MainPageConstants.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MinLength))
-            .MaximumLength(MainPageConstants.Title.MaxLength)
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
 
         RuleFor(x => x.Description)
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMainPartnersDto.Description)))
-            .MinimumLength(MainPageConstants.Description.MinLength)
+            .MinimumLength(MainPageConstants.ValidationDescriptionRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MinLength))
-            .MaximumLength(MainPageConstants.Description.MaxLength)
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen))
+            .MaximumLength(MainPageConstants.ValidationDescriptionRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMetricDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/BaseMetricDtoValidator.cs
@@ -17,12 +17,12 @@ public abstract class BaseMetricDtoValidator<TDto> : AbstractValidator<TDto>
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(BaseMetricDto.Name)))
-            .MinimumLength(MainPageConstants.Metric.Name.MinLength)
+            .MinimumLength(MainPageConstants.Metric.ValidationNameRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMetricDto.Name), MainPageConstants.Metric.Name.MinLength))
-            .MaximumLength(MainPageConstants.Metric.Name.MaxLength)
+                nameof(BaseMetricDto.Name), MainPageConstants.Metric.ValidationNameRules.MinLen))
+            .MaximumLength(MainPageConstants.Metric.ValidationNameRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMetricDto.Name), MainPageConstants.Metric.Name.MaxLength));
+                nameof(BaseMetricDto.Name), MainPageConstants.Metric.ValidationNameRules.MaxLen));
 
         RuleFor(x => x.Type)
             .IsInEnum()

--- a/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/UpdateImpactStatisticDtoValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/MainPage/Dto/UpdateImpactStatisticDtoValidator.cs
@@ -12,12 +12,12 @@ public class UpdateImpactStatisticDtoValidator : AbstractValidator<UpdateImpactS
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateImpactStatisticDto.Title)))
-            .MinimumLength(MainPageConstants.ImpactStatistic.TitleConstraints.MinLength)
+            .MinimumLength(MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateImpactStatisticDto.Title), MainPageConstants.ImpactStatistic.TitleConstraints.MinLength))
-            .MaximumLength(MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength)
+                nameof(UpdateImpactStatisticDto.Title), MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen))
+            .MaximumLength(MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateImpactStatisticDto.Title), MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength));
+                nameof(UpdateImpactStatisticDto.Title), MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen));
 
         RuleFor(x => x.Id)
             .GreaterThan(0)

--- a/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
+++ b/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
@@ -6,7 +6,7 @@ using VictoryCenter.DbUpdate;
 
 try
 {
-    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebApi"));
+    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebAPI"));
 
     DotEnv.Load(new DotEnvOptions(envFilePaths: new[] { Path.Combine(webApiProjectPath, ".env") }));
 

--- a/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
+++ b/VictoryCenter/VictoryCenter.DbUpdate/Program.cs
@@ -6,7 +6,7 @@ using VictoryCenter.DbUpdate;
 
 try
 {
-    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebAPI"));
+    var webApiProjectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "VictoryCenter.WebApi"));
 
     DotEnv.Load(new DotEnvOptions(envFilePaths: new[] { Path.Combine(webApiProjectPath, ".env") }));
 

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateImpactStatisticLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateImpactStatisticLocalizationValidatorTests.cs
@@ -15,7 +15,7 @@ public class CreateImpactStatisticLocalizationValidatorTests
         var dto = new CreateImpactStatisticLocalizationDto
         {
             LanguageId = 1,
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MinLength),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen),
         };
 
         var result = _validator.TestValidate(dto);
@@ -31,7 +31,7 @@ public class CreateImpactStatisticLocalizationValidatorTests
         var dto = new CreateImpactStatisticLocalizationDto
         {
             LanguageId = languageId,
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MinLength),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen),
         };
 
         var result = _validator.TestValidate(dto);
@@ -62,7 +62,7 @@ public class CreateImpactStatisticLocalizationValidatorTests
         var dto = new CreateImpactStatisticLocalizationDto
         {
             LanguageId = 1,
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MinLength - 1),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen - 1),
         };
 
         var result = _validator.TestValidate(dto);
@@ -70,7 +70,7 @@ public class CreateImpactStatisticLocalizationValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
                 nameof(CreateImpactStatisticLocalizationDto.Title),
-                MainPageConstants.ImpactStatistic.TitleConstraints.MinLength));
+                MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class CreateImpactStatisticLocalizationValidatorTests
         var dto = new CreateImpactStatisticLocalizationDto
         {
             LanguageId = 1,
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength + 1),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen + 1),
         };
 
         var result = _validator.TestValidate(dto);
@@ -87,6 +87,6 @@ public class CreateImpactStatisticLocalizationValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(CreateImpactStatisticLocalizationDto.Title),
-                MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength));
+                MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen));
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainDonationsLocalizationDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainDonationsLocalizationDtoValidatorTests.cs
@@ -51,55 +51,55 @@ public class CreateMainDonationsLocalizationDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.Title.MinLength));
+                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.Title.MaxLength));
+                nameof(CreateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MaxLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.SectionDescription.MinLength));
+                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.SectionDescription.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.SectionDescription.MaxLength));
+                nameof(CreateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen));
     }
 
     private static CreateMainDonationsLocalizationDto GetValidDto() => new()
     {
         EntityId = 1,
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength),
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen),
     };
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainPageLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/CreateMainPageLocalizationValidatorTests.cs
@@ -68,13 +68,13 @@ public class CreateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.Localization.Title.MinLength - 1)
+            Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen - 1)
         };
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor(x => x.Dto.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(CreateMainPageLocalizationDto.Title), MainPageConstants.Localization.Title.MinLength));
+                nameof(CreateMainPageLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MinLen));
     }
 
     [Fact]
@@ -82,13 +82,13 @@ public class CreateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.Localization.Title.MaxLength + 1)
+            Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MaxLen + 1)
         };
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor(x => x.Dto.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(CreateMainPageLocalizationDto.Title), MainPageConstants.Localization.Title.MaxLength));
+                nameof(CreateMainPageLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MaxLen));
     }
 
     [Fact]
@@ -106,14 +106,14 @@ public class CreateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Description = new string('a', MainPageConstants.Localization.TitleBlockDescription.MaxLength + 1)
+            Description = new string('a', MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MaxLen + 1)
         };
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor(x => x.Dto.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(CreateMainPageLocalizationDto.Description),
-                MainPageConstants.Localization.TitleBlockDescription.MaxLength));
+                MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MaxLen));
     }
 
     [Theory]
@@ -122,7 +122,7 @@ public class CreateMainPageLocalizationValidatorTests
     [InlineData(nameof(CreateMainPageLocalizationDto.MainDonations))]
     public void Validate_ShouldHaveError_WhenSectionTitleIsTooLong(string sectionName)
     {
-        var dto = GetValidDtoWithInvalidSection(sectionName, title: new string('a', MainPageConstants.Localization.Title.MaxLength + 1));
+        var dto = GetValidDtoWithInvalidSection(sectionName, title: new string('a', MainPageConstants.Localization.ValidationTitleRules.MaxLen + 1));
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor($"Dto.{sectionName}.Title");
@@ -136,7 +136,7 @@ public class CreateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDtoWithInvalidSection(
             sectionName,
-            description: new string('a', MainPageConstants.Localization.SectionDescription.MaxLength + 1));
+            description: new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen + 1));
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor($"Dto.{sectionName}.Description");
@@ -146,8 +146,8 @@ public class CreateMainPageLocalizationValidatorTests
     {
         EntityId = 1,
         LanguageId = 1,
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.TitleBlockDescription.MinLength),
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MinLen),
         MainAboutUs = GetValidAboutUs(),
         MainPartners = GetValidPartners(),
         MainDonations = GetValidDonations()
@@ -193,22 +193,22 @@ public class CreateMainPageLocalizationValidatorTests
     private static CreateMainAboutUsLocalizationDto GetValidAboutUs() => new()
     {
         EntityId = 2,
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength)
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
     };
 
     private static CreateMainPartnersLocalizationDto GetValidPartners() => new()
     {
         EntityId = 3,
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength)
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
     };
 
     private static CreateMainDonationsLocalizationDto GetValidDonations() => new()
     {
         EntityId = 4,
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength)
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
     };
 
     private static CreateMainPageLocalizationCommand BuildCommand(CreateMainPageLocalizationDto dto) => new(dto);

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainDonationsLocalizationDtoValidatorTests.cs
@@ -37,54 +37,54 @@ public class UpdateMainDonationsLocalizationDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.Title.MinLength));
+                nameof(UpdateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.Title.MaxLength));
+                nameof(UpdateMainDonationsLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MaxLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.SectionDescription.MinLength));
+                nameof(UpdateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.SectionDescription.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(UpdateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.SectionDescription.MaxLength));
+                nameof(UpdateMainDonationsLocalizationDto.Description), MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen));
     }
 
     private static UpdateMainDonationsLocalizationDto GetValidDto() => new()
     {
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength),
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen),
     };
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainPageLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/MainPage/UpdateMainPageLocalizationValidatorTests.cs
@@ -42,13 +42,13 @@ public class UpdateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.Localization.Title.MinLength - 1)
+            Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen - 1)
         };
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor(x => x.Dto.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(UpdateMainPageLocalizationDto.Title), MainPageConstants.Localization.Title.MinLength));
+                nameof(UpdateMainPageLocalizationDto.Title), MainPageConstants.Localization.ValidationTitleRules.MinLen));
     }
 
     [Fact]
@@ -56,14 +56,14 @@ public class UpdateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Description = new string('a', MainPageConstants.Localization.TitleBlockDescription.MaxLength + 1)
+            Description = new string('a', MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MaxLen + 1)
         };
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor(x => x.Dto.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(UpdateMainPageLocalizationDto.Description),
-                MainPageConstants.Localization.TitleBlockDescription.MaxLength));
+                MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MaxLen));
     }
 
     [Theory]
@@ -72,7 +72,7 @@ public class UpdateMainPageLocalizationValidatorTests
     [InlineData(nameof(UpdateMainPageLocalizationDto.MainDonations))]
     public void Validate_ShouldHaveError_WhenSectionTitleIsTooShort(string sectionName)
     {
-        var dto = GetValidDtoWithInvalidSection(sectionName, title: new string('a', MainPageConstants.Localization.Title.MinLength - 1));
+        var dto = GetValidDtoWithInvalidSection(sectionName, title: new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen - 1));
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor($"Dto.{sectionName}.Title");
@@ -86,7 +86,7 @@ public class UpdateMainPageLocalizationValidatorTests
     {
         var dto = GetValidDtoWithInvalidSection(
             sectionName,
-            description: new string('a', MainPageConstants.Localization.SectionDescription.MaxLength + 1));
+            description: new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MaxLen + 1));
 
         _validator.TestValidate(BuildCommand(dto))
             .ShouldHaveValidationErrorFor($"Dto.{sectionName}.Description");
@@ -94,8 +94,8 @@ public class UpdateMainPageLocalizationValidatorTests
 
     private static UpdateMainPageLocalizationDto GetValidDto() => new()
     {
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.TitleBlockDescription.MinLength),
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationTitleBlockDescriptionRules.MinLen),
         MainAboutUs = GetValidAboutUs(),
         MainPartners = GetValidPartners(),
         MainDonations = GetValidDonations()
@@ -140,20 +140,20 @@ public class UpdateMainPageLocalizationValidatorTests
 
     private static UpdateMainAboutUsLocalizationDto GetValidAboutUs() => new()
     {
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength)
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
     };
 
     private static UpdateMainPartnersLocalizationDto GetValidPartners() => new()
     {
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength)
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
     };
 
     private static UpdateMainDonationsLocalizationDto GetValidDonations() => new()
     {
-        Title = new string('a', MainPageConstants.Localization.Title.MinLength),
-        Description = new string('a', MainPageConstants.Localization.SectionDescription.MinLength)
+        Title = new string('a', MainPageConstants.Localization.ValidationTitleRules.MinLen),
+        Description = new string('a', MainPageConstants.Localization.ValidationSectionDescriptionRules.MinLen)
     };
 
     private static UpdateMainPageLocalizationCommand BuildCommand(UpdateMainPageLocalizationDto dto)

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateImpactStatisticDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateImpactStatisticDtoValidatorTests.cs
@@ -37,7 +37,7 @@ public class CreateImpactStatisticDtoValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MinLength - 1),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen - 1),
         };
 
         var result = _validator.TestValidate(dto);
@@ -50,7 +50,7 @@ public class CreateImpactStatisticDtoValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength + 1),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen + 1),
         };
 
         var result = _validator.TestValidate(dto);
@@ -110,22 +110,22 @@ public class CreateImpactStatisticDtoValidatorTests
             [
                 new CreateMetricDto
                 {
-                    Value = 100, Name = "a", Type = MetricType.Partners,
+                    Value = 100, Name = "aa", Type = MetricType.Partners,
                     Localization = new CreateMetricLocalizationDto { LanguageId = 1, Name = "Партнери" },
                 },
                 new CreateMetricDto
                 {
-                    Value = 200, Name = "b", Type = MetricType.Programs,
+                    Value = 200, Name = "bb", Type = MetricType.Programs,
                     Localization = new CreateMetricLocalizationDto { LanguageId = 1, Name = "Програми" },
                 },
                 new CreateMetricDto
                 {
-                    Value = 300, Name = "c", Type = MetricType.Raised,
+                    Value = 300, Name = "cc", Type = MetricType.Raised,
                     Localization = new CreateMetricLocalizationDto { LanguageId = 1, Name = "Зібрано" },
                 },
                 new CreateMetricDto
                 {
-                    Value = 400, Name = "d", Type = MetricType.TherapyHours,
+                    Value = 400, Name = "dd", Type = MetricType.TherapyHours,
                     Localization = new CreateMetricLocalizationDto { LanguageId = 1, Name = "Терапія" },
                 },
             ],

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainAboutUsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainAboutUsDtoValidatorTests.cs
@@ -33,25 +33,25 @@ public class CreateMainAboutUsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -71,25 +71,25 @@ public class CreateMainAboutUsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     private static CreateMainAboutUsDto GetValidDto() => new()

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainDonationsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainDonationsDtoValidatorTests.cs
@@ -43,25 +43,25 @@ public class CreateMainDonationsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -81,25 +81,25 @@ public class CreateMainDonationsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     [Theory]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPageDtoValidatorTests.cs
@@ -40,25 +40,25 @@ public class CreateMainPageDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainPageDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainPageDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -78,25 +78,25 @@ public class CreateMainPageDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainPageDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainPageDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     [Fact]
@@ -187,6 +187,29 @@ public class CreateMainPageDtoValidatorTests
         var result = _validator.TestValidate(dto);
 
         result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(0, 7)]
+    [InlineData(1, 32)]
+    [InlineData(50, 1257)]
+    [InlineData(150, 3757)]
+    [InlineData(1000, 25007)]
+    public void CalculateHighestCharactersLimitForRichInput_ShouldReturnExpectedValue(int rawLimit, int expected)
+    {
+        var result = MainPageConstants.CalculateHighestCharactersLimitForRichInput(rawLimit);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void MainPageRichTextLimits_ShouldAllowFormattingPayloadOverRawTextLimit()
+    {
+        var visibleText = new string('a', 34);
+        var formattedTitle = $"<p><strong>{visibleText}</strong></p>";
+
+        Assert.True(formattedTitle.Length > 50);
+        Assert.True(formattedTitle.Length <= MainPageConstants.Localization.ValidationTitleRules.MaxLen);
     }
 
     private static CreateMainPageDto GetValidDto() => new()

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPartnersDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMainPartnersDtoValidatorTests.cs
@@ -33,25 +33,25 @@ public class CreateMainPartnersDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -71,25 +71,25 @@ public class CreateMainPartnersDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     private static CreateMainPartnersDto GetValidDto() => new()

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMetricDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/CreateMetricDtoValidatorTests.cs
@@ -47,14 +47,14 @@ public class CreateMetricDtoValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Name = new string('a', MainPageConstants.Metric.Name.MaxLength + 1),
+            Name = new string('a', MainPageConstants.Metric.ValidationNameRules.MaxLen + 1),
         };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Name)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMetricDto.Name), MainPageConstants.Metric.Name.MaxLength));
+                nameof(BaseMetricDto.Name), MainPageConstants.Metric.ValidationNameRules.MaxLen));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateImpactStatisticDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateImpactStatisticDtoValidatorTests.cs
@@ -78,7 +78,7 @@ public class UpdateImpactStatisticDtoValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MinLength - 1),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen - 1),
         };
 
         var result = _validator.TestValidate(dto);
@@ -86,7 +86,7 @@ public class UpdateImpactStatisticDtoValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
                 nameof(BaseImpactStatisticDto.Title),
-                MainPageConstants.ImpactStatistic.TitleConstraints.MinLength));
+                MainPageConstants.ImpactStatistic.ValidationTitleRules.MinLen));
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class UpdateImpactStatisticDtoValidatorTests
     {
         var dto = GetValidDto() with
         {
-            Title = new string('a', MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength + 1),
+            Title = new string('a', MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen + 1),
         };
 
         var result = _validator.TestValidate(dto);
@@ -102,7 +102,7 @@ public class UpdateImpactStatisticDtoValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(BaseImpactStatisticDto.Title),
-                MainPageConstants.ImpactStatistic.TitleConstraints.MaxLength));
+                MainPageConstants.ImpactStatistic.ValidationTitleRules.MaxLen));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainAboutUsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainAboutUsDtoValidatorTests.cs
@@ -33,25 +33,25 @@ public class UpdateMainAboutUsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainAboutUsDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -71,25 +71,25 @@ public class UpdateMainAboutUsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainAboutUsDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainAboutUsDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     private static UpdateMainAboutUsDto GetValidDto() => new()

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainDonationsDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainDonationsDtoValidatorTests.cs
@@ -43,25 +43,25 @@ public class UpdateMainDonationsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainDonationsDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -81,25 +81,25 @@ public class UpdateMainDonationsDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainDonationsDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainDonationsDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     [Theory]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainPageDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainPageDtoValidatorTests.cs
@@ -39,25 +39,25 @@ public class UpdateMainPageDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainPageDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainPageDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -77,25 +77,25 @@ public class UpdateMainPageDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainPageDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPageDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainPageDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainPartnersDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMainPartnersDtoValidatorTests.cs
@@ -33,25 +33,25 @@ public class UpdateMainPartnersDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooShort()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MinLength - 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MinLength));
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.ValidationTitleRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenTitleIsTooLong()
     {
-        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.Title.MaxLength + 1) };
+        var dto = GetValidDto() with { Title = new string('a', MainPageConstants.ValidationTitleRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Title)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Title), MainPageConstants.Title.MaxLength));
+                nameof(BaseMainPartnersDto.Title), MainPageConstants.ValidationTitleRules.MaxLen));
     }
 
     [Theory]
@@ -71,25 +71,25 @@ public class UpdateMainPartnersDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooShort()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MinLength - 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MinLen - 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MinLength));
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.ValidationDescriptionRules.MinLen));
     }
 
     [Fact]
     public void Validate_ShouldHaveError_WhenDescriptionIsTooLong()
     {
-        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.Description.MaxLength + 1) };
+        var dto = GetValidDto() with { Description = new string('a', MainPageConstants.ValidationDescriptionRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Description)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMainPartnersDto.Description), MainPageConstants.Description.MaxLength));
+                nameof(BaseMainPartnersDto.Description), MainPageConstants.ValidationDescriptionRules.MaxLen));
     }
 
     private static UpdateMainPartnersDto GetValidDto() => new()

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMetricDtoValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/MainPage/UpdateMetricDtoValidatorTests.cs
@@ -67,13 +67,13 @@ public class UpdateMetricDtoValidatorTests
     [Fact]
     public void Validate_ShouldHaveError_WhenNameIsTooLong()
     {
-        var dto = GetValidDto() with { Name = new string('a', MainPageConstants.Metric.Name.MaxLength + 1) };
+        var dto = GetValidDto() with { Name = new string('a', MainPageConstants.Metric.ValidationNameRules.MaxLen + 1) };
 
         var result = _validator.TestValidate(dto);
 
         result.ShouldHaveValidationErrorFor(x => x.Name)
             .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
-                nameof(BaseMetricDto.Name), MainPageConstants.Metric.Name.MaxLength));
+                nameof(BaseMetricDto.Name), MainPageConstants.Metric.ValidationNameRules.MaxLen));
     }
 
     [Fact]


### PR DESCRIPTION
dev
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2834

## Summary of issue

Main page backend validation used raw string length limits for editable text fields. After switching Admin Main page fields to RichText, formatted content could be rejected because serialized markup tags were counted as part of the backend character limit, even when the visible text length was valid.

## Summary of change

Refactored MainPageConstants to use RichText-compatible validation limits, following the existing WhoWeAreConstants approach.

Updated Main page and Main page localization validators to use the new tuple-based validation rules with calculated max payload lengths. Updated related unit tests and added coverage for the RichText payload limit calculation.

## Testing approach

- Tested Admin Main page RichText editing from the frontend with a locally connected backend.
- Verified backend build and tests

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
