### PR TITLE
Fix/issue-2805 [Partners] The wrong validation message appears when Admin uploads too large image

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/ImageConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ImageConstants.cs
@@ -2,7 +2,7 @@ namespace VictoryCenter.BLL.Constants;
 
 public static class ImageConstants
 {
-    public static readonly int MaxImageSizeInMb = 3;
+    public static readonly int MaxImageSizeInMb = 5;
     public static readonly int BytesPerMb = 1024 * 1024;
     public static readonly int MaxImageSizeInBytes = MaxImageSizeInMb * BytesPerMb;
 


### PR DESCRIPTION
## Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2805


## Description
  This PR resolves a validation mismatch on the Partners page where image uploads between 3 MB and 5 MB were
  rejected by the backend. It updates the backend size validation limit to 5 MB to align with the expected client-
  side image validation rules.

 ## Summary of Changes

 ### 1. Partner Image Upload Size Limit Alignment (Backend)

 • **Issue**: Mismatch between the frontend image validator (which defaults to 5 MB) and the backend validator
  (previously set to 3 MB), causing image uploads between 3 MB and 5 MB to fail at the database/storage layer with a
  400 Bad Request.
 • **Fix**: Increased `MaxImageSizeInMb` from `3` to `5` in `ImageConstants.cs` on the backend to align size
  constraints with expected image validation rules.

 ## How to recreate changes

 ### Partner Image Size Validation:
 1. Log in to the **Admin Panel**.
 2. Open the **Partners** page and edit an existing partner profile.
 3. Upload an image file with a size between **3 MB and 5 MB**.
 4. **Observe**: The file is successfully accepted by the system without returning a `400 Bad Request` or
  validation error.
 5. Try uploading an image file larger than **5 MB**.
 6. **Observe**: The system rejects the file and displays the validation message `"Фото не більше 5 MB"`.

 ## CHECK LIST
 - [ ] New tests was added or existing was modified
 - [ ] Changes has severe impact on users
 - [ ] Changes has medium impact on users
 - [x] Changes has light impact on users
 - [ ] Test coverage was updated
 - [x] PR meets all conventions
