### PR TITLE
Feature/issue 2487 [Reports] Upload PDF file in EN

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/PdfReports/Create/CreatePdfReportHandler.cs
@@ -61,15 +61,24 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
             blobName = await _pdfService.UploadPdfAsync(dto.File, fileName);
             using var transaction = _repositoryWrapper.BeginTransaction();
 
-            var nextPriority = await _reorderService.GetNextDisplayOrderAsync<PdfReport>(
-                p => p.LanguageId == dto.LanguageId);
+            var existingReports = await _repositoryWrapper.PdfReportRepository.GetAllAsync(new QueryOptions<PdfReport>
+            {
+                Filter = p => p.LanguageId == dto.LanguageId,
+                AsNoTracking = false
+            });
+
+            foreach (var report in existingReports)
+            {
+                report.Priority++;
+                _repositoryWrapper.PdfReportRepository.Update(report);
+            }
 
             var pdfReport = new PdfReport
             {
                 Name = Path.GetFileNameWithoutExtension(dto.File.FileName),
                 BlobName = blobName,
                 FileSizeBytes = dto.File.Length,
-                Priority = nextPriority,
+                Priority = 1,
                 LanguageId = dto.LanguageId,
                 CreatedAt = DateTimeOffset.UtcNow
             };
@@ -83,7 +92,6 @@ public class CreatePdfReportHandler : IRequestHandler<CreatePdfReportCommand, Re
 
             transaction.Complete();
             committed = true;
-
             var result = _mapper.Map<PdfReportDto>(pdfReport);
             return Result.Ok(result);
         }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -121,7 +121,7 @@ public class CreatePdfReportTests : BaseTestClass
         Assert.True(response2.IsSuccessStatusCode);
         Assert.NotNull(result1);
         Assert.NotNull(result2);
-        
+
         Assert.Equal(1, result1.Priority);
         Assert.Equal(1, result2.Priority);
 

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/PdfReports/Create/CreatePdfReportTests.cs
@@ -121,7 +121,13 @@ public class CreatePdfReportTests : BaseTestClass
         Assert.True(response2.IsSuccessStatusCode);
         Assert.NotNull(result1);
         Assert.NotNull(result2);
-        Assert.True(result2.Priority > result1.Priority);
+        
+        Assert.Equal(1, result1.Priority);
+        Assert.Equal(1, result2.Priority);
+
+        var firstReportInDb = await Fixture.DbContext.PdfReports.FirstOrDefaultAsync(p => p.Id == result1.Id);
+        Assert.NotNull(firstReportInDb);
+        Assert.Equal(2, firstReportInDb.Priority);
     }
 
     [Fact]


### PR DESCRIPTION
dev
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2487)


## Summary of issue

When creating a new PDF report, the newly uploaded file wolud appear at the bottom (end) of the list when fetched from the backend, not the top.

## Summary of change

* **Increment-Then-Insert Logic:** Refactored `CreatePdfReportHandler` to fetch all existing PDF reports for the requested language and increment their Priority by 1 before inserting the new report.
* **Top Priority for New Reports:** Hardcoded the newly created `PdfReport` entity to have `Priority = 1`, ensuring that the most recently uploaded reports naturally appear at the top of the list.
* **Transaction Safety**: Leveraged ` _repositoryWrapper.BeginTransaction()` to wrap both the priority-shifting of existing reports and the creation of the new report in a single database transaction, guaranteeing data integrity and consistent ordering in case of a failure.


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
