### PR TITLE
Fix/issue-3020 [Single Program] [FAQ Template][Редагування]The system does not save new data after publishing or saving a draft.

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -131,6 +131,16 @@ public static class ErrorMessagesConstants
         return $"{property} must be greater than {value}";
     }
 
+    public static string PropertyMustHaveAMinimumVisibleLengthOfNCharacters(string property, int length)
+    {
+        return $"{property} field must have a minimum length of {length} visible characters, excluding HTML markup";
+    }
+
+    public static string PropertyMustHaveAMaximumVisibleLengthOfNCharacters(string property, int length)
+    {
+        return $"{property} field must have a maximum length of {length} visible characters, excluding HTML markup";
+    }
+
     public static string PropertyIsRequired(string property)
     {
         return $"{property} is required";

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Partners/Commands/UpdatePartnersPageBannerCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Partners/Commands/UpdatePartnersPageBannerCommandValidator.cs
@@ -6,7 +6,7 @@ using VictoryCenter.BLL.DTOs.Admin.Partners;
 
 namespace VictoryCenter.BLL.Validators.Partners.Commands;
 
-public class UpdatePartnersPageBannerCommandValidator : AbstractValidator<UpdatePartnersPageBannerCommand>
+public partial class UpdatePartnersPageBannerCommandValidator : AbstractValidator<UpdatePartnersPageBannerCommand>
 {
     public UpdatePartnersPageBannerCommandValidator()
     {
@@ -38,6 +38,9 @@ public class UpdatePartnersPageBannerCommandValidator : AbstractValidator<Update
     {
         return string.IsNullOrEmpty(input)
             ? input
-            : Regex.Replace(input, "<.*?>", string.Empty);
+            : HtmlTagRegex().Replace(input, string.Empty);
     }
+
+    [GeneratedRegex("<.*?>", RegexOptions.None, matchTimeoutMilliseconds: 100)]
+    private static partial Regex HtmlTagRegex();
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Partners/Commands/UpdatePartnersPageBannerCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Partners/Commands/UpdatePartnersPageBannerCommandValidator.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+using HtmlAgilityPack;
 using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.Partners.UpdateBanner;
 using VictoryCenter.BLL.Constants;
@@ -6,7 +6,7 @@ using VictoryCenter.BLL.DTOs.Admin.Partners;
 
 namespace VictoryCenter.BLL.Validators.Partners.Commands;
 
-public partial class UpdatePartnersPageBannerCommandValidator : AbstractValidator<UpdatePartnersPageBannerCommand>
+public class UpdatePartnersPageBannerCommandValidator : AbstractValidator<UpdatePartnersPageBannerCommand>
 {
     public UpdatePartnersPageBannerCommandValidator()
     {
@@ -14,10 +14,10 @@ public partial class UpdatePartnersPageBannerCommandValidator : AbstractValidato
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdatePartnersPageBannerDto.Title)))
             .Must(title => StripHtmlTags(title).Length >= PartnerConstants.PartnersPageBannerTitleMinLength)
-            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumVisibleLengthOfNCharacters(
                 nameof(UpdatePartnersPageBannerDto.Title), PartnerConstants.PartnersPageBannerTitleMinLength))
             .Must(title => StripHtmlTags(title).Length <= PartnerConstants.PartnersPageBannerTitleMaxLength)
-            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumVisibleLengthOfNCharacters(
                 nameof(UpdatePartnersPageBannerDto.Title), PartnerConstants.PartnersPageBannerTitleMaxLength));
 
         RuleFor(x => x.Dto.Description)
@@ -36,11 +36,13 @@ public partial class UpdatePartnersPageBannerCommandValidator : AbstractValidato
 
     private static string StripHtmlTags(string input)
     {
-        return string.IsNullOrEmpty(input)
-            ? input
-            : HtmlTagRegex().Replace(input, string.Empty);
-    }
+        if (string.IsNullOrEmpty(input))
+        {
+            return string.Empty;
+        }
 
-    [GeneratedRegex("<.*?>", RegexOptions.None, matchTimeoutMilliseconds: 100)]
-    private static partial Regex HtmlTagRegex();
+        var htmlDoc = new HtmlDocument();
+        htmlDoc.LoadHtml(input);
+        return htmlDoc.DocumentNode.InnerText;
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Partners/Commands/UpdatePartnersPageBannerCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Partners/Commands/UpdatePartnersPageBannerCommandValidator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using FluentValidation;
 using VictoryCenter.BLL.Commands.Admin.Partners.UpdateBanner;
 using VictoryCenter.BLL.Constants;
@@ -12,10 +13,10 @@ public class UpdatePartnersPageBannerCommandValidator : AbstractValidator<Update
         RuleFor(x => x.Dto.Title)
             .NotEmpty()
             .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdatePartnersPageBannerDto.Title)))
-            .MinimumLength(PartnerConstants.PartnersPageBannerTitleMinLength)
+            .Must(title => StripHtmlTags(title).Length >= PartnerConstants.PartnersPageBannerTitleMinLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
                 nameof(UpdatePartnersPageBannerDto.Title), PartnerConstants.PartnersPageBannerTitleMinLength))
-            .MaximumLength(PartnerConstants.PartnersPageBannerTitleMaxLength)
+            .Must(title => StripHtmlTags(title).Length <= PartnerConstants.PartnersPageBannerTitleMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(UpdatePartnersPageBannerDto.Title), PartnerConstants.PartnersPageBannerTitleMaxLength));
 
@@ -31,5 +32,12 @@ public class UpdatePartnersPageBannerCommandValidator : AbstractValidator<Update
 
         RuleFor(x => x.Dto.ImageId)
             .GreaterThan(0).WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdatePartnersPageBannerDto.ImageId)));
+    }
+
+    private static string StripHtmlTags(string input)
+    {
+        return string.IsNullOrEmpty(input)
+            ? input
+            : Regex.Replace(input, "<.*?>", string.Empty);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/VictoryCenter.BLL.csproj
+++ b/VictoryCenter/VictoryCenter.BLL/VictoryCenter.BLL.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="AutoMapper" Version="12.0.1"/>
         <PackageReference Include="FluentResults" Version="3.16.0"/>
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1"/>
+        <PackageReference Include="HtmlAgilityPack" Version="1.12.4"/>
         <PackageReference Include="MediatR" Version="12.5.0"/>
         <PackageReference Include="MediatR.Contracts" Version="2.0.1"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5"/>

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Partners/UpdatePartnersPageBannerCommandValidator.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Partners/UpdatePartnersPageBannerCommandValidator.cs
@@ -51,7 +51,7 @@ public class UpdatePartnersPageBannerCommandValidatorTests
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Dto.Title)
-              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumVisibleLengthOfNCharacters(
                     nameof(UpdatePartnersPageBannerDto.Title),
                     PartnerConstants.PartnersPageBannerTitleMinLength));
     }
@@ -69,7 +69,7 @@ public class UpdatePartnersPageBannerCommandValidatorTests
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Dto.Title)
-              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+              .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumVisibleLengthOfNCharacters(
                     nameof(UpdatePartnersPageBannerDto.Title),
                     PartnerConstants.PartnersPageBannerTitleMaxLength));
     }
@@ -158,6 +158,22 @@ public class UpdatePartnersPageBannerCommandValidatorTests
 
         // Assert
         result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_TitleWithHtmlFormattingWithinVisibleLimit_ShouldNotHaveError()
+    {
+        // Arrange
+        var visibleText = new string('A', PartnerConstants.PartnersPageBannerTitleMaxLength);
+        var htmlTitle = $"<p><strong>{visibleText}</strong></p>";
+        var dto = GetValidDto() with { Title = htmlTitle };
+        var command = new UpdatePartnersPageBannerCommand(dto);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Dto.Title);
     }
 
     private UpdatePartnersPageBannerDto GetValidDto()


### PR DESCRIPTION
## GitHub ticket
* [#3020](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3020)

## Summary of issue
Saving the partner banner title from the admin panel failed with a 400 Bad Request ("Title field must have a maximum length of 30 characters") whenever the title contained rich-text formatting (bold/italic), even though the visible text was within the limit. The validator counted the raw string length including HTML tags (e.g. `<p><strong>...</strong></p>`), not the visible text length.

## Summary of change
- Updated `UpdatePartnersPageBannerCommandValidator` to validate `Title` length based on plain text (HTML tags stripped) instead of the raw string
- Added a `StripHtmlTags` helper that removes HTML tags before length calculation, without modifying the original value that gets persisted

## Testing approach
1. Login as Admin
2. Go to "Partners" section
3. Open the partner banner edit form
4. Enter a title 30 visible characters long, using bold/italic formatting
5. Click "Опублікувати" → in "Опублікувати зміни?" popup click "Так"
6. Verify the banner saves successfully without a 400 error
7. Reload the page and verify the title displays with formatting preserved
8. Verify that a title exceeding 30 visible characters (excluding tags) still fails validation as expected

## CHECK LIST
- [ ]  CI passed
- [ ]  Code coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Banner title validation now measures only visible text, excluding HTML tags.
  * Updated minimum and maximum length validation messages to reflect visible title content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->