### PR TITLE
Implement Admin API for creating event/news

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using VictoryCenter.BLL.Behaviors.Abstractions;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+
+public record CreateEventNewsCommand(CreateEventNewsDto CreateEventNewsDto)
+    : IValidatableRequest<Result<EventNewsDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentResults;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.EventNews;
 using VictoryCenter.BLL.Helpers;
@@ -15,6 +16,9 @@ namespace VictoryCenter.BLL.Commands.Admin.EventNews.Create;
 
 public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Result<EventNewsDto>>
 {
+    private const int MaxSlugSaveAttempts = 3;
+    private const string SlugIndexName = "IX_EventNews_Slug";
+
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly ISlugService _slugService;
@@ -33,9 +37,12 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
         CreateEventNewsCommand request,
         CancellationToken cancellationToken)
     {
-        var categoriesResult = await CategoryValidationHelper.ValidateAndGetEventNewsCategoriesAsync(
-            _repositoryWrapper,
-            request.CreateEventNewsDto.CategoryIds);
+        var categoryIds = request.CreateEventNewsDto.CategoryIds ?? [];
+        var localizationDtos = request.CreateEventNewsDto.Localizations ?? [];
+
+        var categoriesResult = await CategoryValidationHelper.ValidateAndGetCategoriesAsync(
+            _repositoryWrapper.EventNewsCategoryRepository,
+            categoryIds);
 
         if (categoriesResult.IsFailed)
         {
@@ -60,7 +67,11 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
             return Result.Fail<EventNewsDto>(backgroundImageResult.Errors);
         }
 
-        var languagesResult = await ValidateAndGetLanguagesAsync(request.CreateEventNewsDto.Localizations);
+        var localizationsToCreate = localizationDtos
+            .Where(localization => localization is not null && !string.IsNullOrWhiteSpace(localization.Title))
+            .ToList();
+
+        var languagesResult = await ValidateAndGetLanguagesAsync(localizationsToCreate);
 
         if (languagesResult.IsFailed)
         {
@@ -74,7 +85,16 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
         eventNews.BackgroundImage = backgroundImageResult.Value;
 
         AddCategories(eventNews, categoriesResult.Value);
-        AddLocalizations(eventNews, request.CreateEventNewsDto.Localizations, languagesResult.Value, now);
+        var localizationsResult = AddLocalizations(
+            eventNews,
+            localizationsToCreate,
+            languagesResult.Value,
+            now);
+
+        if (localizationsResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(localizationsResult.Errors);
+        }
 
         var titleForSlug = eventNews.Localizations
             .Select(localization => localization.Title)
@@ -90,7 +110,7 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
 
         await _repositoryWrapper.EventNewsRepository.CreateAsync(eventNews);
 
-        if (await _repositoryWrapper.SaveChangesAsync() > 0)
+        if (await SaveEventNewsAsync(eventNews, titleForSlug, cancellationToken) > 0)
         {
             return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
         }
@@ -103,7 +123,6 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
     {
         var languageIds = localizations
             .Select(localization => localization.LanguageId)
-            .Where(id => id > 0)
             .Distinct()
             .ToList();
 
@@ -137,7 +156,7 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
         }
     }
 
-    private static void AddLocalizations(
+    private static Result AddLocalizations(
         EventNewsEntity eventNews,
         IEnumerable<CreateEventNewsLocalizationDto> localizationDtos,
         IReadOnlyDictionary<long, LocalizationLanguage> languagesById,
@@ -145,15 +164,16 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
     {
         foreach (var localizationDto in localizationDtos)
         {
-            if (string.IsNullOrWhiteSpace(localizationDto.Title))
+            if (!languagesById.TryGetValue(localizationDto.LanguageId, out var language))
             {
-                continue;
+                return Result.Fail(
+                    ErrorMessagesConstants.NotFound(localizationDto.LanguageId, typeof(LocalizationLanguage)));
             }
 
             var localization = new EventNewsLocalization
             {
                 LanguageId = localizationDto.LanguageId,
-                Language = languagesById[localizationDto.LanguageId],
+                Language = language,
                 Title = localizationDto.Title!.Trim(),
                 Description = localizationDto.Description?.Trim(),
                 CreatedAt = createdAt
@@ -161,5 +181,41 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
 
             eventNews.Localizations.Add(localization);
         }
+
+        return Result.Ok();
+    }
+
+    private async Task<int> SaveEventNewsAsync(
+        EventNewsEntity eventNews,
+        string? titleForSlug,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= MaxSlugSaveAttempts; attempt++)
+        {
+            try
+            {
+                return await _repositoryWrapper.SaveChangesAsync();
+            }
+            catch (DbUpdateException exception) when (
+                attempt < MaxSlugSaveAttempts
+                && !string.IsNullOrWhiteSpace(titleForSlug)
+                && IsSlugUniqueConstraintException(exception))
+            {
+                eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
+                    eventNews.Id,
+                    titleForSlug,
+                    cancellationToken);
+            }
+        }
+
+        return 0;
+    }
+
+    private static bool IsSlugUniqueConstraintException(DbUpdateException exception)
+    {
+        return exception.IsUniqueConstraintException()
+               && exception.InnerException?.Message.Contains(
+                   SlugIndexName,
+                   StringComparison.OrdinalIgnoreCase) == true;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
@@ -1,0 +1,165 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Interfaces.SlugService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+
+public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Result<EventNewsDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly ISlugService _slugService;
+
+    public CreateEventNewsHandler(
+        IMapper mapper,
+        IRepositoryWrapper repositoryWrapper,
+        ISlugService slugService)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+        _slugService = slugService;
+    }
+
+    public async Task<Result<EventNewsDto>> Handle(
+        CreateEventNewsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var categoriesResult = await CategoryValidationHelper.ValidateAndGetEventNewsCategoriesAsync(
+            _repositoryWrapper,
+            request.CreateEventNewsDto.CategoryIds);
+
+        if (categoriesResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(categoriesResult.Errors);
+        }
+
+        var previewImageResult = await ImageValidationHelper.ValidateAndGetImageAsync(
+            _repositoryWrapper,
+            request.CreateEventNewsDto.PreviewImageId);
+
+        if (previewImageResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(previewImageResult.Errors);
+        }
+
+        var backgroundImageResult = await ImageValidationHelper.ValidateAndGetImageAsync(
+            _repositoryWrapper,
+            request.CreateEventNewsDto.BackgroundImageId);
+
+        if (backgroundImageResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(backgroundImageResult.Errors);
+        }
+
+        var languagesResult = await ValidateAndGetLanguagesAsync(request.CreateEventNewsDto.Localizations);
+
+        if (languagesResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(languagesResult.Errors);
+        }
+
+        var eventNews = _mapper.Map<EventNewsEntity>(request.CreateEventNewsDto);
+        var now = DateTimeOffset.UtcNow;
+        eventNews.CreatedAt = now;
+        eventNews.PreviewImage = previewImageResult.Value;
+        eventNews.BackgroundImage = backgroundImageResult.Value;
+
+        AddCategories(eventNews, categoriesResult.Value);
+        AddLocalizations(eventNews, request.CreateEventNewsDto.Localizations, languagesResult.Value, now);
+
+        var titleForSlug = eventNews.Localizations
+            .Select(localization => localization.Title)
+            .FirstOrDefault(title => !string.IsNullOrWhiteSpace(title));
+
+        if (!string.IsNullOrWhiteSpace(titleForSlug))
+        {
+            eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
+                eventNews.Id,
+                titleForSlug,
+                cancellationToken);
+        }
+
+        await _repositoryWrapper.EventNewsRepository.CreateAsync(eventNews);
+
+        if (await _repositoryWrapper.SaveChangesAsync() > 0)
+        {
+            return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
+        }
+
+        return Result.Fail<EventNewsDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(EventNewsEntity)));
+    }
+
+    private async Task<Result<IReadOnlyDictionary<long, LocalizationLanguage>>> ValidateAndGetLanguagesAsync(
+        IEnumerable<CreateEventNewsLocalizationDto> localizations)
+    {
+        var languageIds = localizations
+            .Select(localization => localization.LanguageId)
+            .Where(id => id > 0)
+            .Distinct()
+            .ToList();
+
+        if (languageIds.Count == 0)
+        {
+            return Result.Ok<IReadOnlyDictionary<long, LocalizationLanguage>>(
+                new Dictionary<long, LocalizationLanguage>());
+        }
+
+        var languages = (await _repositoryWrapper.LocalizationLanguagesRepository.GetAllAsync(
+            new QueryOptions<LocalizationLanguage>
+            {
+                Filter = language => languageIds.Contains(language.Id),
+                AsNoTracking = false
+            })).ToList();
+
+        var languagesById = languages.ToDictionary(language => language.Id);
+        var missingIds = languageIds.Where(id => !languagesById.ContainsKey(id)).ToList();
+
+        return missingIds.Count == 0
+            ? Result.Ok<IReadOnlyDictionary<long, LocalizationLanguage>>(languagesById)
+            : Result.Fail<IReadOnlyDictionary<long, LocalizationLanguage>>(
+                ErrorMessagesConstants.NotFound(missingIds, typeof(LocalizationLanguage)));
+    }
+
+    private static void AddCategories(EventNewsEntity eventNews, ICollection<EventNewsCategory> categories)
+    {
+        foreach (var category in categories)
+        {
+            eventNews.Categories.Add(category);
+        }
+    }
+
+    private static void AddLocalizations(
+        EventNewsEntity eventNews,
+        IEnumerable<CreateEventNewsLocalizationDto> localizationDtos,
+        IReadOnlyDictionary<long, LocalizationLanguage> languagesById,
+        DateTimeOffset createdAt)
+    {
+        foreach (var localizationDto in localizationDtos)
+        {
+            if (string.IsNullOrWhiteSpace(localizationDto.Title))
+            {
+                continue;
+            }
+
+            var localization = new EventNewsLocalization
+            {
+                LanguageId = localizationDto.LanguageId,
+                Language = languagesById[localizationDto.LanguageId],
+                Title = localizationDto.Title!.Trim(),
+                Description = localizationDto.Description?.Trim(),
+                CreatedAt = createdAt
+            };
+
+            eventNews.Localizations.Add(localization);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
@@ -17,7 +17,6 @@ namespace VictoryCenter.BLL.Commands.Admin.EventNews.Create;
 public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Result<EventNewsDto>>
 {
     private const int MaxSlugSaveAttempts = 3;
-    private const string SlugIndexName = "IX_EventNews_Slug";
 
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
@@ -199,8 +198,17 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
             catch (DbUpdateException exception) when (
                 attempt < MaxSlugSaveAttempts
                 && !string.IsNullOrWhiteSpace(titleForSlug)
-                && IsSlugUniqueConstraintException(exception))
+                && exception.IsUniqueConstraintException())
             {
+                var slugAlreadyExists = !string.IsNullOrWhiteSpace(eventNews.Slug)
+                    && await _repositoryWrapper.EventNewsRepository.ExistsAsync(
+                        existingEventNews => existingEventNews.Slug == eventNews.Slug);
+
+                if (!slugAlreadyExists)
+                {
+                    throw;
+                }
+
                 eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
                     eventNews.Id,
                     titleForSlug,
@@ -209,13 +217,5 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
         }
 
         return 0;
-    }
-
-    private static bool IsSlugUniqueConstraintException(DbUpdateException exception)
-    {
-        return exception.IsUniqueConstraintException()
-               && exception.InnerException?.Message.Contains(
-                   SlugIndexName,
-                   StringComparison.OrdinalIgnoreCase) == true;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Create/CreateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Create/CreateHippotherapyProgramHandler.cs
@@ -42,7 +42,7 @@ public class CreateHippotherapyProgramHandler
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
             var categoriesResult = await CategoryValidationHelper.ValidateAndGetCategoriesAsync(
-                _repositoryWrapper,
+                _repositoryWrapper.HippotherapyProgramCategoriesRepository,
                 request.CreateProgramDto.CategoryIds);
 
             if (categoriesResult.IsFailed)

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -68,7 +68,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
             }
 
             var newCategoriesResult = await CategoryValidationHelper.ValidateAndGetCategoriesAsync(
-                _repositoryWrapper,
+                _repositoryWrapper.HippotherapyProgramCategoriesRepository,
                 request.UpdateProgramDto.CategoryIds);
 
             if (newCategoriesResult.IsFailed)

--- a/VictoryCenter/VictoryCenter.BLL/Constants/EventNewsConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/EventNewsConstants.cs
@@ -4,9 +4,9 @@ public static class EventNewsConstants
 {
     public const int PublishedTakeMinValue = 1;
     public const int PublishedTakeMaxValue = 100;
-    public const int TitleMinLength = 5;
-    public const int TitleMaxLength = 90;
+    public const int TitleMinLength = 10;
+    public const int TitleMaxLength = 60;
     public const int DescriptionMinLength = 10;
-    public const int DescriptionMaxLength = 400;
+    public const int DescriptionMaxLength = 140;
     public const int ResourceMaxLength = 150;
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/CreateEventNewsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/CreateEventNewsDto.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record CreateEventNewsDto
+{
+    public string? Resource { get; init; }
+    public DateTimeOffset? PublishedAt { get; init; }
+    public Status Status { get; init; }
+    public long? PreviewImageId { get; init; }
+    public long? BackgroundImageId { get; init; }
+    public List<long> CategoryIds { get; init; } = [];
+    public List<CreateEventNewsLocalizationDto> Localizations { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/CreateEventNewsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/CreateEventNewsLocalizationDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record CreateEventNewsLocalizationDto
+{
+    public long LanguageId { get; init; }
+    public string? Title { get; init; }
+    public string? Description { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsCategoryShortDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsCategoryShortDto.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record EventNewsCategoryShortDto
+{
+    public long Id { get; init; }
+    public string Name { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsDto.cs
@@ -1,0 +1,17 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record EventNewsDto
+{
+    public long Id { get; init; }
+    public string? Slug { get; init; }
+    public string? Resource { get; init; }
+    public DateTimeOffset? PublishedAt { get; init; }
+    public Status Status { get; init; }
+    public ImageDto? PreviewImage { get; init; }
+    public ImageDto? BackgroundImage { get; init; }
+    public List<EventNewsCategoryShortDto> Categories { get; init; } = [];
+    public List<EventNewsLocalizationDto> Localizations { get; init; } = [];
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsLocalizationDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record EventNewsLocalizationDto
+{
+    public LocalizationInfoDto Language { get; init; } = null!;
+    public TranslationStatus TranslationStatus { get; init; }
+    public string Title { get; init; } = null!;
+    public string? Description { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/CategoryValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/CategoryValidationHelper.cs
@@ -32,4 +32,34 @@ public static class CategoryValidationHelper
 
         return Result.Ok<ICollection<HippotherapyProgramCategory>>(retrievedCategoriesList);
     }
+
+    public static async Task<Result<ICollection<EventNewsCategory>>> ValidateAndGetEventNewsCategoriesAsync(
+        IRepositoryWrapper repositoryWrapper,
+        IEnumerable<long> requestedCategoryIds)
+    {
+        var requestedIdsList = requestedCategoryIds.ToList();
+
+        if (requestedIdsList.Count == 0)
+        {
+            return Result.Ok<ICollection<EventNewsCategory>>([]);
+        }
+
+        var retrievedCategoriesList = (await repositoryWrapper
+            .EventNewsCategoryRepository.GetAllAsync(new QueryOptions<EventNewsCategory>
+            {
+                Filter = category => requestedIdsList.Contains(category.Id),
+                AsNoTracking = false
+            })).ToList();
+
+        if (retrievedCategoriesList.Count != requestedIdsList.Count)
+        {
+            var existingIds = retrievedCategoriesList.Select(c => c.Id).ToList();
+            var missingIds = requestedIdsList.Except(existingIds).ToList();
+
+            return Result.Fail<ICollection<EventNewsCategory>>(
+                ErrorMessagesConstants.NotFound(missingIds, typeof(EventNewsCategory)));
+        }
+
+        return Result.Ok<ICollection<EventNewsCategory>>(retrievedCategoriesList);
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/CategoryValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/CategoryValidationHelper.cs
@@ -1,6 +1,6 @@
 using FluentResults;
 using VictoryCenter.BLL.Constants;
-using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Data.BaseEntity;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -8,58 +8,33 @@ namespace VictoryCenter.BLL.Helpers;
 
 public static class CategoryValidationHelper
 {
-    public static async Task<Result<ICollection<HippotherapyProgramCategory>>> ValidateAndGetCategoriesAsync(
-        IRepositoryWrapper repositoryWrapper,
+    public static async Task<Result<ICollection<TCategory>>> ValidateAndGetCategoriesAsync<TCategory>(
+        IRepositoryBase<TCategory> categoryRepository,
         IEnumerable<long> requestedCategoryIds)
-    {
-        var requestedIdsList = requestedCategoryIds.ToList();
-
-        var retrievedCategoriesList = (await repositoryWrapper
-            .HippotherapyProgramCategoriesRepository.GetAllAsync(new QueryOptions<HippotherapyProgramCategory>
-            {
-                Filter = category => requestedIdsList.Contains(category.Id),
-                AsNoTracking = false
-            })).ToList();
-
-        if (retrievedCategoriesList.Count != requestedIdsList.Count)
-        {
-            var existingIds = retrievedCategoriesList.Select(c => c.Id).ToList();
-            var missingIds = requestedIdsList.Except(existingIds).ToList();
-
-            return Result.Fail<ICollection<HippotherapyProgramCategory>>(
-                ErrorMessagesConstants.NotFound(string.Join(", ", missingIds), typeof(HippotherapyProgramCategory)));
-        }
-
-        return Result.Ok<ICollection<HippotherapyProgramCategory>>(retrievedCategoriesList);
-    }
-
-    public static async Task<Result<ICollection<EventNewsCategory>>> ValidateAndGetEventNewsCategoriesAsync(
-        IRepositoryWrapper repositoryWrapper,
-        IEnumerable<long> requestedCategoryIds)
+        where TCategory : BaseEntity
     {
         var requestedIdsList = requestedCategoryIds.ToList();
 
         if (requestedIdsList.Count == 0)
         {
-            return Result.Ok<ICollection<EventNewsCategory>>([]);
+            return Result.Ok<ICollection<TCategory>>([]);
         }
 
-        var retrievedCategoriesList = (await repositoryWrapper
-            .EventNewsCategoryRepository.GetAllAsync(new QueryOptions<EventNewsCategory>
-            {
-                Filter = category => requestedIdsList.Contains(category.Id),
-                AsNoTracking = false
-            })).ToList();
+        var retrievedCategoriesList = (await categoryRepository.GetAllAsync(new QueryOptions<TCategory>
+        {
+            Filter = category => requestedIdsList.Contains(category.Id),
+            AsNoTracking = false
+        })).ToList();
 
         if (retrievedCategoriesList.Count != requestedIdsList.Count)
         {
             var existingIds = retrievedCategoriesList.Select(c => c.Id).ToList();
             var missingIds = requestedIdsList.Except(existingIds).ToList();
 
-            return Result.Fail<ICollection<EventNewsCategory>>(
-                ErrorMessagesConstants.NotFound(missingIds, typeof(EventNewsCategory)));
+            return Result.Fail<ICollection<TCategory>>(
+                ErrorMessagesConstants.NotFound(missingIds, typeof(TCategory)));
         }
 
-        return Result.Ok<ICollection<EventNewsCategory>>(retrievedCategoriesList);
+        return Result.Ok<ICollection<TCategory>>(retrievedCategoriesList);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/SlugService/ISlugService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/SlugService/ISlugService.cs
@@ -8,5 +8,7 @@ public interface ISlugService
 
     Task<string> GenerateUniqueHippotherapyProgramSlugAsync(long id, string programName, CancellationToken cancellationToken = default);
 
+    Task<string> GenerateUniqueEventNewsSlugAsync(long id, string title, CancellationToken cancellationToken = default);
+
     Task<HippotherapyProgram?> GetHippotherapyProgramBySlugAsync(string slug, CancellationToken cancellationToken = default);
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/EventNews/EventNewsProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/EventNews/EventNewsProfile.cs
@@ -1,8 +1,11 @@
 using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
 using VictoryCenter.BLL.DTOs.Public.EventNews;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
+using AdminEventNewsCategoryDto = VictoryCenter.BLL.DTOs.Admin.EventNews.EventNewsCategoryShortDto;
 using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+using PublicEventNewsCategoryDto = VictoryCenter.BLL.DTOs.Public.EventNews.EventNewsCategoryDto;
 
 namespace VictoryCenter.BLL.Mapping.EventNews;
 
@@ -11,10 +14,24 @@ public class EventNewsProfile : Profile
     public EventNewsProfile()
     {
         CreateMap<EventNewsEntity, PublishedEventNewsDto>();
+        CreateMap<EventNewsEntity, EventNewsDto>();
 
-        CreateMap<EventNewsCategory, EventNewsCategoryDto>();
+        CreateMap<CreateEventNewsDto, EventNewsEntity>()
+            .ForMember(dest => dest.Slug, opt => opt.Ignore())
+            .ForMember(dest => dest.Categories, opt => opt.Ignore())
+            .ForMember(dest => dest.PreviewImage, opt => opt.Ignore())
+            .ForMember(dest => dest.BackgroundImage, opt => opt.Ignore())
+            .ForMember(dest => dest.Localizations, opt => opt.Ignore())
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.CreatedAt, opt => opt.Ignore());
+
+        CreateMap<EventNewsCategory, PublicEventNewsCategoryDto>();
+        CreateMap<EventNewsCategory, AdminEventNewsCategoryDto>();
 
         CreateMap<EventNewsLocalization, PublishedEventNewsLocalizationDto>()
+            .ForMember(dest => dest.Language, opt => opt.MapFrom(src => src.Language));
+
+        CreateMap<EventNewsLocalization, EventNewsLocalizationDto>()
             .ForMember(dest => dest.Language, opt => opt.MapFrom(src => src.Language));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Services/SlugService/SlugService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/SlugService/SlugService.cs
@@ -4,6 +4,7 @@ using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
 
 namespace VictoryCenter.BLL.Services.SlugService;
 
@@ -39,6 +40,40 @@ public class SlugService : ISlugService
             .Where(s => !string.IsNullOrWhiteSpace(s))
             .Select(s => s!)
             .Where(s => s.StartsWith(baseSlug, StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (existingSlugs.Count == 0)
+        {
+            return baseSlug;
+        }
+
+        while (existingSlugs.Contains(currentSlug))
+        {
+            currentSlug = $"{baseSlug}-{i}";
+            i++;
+        }
+
+        return currentSlug;
+    }
+
+    public async Task<string> GenerateUniqueEventNewsSlugAsync(long id, string title, CancellationToken cancellationToken = default)
+    {
+        var baseSlug = GenerateSlug(title);
+        var currentSlug = baseSlug;
+        var i = 1;
+
+        var eventNewsItems = await _repositoryWrapper.EventNewsRepository.GetAllAsync(
+            new QueryOptions<EventNewsEntity>
+            {
+                AsNoTracking = true,
+                Filter = eventNews => eventNews.Slug != null && eventNews.Id != id,
+            });
+
+        var existingSlugs = eventNewsItems
+            .Select(eventNews => eventNews.Slug)
+            .Where(slug => !string.IsNullOrWhiteSpace(slug))
+            .Select(slug => slug!)
+            .Where(slug => slug.StartsWith(baseSlug, StringComparison.OrdinalIgnoreCase))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         if (existingSlugs.Count == 0)

--- a/VictoryCenter/VictoryCenter.BLL/Services/SlugService/SlugService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/SlugService/SlugService.cs
@@ -4,7 +4,6 @@ using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
-using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
 
 namespace VictoryCenter.BLL.Services.SlugService;
 
@@ -62,18 +61,10 @@ public class SlugService : ISlugService
         var currentSlug = baseSlug;
         var i = 1;
 
-        var eventNewsItems = await _repositoryWrapper.EventNewsRepository.GetAllAsync(
-            new QueryOptions<EventNewsEntity>
-            {
-                AsNoTracking = true,
-                Filter = eventNews => eventNews.Slug != null && eventNews.Id != id,
-            });
-
-        var existingSlugs = eventNewsItems
-            .Select(eventNews => eventNews.Slug)
-            .Where(slug => !string.IsNullOrWhiteSpace(slug))
-            .Select(slug => slug!)
-            .Where(slug => slug.StartsWith(baseSlug, StringComparison.OrdinalIgnoreCase))
+        var existingSlugs = (await _repositoryWrapper.EventNewsRepository.GetSlugsStartingWithAsync(
+                id,
+                baseSlug,
+                cancellationToken))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         if (existingSlugs.Count == 0)

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/BaseEventNewsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/BaseEventNewsValidator.cs
@@ -48,7 +48,7 @@ public class BaseEventNewsValidator : AbstractValidator<CreateEventNewsDto>
             .When(dto => dto.Status == Status.Published);
 
         RuleFor(dto => dto.CategoryIds)
-            .Must(categoryIds => categoryIds.Distinct().Count() == categoryIds.Count)
+            .Must(categoryIds => categoryIds is null || categoryIds.Distinct().Count() == categoryIds.Count)
             .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateEventNewsDto.CategoryIds)));
 
         RuleForEach(dto => dto.CategoryIds)
@@ -68,8 +68,13 @@ public class BaseEventNewsValidator : AbstractValidator<CreateEventNewsDto>
             .Custom(ValidateLocalizations);
     }
 
-    private static bool HaveUniqueLanguageIds(ICollection<CreateEventNewsLocalizationDto> localizations)
+    private static bool HaveUniqueLanguageIds(ICollection<CreateEventNewsLocalizationDto>? localizations)
     {
+        if (localizations is null)
+        {
+            return true;
+        }
+
         var languageIds = localizations
             .Where(localization => localization is not null && IsMeaningful(localization))
             .Select(localization => localization.LanguageId)
@@ -79,9 +84,14 @@ public class BaseEventNewsValidator : AbstractValidator<CreateEventNewsDto>
     }
 
     private static void ValidateLocalizations(
-        ICollection<CreateEventNewsLocalizationDto> localizations,
+        ICollection<CreateEventNewsLocalizationDto>? localizations,
         ValidationContext<CreateEventNewsDto> context)
     {
+        if (localizations is null)
+        {
+            return;
+        }
+
         var isPublished = context.InstanceToValidate.Status == Status.Published;
         var index = 0;
 

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/BaseEventNewsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/BaseEventNewsValidator.cs
@@ -1,0 +1,199 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Validators.EventNews;
+
+public class BaseEventNewsValidator : AbstractValidator<CreateEventNewsDto>
+{
+    public BaseEventNewsValidator()
+    {
+        RuleFor(dto => dto.Status)
+            .IsInEnum()
+            .WithMessage(ErrorMessagesConstants.UnknownStatusValue);
+
+        RuleFor(dto => dto.Resource)
+            .MaximumLength(EventNewsConstants.ResourceMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateEventNewsDto.Resource),
+                EventNewsConstants.ResourceMaxLength))
+            .When(dto => !string.IsNullOrWhiteSpace(dto.Resource));
+
+        RuleFor(dto => dto.PublishedAt)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsDto.PublishedAt)))
+            .When(dto => dto.Status == Status.Published);
+
+        RuleFor(dto => dto.PreviewImageId)
+            .NotNull()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsDto.PreviewImageId)))
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateEventNewsDto.PreviewImageId)))
+            .When(dto => dto.Status == Status.Published);
+
+        RuleFor(dto => dto.PreviewImageId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateEventNewsDto.PreviewImageId)))
+            .When(dto => dto.PreviewImageId.HasValue);
+
+        RuleFor(dto => dto.BackgroundImageId)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateEventNewsDto.BackgroundImageId)))
+            .When(dto => dto.BackgroundImageId.HasValue);
+
+        RuleFor(dto => dto.CategoryIds)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsDto.CategoryIds)))
+            .When(dto => dto.Status == Status.Published);
+
+        RuleFor(dto => dto.CategoryIds)
+            .Must(categoryIds => categoryIds.Distinct().Count() == categoryIds.Count)
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateEventNewsDto.CategoryIds)));
+
+        RuleForEach(dto => dto.CategoryIds)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateEventNewsDto.CategoryIds)));
+
+        RuleFor(dto => dto.Localizations)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsDto.Localizations)))
+            .When(dto => dto.Status == Status.Published);
+
+        RuleFor(dto => dto.Localizations)
+            .Must(HaveUniqueLanguageIds)
+            .WithMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateEventNewsDto.Localizations)));
+
+        RuleFor(dto => dto.Localizations)
+            .Custom(ValidateLocalizations);
+    }
+
+    private static bool HaveUniqueLanguageIds(ICollection<CreateEventNewsLocalizationDto> localizations)
+    {
+        var languageIds = localizations
+            .Where(localization => localization is not null && IsMeaningful(localization))
+            .Select(localization => localization.LanguageId)
+            .ToList();
+
+        return languageIds.Distinct().Count() == languageIds.Count;
+    }
+
+    private static void ValidateLocalizations(
+        ICollection<CreateEventNewsLocalizationDto> localizations,
+        ValidationContext<CreateEventNewsDto> context)
+    {
+        var isPublished = context.InstanceToValidate.Status == Status.Published;
+        var index = 0;
+
+        foreach (var localization in localizations)
+        {
+            var prefix = $"{nameof(CreateEventNewsDto.Localizations)}[{index}]";
+
+            if (localization is null)
+            {
+                context.AddFailure(prefix, ErrorMessagesConstants.CollectionCannotContainNullElements(nameof(CreateEventNewsDto.Localizations)));
+                index++;
+                continue;
+            }
+
+            if (!isPublished && !IsMeaningful(localization))
+            {
+                index++;
+                continue;
+            }
+
+            if (localization.LanguageId <= 0)
+            {
+                context.AddFailure(
+                    $"{prefix}.{nameof(CreateEventNewsLocalizationDto.LanguageId)}",
+                    ErrorMessagesConstants.PropertyMustBePositive(nameof(CreateEventNewsLocalizationDto.LanguageId)));
+            }
+
+            ValidateTitle(localization, context, prefix, isPublished);
+            ValidateDescription(localization, context, prefix, isPublished);
+
+            index++;
+        }
+    }
+
+    private static void ValidateTitle(
+        CreateEventNewsLocalizationDto localization,
+        ValidationContext<CreateEventNewsDto> context,
+        string prefix,
+        bool isPublished)
+    {
+        if (string.IsNullOrWhiteSpace(localization.Title))
+        {
+            if (isPublished || !string.IsNullOrWhiteSpace(localization.Description))
+            {
+                context.AddFailure(
+                    $"{prefix}.{nameof(CreateEventNewsLocalizationDto.Title)}",
+                    ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsLocalizationDto.Title)));
+            }
+
+            return;
+        }
+
+        if (localization.Title.Length < EventNewsConstants.TitleMinLength)
+        {
+            context.AddFailure(
+                $"{prefix}.{nameof(CreateEventNewsLocalizationDto.Title)}",
+                ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                    nameof(CreateEventNewsLocalizationDto.Title),
+                    EventNewsConstants.TitleMinLength));
+        }
+
+        if (localization.Title.Length > EventNewsConstants.TitleMaxLength)
+        {
+            context.AddFailure(
+                $"{prefix}.{nameof(CreateEventNewsLocalizationDto.Title)}",
+                ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                    nameof(CreateEventNewsLocalizationDto.Title),
+                    EventNewsConstants.TitleMaxLength));
+        }
+    }
+
+    private static void ValidateDescription(
+        CreateEventNewsLocalizationDto localization,
+        ValidationContext<CreateEventNewsDto> context,
+        string prefix,
+        bool isPublished)
+    {
+        if (string.IsNullOrWhiteSpace(localization.Description))
+        {
+            if (isPublished)
+            {
+                context.AddFailure(
+                    $"{prefix}.{nameof(CreateEventNewsLocalizationDto.Description)}",
+                    ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsLocalizationDto.Description)));
+            }
+
+            return;
+        }
+
+        if (localization.Description.Length < EventNewsConstants.DescriptionMinLength)
+        {
+            context.AddFailure(
+                $"{prefix}.{nameof(CreateEventNewsLocalizationDto.Description)}",
+                ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                    nameof(CreateEventNewsLocalizationDto.Description),
+                    EventNewsConstants.DescriptionMinLength));
+        }
+
+        if (localization.Description.Length > EventNewsConstants.DescriptionMaxLength)
+        {
+            context.AddFailure(
+                $"{prefix}.{nameof(CreateEventNewsLocalizationDto.Description)}",
+                ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                    nameof(CreateEventNewsLocalizationDto.Description),
+                    EventNewsConstants.DescriptionMaxLength));
+        }
+    }
+
+    private static bool IsMeaningful(CreateEventNewsLocalizationDto localization)
+    {
+        return localization.LanguageId > 0
+               || !string.IsNullOrWhiteSpace(localization.Title)
+               || !string.IsNullOrWhiteSpace(localization.Description);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/CreateEventNewsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/CreateEventNewsValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+
+namespace VictoryCenter.BLL.Validators.EventNews;
+
+public class CreateEventNewsValidator : AbstractValidator<CreateEventNewsCommand>
+{
+    public CreateEventNewsValidator(BaseEventNewsValidator baseEventNewsValidator)
+    {
+        RuleFor(command => command.CreateEventNewsDto)
+            .NotNull()
+            .SetValidator(baseEventNewsValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/EventNews/IEventNewsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/EventNews/IEventNewsRepository.cs
@@ -5,4 +5,8 @@ namespace VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 
 public interface IEventNewsRepository : IRepositoryBase<EventNewsEntity>
 {
+    Task<IReadOnlyCollection<string>> GetSlugsStartingWithAsync(
+        long excludedId,
+        string slugPrefix,
+        CancellationToken cancellationToken = default);
 }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/EventNews/EventNewsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/EventNews/EventNewsRepository.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using VictoryCenter.DAL.Data;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 using VictoryCenter.DAL.Repositories.Realizations.Base;
@@ -10,5 +11,20 @@ public class EventNewsRepository : RepositoryBase<EventNewsEntity>, IEventNewsRe
     public EventNewsRepository(VictoryCenterDbContext context)
         : base(context)
     {
+    }
+
+    public async Task<IReadOnlyCollection<string>> GetSlugsStartingWithAsync(
+        long excludedId,
+        string slugPrefix,
+        CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<EventNewsEntity>()
+            .AsNoTracking()
+            .Where(eventNews =>
+                eventNews.Id != excludedId
+                && eventNews.Slug != null
+                && eventNews.Slug.StartsWith(slugPrefix))
+            .Select(eventNews => eventNews.Slug!)
+            .ToListAsync(cancellationToken);
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Create/CreateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Create/CreateEventNewsTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Text;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.DTOs.Public.EventNews;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.EventNews.Create;
+
+public class CreateEventNewsTests : BaseTestClass
+{
+    private const string EndpointUri = "/api/EventNews/";
+
+    public CreateEventNewsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreatePublishedEventNews_ShouldCreateEventNews()
+    {
+        var createEventNewsDto = PublishedDto("Published Event Title");
+        var serializedDto = JsonConvert.SerializeObject(createEventNewsDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            EndpointUri,
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        response.EnsureSuccessStatusCode();
+        var responseString = await response.Content.ReadAsStringAsync();
+        EventNewsDto? responseContent = JsonConvert.DeserializeObject<EventNewsDto>(responseString);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(responseContent);
+        Assert.Equal(Status.Published, responseContent.Status);
+        Assert.NotNull(responseContent.Slug);
+        Assert.Single(responseContent.Categories);
+        Assert.Single(responseContent.Localizations);
+    }
+
+    [Fact]
+    public async Task CreateDraftEventNews_ShouldCreateEventNews()
+    {
+        var createEventNewsDto = new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = "Draft Event Title"
+                },
+            ]
+        };
+
+        var serializedDto = JsonConvert.SerializeObject(createEventNewsDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            EndpointUri,
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        response.EnsureSuccessStatusCode();
+        var responseString = await response.Content.ReadAsStringAsync();
+        EventNewsDto? responseContent = JsonConvert.DeserializeObject<EventNewsDto>(responseString);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(responseContent);
+        Assert.Equal(Status.Draft, responseContent.Status);
+        Assert.NotNull(responseContent.Slug);
+    }
+
+    [Fact]
+    public async Task CreatePublishedEventNews_ShouldNotCreateEventNews_WhenRequiredFieldsAreMissing()
+    {
+        var createEventNewsDto = new CreateEventNewsDto
+        {
+            Status = Status.Published
+        };
+
+        var serializedDto = JsonConvert.SerializeObject(createEventNewsDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            EndpointUri,
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatedDraftEventNews_ShouldNotBeReturnedByPublicPublishedEndpoint()
+    {
+        var createEventNewsDto = new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = "Private Draft Title"
+                },
+            ]
+        };
+
+        var serializedDto = JsonConvert.SerializeObject(createEventNewsDto);
+
+        HttpResponseMessage createResponse = await Fixture.HttpClient.PostAsync(
+            EndpointUri,
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        createResponse.EnsureSuccessStatusCode();
+        var createResponseString = await createResponse.Content.ReadAsStringAsync();
+        EventNewsDto? createdEventNews = JsonConvert.DeserializeObject<EventNewsDto>(createResponseString);
+
+        HttpResponseMessage publicResponse = await Fixture.HttpClient.GetAsync("/api/EventNews/published");
+
+        publicResponse.EnsureSuccessStatusCode();
+        var publicResponseString = await publicResponse.Content.ReadAsStringAsync();
+        List<PublishedEventNewsDto>? publishedEventNews = JsonConvert.DeserializeObject<List<PublishedEventNewsDto>>(publicResponseString);
+
+        Assert.NotNull(createdEventNews);
+        Assert.NotNull(publishedEventNews);
+        Assert.DoesNotContain(publishedEventNews, eventNews => eventNews.Slug == createdEventNews.Slug);
+    }
+
+    private static CreateEventNewsDto PublishedDto(string title)
+    {
+        return new CreateEventNewsDto
+        {
+            Status = Status.Published,
+            PublishedAt = DateTimeOffset.UtcNow,
+            PreviewImageId = 1,
+            CategoryIds = [1],
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = title,
+                    Description = "Valid event description"
+                },
+            ]
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Create/CreateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Create/CreateEventNewsTests.cs
@@ -73,6 +73,61 @@ public class CreateEventNewsTests : BaseTestClass
     }
 
     [Fact]
+    public async Task CreateDraftEventNews_ShouldIgnoreLocalizationWithoutContent()
+    {
+        var createEventNewsDto = new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            Localizations = [new CreateEventNewsLocalizationDto { LanguageId = 1 }]
+        };
+
+        var serializedDto = JsonConvert.SerializeObject(createEventNewsDto);
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            EndpointUri,
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        response.EnsureSuccessStatusCode();
+        var responseString = await response.Content.ReadAsStringAsync();
+        EventNewsDto? responseContent = JsonConvert.DeserializeObject<EventNewsDto>(responseString);
+
+        Assert.NotNull(responseContent);
+        Assert.Null(responseContent.Slug);
+        Assert.Empty(responseContent.Localizations);
+    }
+
+    [Fact]
+    public async Task CreateDraftEventNews_ShouldIncrementSlug_WhenSlugAlreadyExists()
+    {
+        var firstDto = new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = "Duplicate Slug Review Test"
+                },
+            ]
+        };
+
+        var secondDto = firstDto with { };
+        HttpResponseMessage firstResponse = await PostAsync(firstDto);
+        HttpResponseMessage secondResponse = await PostAsync(secondDto);
+
+        firstResponse.EnsureSuccessStatusCode();
+        secondResponse.EnsureSuccessStatusCode();
+        var firstContent = JsonConvert.DeserializeObject<EventNewsDto>(
+            await firstResponse.Content.ReadAsStringAsync());
+        var secondContent = JsonConvert.DeserializeObject<EventNewsDto>(
+            await secondResponse.Content.ReadAsStringAsync());
+
+        Assert.NotNull(firstContent);
+        Assert.NotNull(secondContent);
+        Assert.Equal($"{firstContent.Slug}-1", secondContent.Slug);
+    }
+
+    [Fact]
     public async Task CreatePublishedEventNews_ShouldNotCreateEventNews_WhenRequiredFieldsAreMissing()
     {
         var createEventNewsDto = new CreateEventNewsDto
@@ -145,5 +200,13 @@ public class CreateEventNewsTests : BaseTestClass
                 },
             ]
         };
+    }
+
+    private async Task<HttpResponseMessage> PostAsync(CreateEventNewsDto dto)
+    {
+        var serializedDto = JsonConvert.SerializeObject(dto);
+        return await Fixture.HttpClient.PostAsync(
+            EndpointUri,
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/RepositoryTests/EventNews/EventNewsRepositoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/RepositoryTests/EventNews/EventNewsRepositoryTests.cs
@@ -1,0 +1,64 @@
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Realizations.EventNews;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.IntegrationTests.RepositoryTests.EventNews;
+
+public class EventNewsRepositoryTests : BaseTestClass
+{
+    public EventNewsRepositoryTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetSlugsStartingWithAsync_ShouldExcludeSpecifiedEntity()
+    {
+        var slugPrefix = $"excluded-id-{Guid.NewGuid():N}";
+        var excludedEventNews = CreateEventNews(slugPrefix);
+        var matchingEventNews = CreateEventNews($"{slugPrefix}-1");
+        var nonMatchingEventNews = CreateEventNews($"another-{Guid.NewGuid():N}");
+        Fixture.DbContext.EventNews.AddRange(
+            excludedEventNews,
+            matchingEventNews,
+            nonMatchingEventNews);
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+        var repository = new EventNewsRepository(Fixture.DbContext);
+
+        var result = await repository.GetSlugsStartingWithAsync(
+            excludedEventNews.Id,
+            slugPrefix,
+            CancellationToken.None);
+
+        Assert.DoesNotContain(excludedEventNews.Slug!, result);
+        Assert.Contains(matchingEventNews.Slug!, result);
+        Assert.DoesNotContain(nonMatchingEventNews.Slug!, result);
+    }
+
+    [Fact]
+    public async Task GetSlugsStartingWithAsync_CancelledToken_ShouldCancelQuery()
+    {
+        var repository = new EventNewsRepository(Fixture.DbContext);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            repository.GetSlugsStartingWithAsync(
+                0,
+                "event-news",
+                cancellationTokenSource.Token));
+    }
+
+    private static EventNewsEntity CreateEventNews(string slug)
+    {
+        return new EventNewsEntity
+        {
+            Slug = slug,
+            Status = Status.Draft,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/CategoryValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/CategoryValidationHelperTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
-using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -11,17 +10,11 @@ namespace VictoryCenter.UnitTests.HelperTests;
 
 public class CategoryValidationHelperTests
 {
-    private readonly Mock<IRepositoryWrapper> _wrapperMock;
     private readonly Mock<IHippotherapyProgramCategoriesRepository> _categoryRepoMock;
 
     public CategoryValidationHelperTests()
     {
-        _wrapperMock = new Mock<IRepositoryWrapper>();
         _categoryRepoMock = new Mock<IHippotherapyProgramCategoriesRepository>();
-
-        _wrapperMock
-            .SetupGet(w => w.HippotherapyProgramCategoriesRepository)
-            .Returns(_categoryRepoMock.Object);
     }
 
     [Fact]
@@ -42,7 +35,7 @@ public class CategoryValidationHelperTests
 
         // Act
         Result<ICollection<HippotherapyProgramCategory>> result =
-            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_wrapperMock.Object, requestedIds);
+            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_categoryRepoMock.Object, requestedIds);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -71,13 +64,11 @@ public class CategoryValidationHelperTests
             .Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
             .ReturnsAsync(foundCategories);
 
-        var expectedMessage = ErrorMessagesConstants.NotFound(
-            "2, 4",
-            typeof(HippotherapyProgramCategory));
+        var expectedMessage = ErrorMessagesConstants.NotFound([2, 4], typeof(HippotherapyProgramCategory));
 
         // Act
         Result<ICollection<HippotherapyProgramCategory>> result =
-            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_wrapperMock.Object, requestedIds);
+            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_categoryRepoMock.Object, requestedIds);
 
         // Assert
         Assert.True(result.IsFailed);
@@ -102,13 +93,11 @@ public class CategoryValidationHelperTests
             .Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
             .ReturnsAsync(emptyList);
 
-        var expectedMessage = ErrorMessagesConstants.NotFound(
-            "10, 20",
-            typeof(HippotherapyProgramCategory));
+        var expectedMessage = ErrorMessagesConstants.NotFound([10, 20], typeof(HippotherapyProgramCategory));
 
         // Act
         Result<ICollection<HippotherapyProgramCategory>> result =
-            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_wrapperMock.Object, requestedIds);
+            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_categoryRepoMock.Object, requestedIds);
 
         // Assert
         Assert.True(result.IsFailed);
@@ -122,20 +111,18 @@ public class CategoryValidationHelperTests
     {
         // Arrange
         var requestedIds = new List<long>();
-        var emptyList = new List<HippotherapyProgramCategory>();
-
-        _categoryRepoMock
-            .Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
-            .ReturnsAsync(emptyList);
 
         // Act
         Result<ICollection<HippotherapyProgramCategory>> result =
-            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_wrapperMock.Object, requestedIds);
+            await CategoryValidationHelper.ValidateAndGetCategoriesAsync(_categoryRepoMock.Object, requestedIds);
 
         // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Value);
         Assert.Empty(result.Value);
+        _categoryRepoMock.Verify(
+            repository => repository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()),
+            Times.Never);
     }
 
     private static HippotherapyProgramCategory MakeCategory(long id, string name)

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using AutoMapper;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
@@ -179,6 +181,60 @@ public class CreateEventNewsTests
             () => sut.Handle(Command(Dto(Status.Published)), CancellationToken.None));
     }
 
+    [Fact]
+    public async Task Handle_SlugUniqueConstraintViolation_RegeneratesSlugAndRetriesSave()
+    {
+        var (sut, entity) = CreateSut(saveChanges: 1);
+        var exception = CreateUniqueConstraintException();
+        _repo.SetupSequence(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(exception)
+            .ReturnsAsync(1);
+        _repo.Setup(repository => repository.EventNewsRepository.ExistsAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<EventNewsEntity, bool>>>()))
+            .ReturnsAsync(true);
+        _slugService.SetupSequence(service => service.GenerateUniqueEventNewsSlugAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("event-news-title")
+            .ReturnsAsync("event-news-title-1");
+
+        var result = await sut.Handle(Command(Dto(Status.Published)), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("event-news-title-1", entity.Slug);
+        _repo.Verify(repository => repository.SaveChangesAsync(), Times.Exactly(2));
+        _slugService.Verify(
+            service => service.GenerateUniqueEventNewsSlugAsync(
+                0,
+                "Event News Title",
+                CancellationToken.None),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_NonSlugUniqueConstraintViolation_PropagatesWithoutRetry()
+    {
+        var (sut, _) = CreateSut(saveChanges: 1);
+        var exception = CreateUniqueConstraintException();
+        _repo.Setup(repository => repository.SaveChangesAsync()).ThrowsAsync(exception);
+        _repo.Setup(repository => repository.EventNewsRepository.ExistsAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<EventNewsEntity, bool>>>()))
+            .ReturnsAsync(false);
+
+        var actualException = await Assert.ThrowsAsync<DbUpdateException>(
+            () => sut.Handle(Command(Dto(Status.Published)), CancellationToken.None));
+
+        Assert.Same(exception, actualException);
+        _repo.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+        _slugService.Verify(
+            service => service.GenerateUniqueEventNewsSlugAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private (CreateEventNewsHandler sut, EventNewsEntity entity) CreateSut(
         int saveChanges,
         List<EventNewsCategory>? categories = null,
@@ -286,6 +342,65 @@ public class CreateEventNewsTests
     }
 
     private static CreateEventNewsCommand Command(CreateEventNewsDto dto) => new(dto);
+
+    private static DbUpdateException CreateUniqueConstraintException()
+    {
+        var errorCollection = (SqlErrorCollection)Activator.CreateInstance(
+            typeof(SqlErrorCollection),
+            nonPublic: true)!;
+        var errorConstructor = typeof(SqlError)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            .OrderByDescending(constructor => constructor.GetParameters().Length)
+            .First();
+        var errorArguments = errorConstructor.GetParameters()
+            .Select(parameter => CreateSqlErrorArgument(parameter, 2601))
+            .ToArray();
+        var error = (SqlError)errorConstructor.Invoke(errorArguments);
+
+        typeof(SqlErrorCollection)
+            .GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(errorCollection, [error]);
+
+        var createExceptionMethod = typeof(SqlException)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .First(method => method.Name == "CreateException"
+                && method.GetParameters().Length == 2);
+        var sqlException = (SqlException)createExceptionMethod.Invoke(
+            null,
+            [errorCollection, "15.0.0"])!;
+
+        return new DbUpdateException("Unique constraint violation", sqlException);
+    }
+
+    private static object? CreateSqlErrorArgument(ParameterInfo parameter, int errorNumber)
+    {
+        if (parameter.Name is "infoNumber" or "number")
+        {
+            return errorNumber;
+        }
+
+        if (parameter.ParameterType == typeof(byte))
+        {
+            return (byte)0;
+        }
+
+        if (parameter.ParameterType == typeof(int))
+        {
+            return 0;
+        }
+
+        if (parameter.ParameterType == typeof(uint))
+        {
+            return 0u;
+        }
+
+        if (parameter.ParameterType == typeof(string))
+        {
+            return parameter.Name == "errorMessage" ? "Unique constraint violation" : string.Empty;
+        }
+
+        return null;
+    }
 
     private static CreateEventNewsDto Dto(Status status, List<long>? categoryIds = null)
     {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
@@ -51,6 +51,21 @@ public class CreateEventNewsTests
     }
 
     [Fact]
+    public async Task Handle_ValidPublishedRequest_PassesDefaultEntityIdToSlugService()
+    {
+        var (sut, _) = CreateSut(saveChanges: 1);
+
+        await sut.Handle(Command(Dto(Status.Published)), CancellationToken.None);
+
+        _slugService.Verify(
+            service => service.GenerateUniqueEventNewsSlugAsync(
+                0,
+                "Event News Title",
+                CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task Handle_ValidDraftWithoutTitle_ReturnsSuccessWithoutSlug()
     {
         var (sut, entity) = CreateSut(saveChanges: 1);
@@ -64,6 +79,46 @@ public class CreateEventNewsTests
 
         Assert.True(result.IsSuccess);
         Assert.Null(entity.Slug);
+        Assert.Empty(entity.Localizations);
+    }
+
+    [Fact]
+    public async Task Handle_DraftLocalizationWithoutContent_IgnoresLocalization()
+    {
+        var (sut, entity) = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(
+            Command(new CreateEventNewsDto
+            {
+                Status = Status.Draft,
+                Localizations = [new CreateEventNewsLocalizationDto { LanguageId = 1 }]
+            }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(entity.Localizations);
+        _repo.Verify(
+            repository => repository.LocalizationLanguagesRepository.GetAllAsync(
+                It.IsAny<QueryOptions<LocalizationLanguage>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NullDraftCollections_ReturnsSuccess()
+    {
+        var (sut, entity) = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(
+            Command(new CreateEventNewsDto
+            {
+                Status = Status.Draft,
+                CategoryIds = null!,
+                Localizations = null!
+            }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(entity.Categories);
         Assert.Empty(entity.Localizations);
     }
 
@@ -88,6 +143,18 @@ public class CreateEventNewsTests
 
         Assert.Contains(
             nameof(Image),
+            string.Join(" | ", result.Errors.Select(error => error.Message)));
+    }
+
+    [Fact]
+    public async Task Handle_MissingLocalizationLanguage_ReturnsNotFoundError()
+    {
+        var (sut, _) = CreateSut(saveChanges: 1, languages: []);
+
+        var result = await sut.Handle(Command(Dto(Status.Published)), CancellationToken.None);
+
+        Assert.Contains(
+            nameof(LocalizationLanguage),
             string.Join(" | ", result.Errors.Select(error => error.Message)));
     }
 
@@ -121,7 +188,6 @@ public class CreateEventNewsTests
     {
         var entity = new EventNewsEntity
         {
-            Id = 1,
             Categories = [],
             Localizations = []
         };

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
@@ -1,0 +1,243 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Interfaces.SlugService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNews;
+
+public class CreateEventNewsTests
+{
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<IRepositoryWrapper> _repo = new();
+    private readonly Mock<ISlugService> _slugService = new();
+
+    private static readonly List<EventNewsCategory> Categories =
+    [
+        new() { Id = 1, Name = "News" },
+        new() { Id = 2, Name = "Events" }
+    ];
+
+    private static readonly List<Image> Images =
+    [
+        new() { Id = 1, BlobName = "image-1", MimeType = "image/png" }
+    ];
+
+    private static readonly List<LocalizationLanguage> Languages =
+    [
+        new() { Id = 1, Code = "uk", Name = "Ukrainian" },
+        new() { Id = 2, Code = "en", Name = "English" }
+    ];
+
+    [Fact]
+    public async Task Handle_ValidPublishedRequest_ReturnsSuccessAndSetsSlug()
+    {
+        var (sut, entity) = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(Command(Dto(Status.Published)), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("event-news-title", entity.Slug);
+        Assert.Single(entity.Categories);
+        Assert.Single(entity.Localizations);
+    }
+
+    [Fact]
+    public async Task Handle_ValidDraftWithoutTitle_ReturnsSuccessWithoutSlug()
+    {
+        var (sut, entity) = CreateSut(saveChanges: 1);
+
+        var result = await sut.Handle(
+            Command(new CreateEventNewsDto
+            {
+                Status = Status.Draft
+            }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(entity.Slug);
+        Assert.Empty(entity.Localizations);
+    }
+
+    [Fact]
+    public async Task Handle_MissingCategory_ReturnsNotFoundError()
+    {
+        var (sut, _) = CreateSut(saveChanges: 1, categories: [Categories[0]]);
+
+        var result = await sut.Handle(Command(Dto(Status.Published, categoryIds: [1, 2])), CancellationToken.None);
+
+        Assert.Contains(
+            nameof(EventNewsCategory),
+            string.Join(" | ", result.Errors.Select(error => error.Message)));
+    }
+
+    [Fact]
+    public async Task Handle_MissingImage_ReturnsNotFoundError()
+    {
+        var (sut, _) = CreateSut(saveChanges: 1, images: []);
+
+        var result = await sut.Handle(Command(Dto(Status.Published)), CancellationToken.None);
+
+        Assert.Contains(
+            nameof(Image),
+            string.Join(" | ", result.Errors.Select(error => error.Message)));
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesReturnsZero_ReturnsFailedToCreateEntity()
+    {
+        var (sut, _) = CreateSut(saveChanges: 0);
+
+        var result = await sut.Handle(Command(Dto(Status.Published)), CancellationToken.None);
+
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(EventNewsEntity)),
+            string.Join(" | ", result.Errors.Select(error => error.Message)));
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesThrowsDbUpdateException_PropagatesException()
+    {
+        var (sut, _) = CreateSut(saveChanges: 1, throwOnSave: true);
+
+        await Assert.ThrowsAsync<DbUpdateException>(
+            () => sut.Handle(Command(Dto(Status.Published)), CancellationToken.None));
+    }
+
+    private (CreateEventNewsHandler sut, EventNewsEntity entity) CreateSut(
+        int saveChanges,
+        List<EventNewsCategory>? categories = null,
+        List<Image>? images = null,
+        List<LocalizationLanguage>? languages = null,
+        bool throwOnSave = false)
+    {
+        var entity = new EventNewsEntity
+        {
+            Id = 1,
+            Categories = [],
+            Localizations = []
+        };
+
+        SetUpMapper(entity);
+        SetUpRepositories(saveChanges, categories ?? Categories, images ?? Images, languages ?? Languages, throwOnSave);
+        SetUpSlugService();
+
+        return (new CreateEventNewsHandler(_mapper.Object, _repo.Object, _slugService.Object), entity);
+    }
+
+    private void SetUpMapper(EventNewsEntity entity)
+    {
+        _mapper.Reset();
+
+        _mapper
+            .Setup(mapper => mapper.Map<EventNewsEntity>(It.IsAny<CreateEventNewsDto>()))
+            .Returns((CreateEventNewsDto dto) =>
+            {
+                entity.Resource = dto.Resource;
+                entity.PublishedAt = dto.PublishedAt;
+                entity.Status = dto.Status;
+                entity.PreviewImageId = dto.PreviewImageId;
+                entity.BackgroundImageId = dto.BackgroundImageId;
+                entity.Categories = [];
+                entity.Localizations = [];
+                return entity;
+            });
+
+        _mapper
+            .Setup(mapper => mapper.Map<EventNewsDto>(It.IsAny<EventNewsEntity>()))
+            .Returns((EventNewsEntity eventNews) => new EventNewsDto
+            {
+                Id = eventNews.Id,
+                Slug = eventNews.Slug,
+                Resource = eventNews.Resource,
+                PublishedAt = eventNews.PublishedAt,
+                Status = eventNews.Status,
+                Categories = [],
+                Localizations = []
+            });
+    }
+
+    private void SetUpRepositories(
+        int saveChanges,
+        List<EventNewsCategory> categories,
+        List<Image> images,
+        List<LocalizationLanguage> languages,
+        bool throwOnSave)
+    {
+        _repo.Reset();
+
+        _repo
+            .Setup(repo => repo.EventNewsCategoryRepository.GetAllAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync((QueryOptions<EventNewsCategory> options) =>
+            {
+                var predicate = options.Filter?.Compile();
+                return predicate is null ? categories : [.. categories.Where(predicate)];
+            });
+
+        _repo
+            .Setup(repo => repo.ImageRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<Image>>()))
+            .ReturnsAsync((QueryOptions<Image> options) =>
+            {
+                var predicate = options.Filter?.Compile();
+                return predicate is null ? images.FirstOrDefault() : images.FirstOrDefault(predicate);
+            });
+
+        _repo
+            .Setup(repo => repo.LocalizationLanguagesRepository.GetAllAsync(It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync((QueryOptions<LocalizationLanguage> options) =>
+            {
+                var predicate = options.Filter?.Compile();
+                return predicate is null ? languages : [.. languages.Where(predicate)];
+            });
+
+        _repo
+            .Setup(repo => repo.EventNewsRepository.CreateAsync(It.IsAny<EventNewsEntity>()));
+
+        if (throwOnSave)
+        {
+            _repo.Setup(repo => repo.SaveChangesAsync()).ThrowsAsync(new DbUpdateException());
+            return;
+        }
+
+        _repo.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(saveChanges);
+    }
+
+    private void SetUpSlugService()
+    {
+        _slugService.Reset();
+
+        _slugService
+            .Setup(service => service.GenerateUniqueEventNewsSlugAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("event-news-title");
+    }
+
+    private static CreateEventNewsCommand Command(CreateEventNewsDto dto) => new(dto);
+
+    private static CreateEventNewsDto Dto(Status status, List<long>? categoryIds = null)
+    {
+        return new CreateEventNewsDto
+        {
+            Status = status,
+            PublishedAt = DateTimeOffset.UtcNow,
+            PreviewImageId = 1,
+            CategoryIds = categoryIds ?? [1],
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = "Event News Title",
+                    Description = "Valid event description"
+                },
+            ]
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -139,7 +139,7 @@ public class UpdateHippotherapyProgramTests
         var result = await sut.Handle(Command(id: 1, dto: Dto(categoryIds: [1, 2])), CancellationToken.None);
 
         Assert.Contains(
-            ErrorMessagesConstants.NotFound(2, typeof(HippotherapyProgramCategory)),
+            ErrorMessagesConstants.NotFound([2], typeof(HippotherapyProgramCategory)),
             result.Errors.Select(e => e.Message));
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/SlugServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/SlugServiceTests.cs
@@ -3,6 +3,7 @@ using Slugify;
 using VictoryCenter.BLL.Services.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 using VictoryCenter.DAL.Repositories.Interfaces.HippotherapyPrograms;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -83,6 +84,39 @@ public class SlugServiceTests
         var result = await service.GenerateUniqueHippotherapyProgramSlugAsync(1, "My Program");
 
         Assert.Equal("my-program-3", result);
+    }
+
+    [Fact]
+    public async Task GenerateUniqueEventNewsSlugAsync_WhenSimilarSlugsExist_ShouldReturnIncrementedSlug()
+    {
+        var slugHelperMock = new Mock<ISlugHelper>();
+        var repoWrapperMock = new Mock<IRepositoryWrapper>();
+        var eventNewsRepoMock = new Mock<IEventNewsRepository>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        repoWrapperMock.SetupGet(repository => repository.EventNewsRepository).Returns(eventNewsRepoMock.Object);
+        slugHelperMock.Setup(helper => helper.GenerateSlug("Event News")).Returns("event-news");
+        eventNewsRepoMock
+            .Setup(repository => repository.GetSlugsStartingWithAsync(
+                1,
+                "event-news",
+                cancellationTokenSource.Token))
+            .ReturnsAsync(["event-news", "event-news-1", "event-news-2"]);
+
+        var service = new SlugService(slugHelperMock.Object, repoWrapperMock.Object);
+
+        var result = await service.GenerateUniqueEventNewsSlugAsync(
+            1,
+            "Event News",
+            cancellationTokenSource.Token);
+
+        Assert.Equal("event-news-3", result);
+        eventNewsRepoMock.Verify(
+            repository => repository.GetSlugsStartingWithAsync(
+                1,
+                "event-news",
+                cancellationTokenSource.Token),
+            Times.Once);
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/CreateEventNewsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/CreateEventNewsValidatorTests.cs
@@ -25,6 +25,39 @@ public class CreateEventNewsValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDraftCollectionsAreNull()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            CategoryIds = null!,
+            Localizations = null!
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveErrors_WhenPublishedCollectionsAreNull()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Published,
+            PublishedAt = DateTimeOffset.UtcNow,
+            PreviewImageId = 1,
+            CategoryIds = null!,
+            Localizations = null!
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.CategoryIds);
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.Localizations);
+    }
+
+    [Fact]
     public void Validate_ShouldHaveErrors_WhenPublishedRequiredFieldsAreMissing()
     {
         var command = new CreateEventNewsCommand(new CreateEventNewsDto

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/CreateEventNewsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/CreateEventNewsValidatorTests.cs
@@ -1,0 +1,107 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Validators.EventNews;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.EventNews;
+
+public class CreateEventNewsValidatorTests
+{
+    private readonly CreateEventNewsValidator _validator = new(new BaseEventNewsValidator());
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDraftIsEmpty()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Draft
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveErrors_WhenPublishedRequiredFieldsAreMissing()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Published
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.PublishedAt);
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.PreviewImageId);
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.CategoryIds);
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.Localizations);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveErrors_WhenPublishedLocalizationTextIsMissing()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Published,
+            PublishedAt = DateTimeOffset.UtcNow,
+            PreviewImageId = 1,
+            CategoryIds = [1],
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1
+                },
+            ]
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("CreateEventNewsDto.Localizations[0].Title")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsLocalizationDto.Title)));
+        result.ShouldHaveValidationErrorFor("CreateEventNewsDto.Localizations[0].Description")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(CreateEventNewsLocalizationDto.Description)));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenTitleIsTooLong()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = new string('a', EventNewsConstants.TitleMaxLength + 1)
+                },
+            ]
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor("CreateEventNewsDto.Localizations[0].Title")
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(CreateEventNewsLocalizationDto.Title),
+                EventNewsConstants.TitleMaxLength));
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenCategoryIdsAreDuplicated()
+    {
+        var command = new CreateEventNewsCommand(new CreateEventNewsDto
+        {
+            Status = Status.Draft,
+            CategoryIds = [1, 1]
+        });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(command => command.CreateEventNewsDto.CategoryIds)
+            .WithErrorMessage(ErrorMessagesConstants.CollectionMustContainUniqueValues(nameof(CreateEventNewsDto.CategoryIds)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class EventNewsController : AuthorizedApiController
+{
+    [HttpPost]
+    public async Task<IActionResult> CreateEventNews([FromBody] CreateEventNewsDto createEventNewsDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateEventNewsCommand(createEventNewsDto)));
+    }
+}


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin endpoint to create event news as drafts or published items.
  - Supports categories, optional images/resources, publication dates and statuses, and localized titles/descriptions.
  - Tightened title/description length rules.
  - Automatically generates unique slugs, including incremental suffixes when conflicts occur.
- **Bug Fixes**
  - Ensures draft event news remains excluded from public published listings.
  - Draft localizations without usable content are not persisted/returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->