### PR TITLE
Fix/issue-2830 [Partners][Admin panel][API] 200 OK is returned when Partner banner description exceeds 30 characters

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/PartnerConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/PartnerConstants.cs
@@ -4,15 +4,15 @@ public static class PartnerConstants
 {
     public static readonly int PartnersSectionTitleMaxLength = 50;
     public static readonly int PartnersSectionTitleMinLength = 10;
-    public static readonly int PartnersSectionDescriptionMaxLength = 100;
+    public static readonly int PartnersSectionDescriptionMaxLength = 70;
     public static readonly int PartnersSectionDescriptionMinLength = 10;
     public static readonly int PartnersSectionPartnersMaxCount = 50;
 
     public static readonly int PartnerDescriptionMaxLength = 50;
     public static readonly int PartnerDescriptionMinLength = 5;
 
-    public static readonly int PartnersPageBannerTitleMaxLength = 150;
+    public static readonly int PartnersPageBannerTitleMaxLength = 30;
     public static readonly int PartnersPageBannerTitleMinLength = 10;
-    public static readonly int PartnersPageBannerDescriptionMaxLength = 100;
+    public static readonly int PartnersPageBannerDescriptionMaxLength = 30;
     public static readonly int PartnersPageBannerDescriptionMinLength = 10;
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Partners/UpdateBanner/UpdatePartnersBannerTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Partners/UpdateBanner/UpdatePartnersBannerTests.cs
@@ -28,7 +28,7 @@ public class UpdatePartnersBannerTests : BaseTestClass
         var updateDto = new UpdatePartnersPageBannerDto
         {
             Title = "Updated Banner Title",
-            Description = "This is the new and updated description.",
+            Description = "Updated banner description.",
             ImageId = newImage.Id
         };
         var serializedDto = JsonSerializer.Serialize(updateDto);


### PR DESCRIPTION
## GitHub ticket
* [#2830](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2830)

## Summary of issue
PUT request to `/api/Partners/banner` returned `200 OK` and successfully saved the data even when the `description` field exceeded the 30-character limit enforced on the frontend. Instead, a `400 Bad Request` response with a validation error was expected, and the data should not have been saved.

## Summary of change
Updated constants in `PartnerConstants.cs` to match the actual frontend limits:
- `PartnersPageBannerTitleMaxLength`: `150` → `30`
- `PartnersPageBannerDescriptionMaxLength`: `100` → `30`
- `PartnersSectionDescriptionMaxLength`: `100` → `70`

## How it looks
<img width="898" height="621" alt="image" src="https://github.com/user-attachments/assets/24e9feb6-4ec2-4785-97f1-4d7840689731" />

## Testing approach
 Manual verification via Postman or Swagger:
  - PUT `/api/Partners/banner` with `title`/`description` longer than 30 characters → expected `400 Bad Request` with a validation error
  - PUT `/api/Partners/banner` with `title`/`description` within the limit (≤30 characters) → expected `200 OK`, banner updated

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the allowed length for partner section and banner text, so content now follows stricter display limits across the partners area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->