### PR TITLE
Fix/issue-3096 [Reports, Delete Category, Admin Panel] "Програмні" categories are displayed in the "Категорія" dropdown and can be deleted

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryHandler.cs
@@ -5,7 +5,6 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
-using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -36,14 +35,6 @@ public class CreateReportFundsExpendituresCategoryHandler
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
-
-            if (ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
-                    request.CreateReportFundsExpendituresCategoryDto.Name,
-                    request.CreateReportFundsExpendituresCategoryDto.Type))
-            {
-                return Result.Fail<ReportFundsExpendituresCategoryDto>(
-                    ReportFundsExpendituresCategoryConstants.ReservedCategoryName);
-            }
 
             var duplicateCategoriesCount = await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.CountAsync(
                 new QueryOptions<ReportFundsExpendituresCategory>

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -35,6 +36,14 @@ public class CreateReportFundsExpendituresCategoryHandler
         try
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            if (ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+                    request.CreateReportFundsExpendituresCategoryDto.Name,
+                    request.CreateReportFundsExpendituresCategoryDto.Type))
+            {
+                return Result.Fail<ReportFundsExpendituresCategoryDto>(
+                    ReportFundsExpendituresCategoryConstants.ReservedCategoryName);
+            }
 
             var duplicateCategoriesCount = await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.CountAsync(
                 new QueryOptions<ReportFundsExpendituresCategory>

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryHandler.cs
@@ -2,6 +2,7 @@ using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -35,6 +36,11 @@ public class DeleteReportFundsExpendituresCategoryHandler
         if (categoryToDelete.Records.Count > 0)
         {
             return Result.Fail<long>(ReportFundsExpendituresCategoryConstants.CantDeleteCategoryWhileAssociatedWithAnyRecord);
+        }
+
+        if (ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(categoryToDelete.Name, categoryToDelete.Type))
+        {
+            return Result.Fail<long>(ReportFundsExpendituresCategoryConstants.CantDeleteReservedCategory);
         }
 
         _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.Delete(categoryToDelete);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -53,6 +54,20 @@ public class UpdateReportFundsExpendituresCategoryHandler
             {
                 return Result.Fail<ReportFundsExpendituresCategoryDto>(
                     ErrorMessagesConstants.NotFound(request.Id, typeof(ReportFundsExpendituresCategory)));
+            }
+
+            if (ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(categoryToUpdate.Name, categoryToUpdate.Type))
+            {
+                return Result.Fail<ReportFundsExpendituresCategoryDto>(
+                    ReportFundsExpendituresCategoryConstants.CantUpdateReservedCategory);
+            }
+
+            if (ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+                    request.UpdateReportFundsExpendituresCategoryDto.Name,
+                    categoryToUpdate.Type))
+            {
+                return Result.Fail<ReportFundsExpendituresCategoryDto>(
+                    ReportFundsExpendituresCategoryConstants.ReservedCategoryName);
             }
 
             if (NormalizeName(categoryToUpdate.Name) != normalizedRequestedName &&

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
@@ -8,7 +8,7 @@ public static class ReportFundsExpendituresCategoryConstants
     public static readonly string CantDeleteCategoryWhileAssociatedWithAnyRecord =
         "Can't delete category while associated with any funds and expenditures record";
 
-    public static readonly string ReservedCategoryNameFragment = "Програмні";
+    public static readonly string ReservedCategoryNamePrefix = "Програмні";
 
     public static readonly string CantDeleteReservedCategory = "Can't delete a reserved category";
 

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
@@ -7,4 +7,12 @@ public static class ReportFundsExpendituresCategoryConstants
 
     public static readonly string CantDeleteCategoryWhileAssociatedWithAnyRecord =
         "Can't delete category while associated with any funds and expenditures record";
+
+    public static readonly string ReservedCategoryNamePrefix = "Програмні";
+
+    public static readonly string CantDeleteReservedCategory = "Can't delete a reserved category";
+
+    public static readonly string CantUpdateReservedCategory = "Can't update a reserved category";
+
+    public static readonly string ReservedCategoryName = "This category name is reserved";
 }

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ReportFundsExpendituresCategoryConstants.cs
@@ -8,7 +8,7 @@ public static class ReportFundsExpendituresCategoryConstants
     public static readonly string CantDeleteCategoryWhileAssociatedWithAnyRecord =
         "Can't delete category while associated with any funds and expenditures record";
 
-    public static readonly string ReservedCategoryNamePrefix = "Програмні";
+    public static readonly string ReservedCategoryNameFragment = "Програмні";
 
     public static readonly string CantDeleteReservedCategory = "Can't delete a reserved category";
 

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresCategoryValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresCategoryValidationHelper.cs
@@ -13,8 +13,8 @@ public static class ReportFundsExpendituresCategoryValidationHelper
         }
 
         return type == ReportFundsExpendituresType.Expense &&
-            name.Contains(
-                ReportFundsExpendituresCategoryConstants.ReservedCategoryNameFragment,
+            name.Trim().StartsWith(
+                ReportFundsExpendituresCategoryConstants.ReservedCategoryNamePrefix,
                 StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresCategoryValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresCategoryValidationHelper.cs
@@ -7,9 +7,14 @@ public static class ReportFundsExpendituresCategoryValidationHelper
 {
     public static bool IsReservedCategoryName(string name, ReportFundsExpendituresType type)
     {
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
         return type == ReportFundsExpendituresType.Expense &&
             name.Contains(
-                ReportFundsExpendituresCategoryConstants.ReservedCategoryNamePrefix,
+                ReportFundsExpendituresCategoryConstants.ReservedCategoryNameFragment,
                 StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresCategoryValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresCategoryValidationHelper.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Helpers;
+
+public static class ReportFundsExpendituresCategoryValidationHelper
+{
+    public static bool IsReservedCategoryName(string name, ReportFundsExpendituresType type)
+    {
+        return type == ReportFundsExpendituresType.Expense &&
+            name.Contains(
+                ReportFundsExpendituresCategoryConstants.ReservedCategoryNamePrefix,
+                StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresCategories;
+using VictoryCenter.BLL.Helpers;
 
 namespace VictoryCenter.BLL.Validators.ReportFundsExpendituresCategories;
 
@@ -14,7 +15,9 @@ public class BaseReportFundsExpendituresCategoryValidator : AbstractValidator<Ba
             .MaximumLength(ReportFundsExpendituresCategoryConstants.NameMaxLength)
             .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
                 nameof(ReportFundsExpendituresCategoryDto.Name),
-                ReportFundsExpendituresCategoryConstants.NameMaxLength));
+                ReportFundsExpendituresCategoryConstants.NameMaxLength))
+            .Must((dto, name) => !ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(name, dto.Type))
+            .WithMessage(ReportFundsExpendituresCategoryConstants.ReservedCategoryName);
 
         RuleFor(dto => dto.Type)
             .IsInEnum()

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
@@ -40,6 +40,43 @@ public class CreateReportFundsExpendituresCategoryTests : BaseTestClass
     }
 
     [Theory]
+    [InlineData("ПРОГРАМНІ")]
+    [InlineData("програмні тест")]
+    [InlineData("Програмні тест 2")]
+    public async Task CreateCategory_ShouldNotCreateCategory_WhenNameIsReservedAndTypeIsExpense(string name)
+    {
+        var createDto = new CreateReportFundsExpendituresCategoryDto
+        {
+            Name = name,
+            Type = ReportFundsExpendituresType.Expense
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategories/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateCategory_ShouldCreateCategory_WhenNameIsReservedButTypeIsIncome()
+    {
+        var createDto = new CreateReportFundsExpendituresCategoryDto
+        {
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Income
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategories/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
@@ -39,6 +39,40 @@ public class CreateReportFundsExpendituresCategoryTests : BaseTestClass
         Assert.Equal(createDto.Type, responseContent.Type);
     }
 
+    [Fact]
+    public async Task CreateCategory_ShouldNotCreateCategory_WhenNameIsReservedAndTypeIsExpense()
+    {
+        var createDto = new CreateReportFundsExpendituresCategoryDto
+        {
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Expense
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategories/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateCategory_ShouldCreateCategory_WhenNameIsReservedButTypeIsIncome()
+    {
+        var createDto = new CreateReportFundsExpendituresCategoryDto
+        {
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Income
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
+            "/api/ReportFundsExpendituresCategories/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+        response.EnsureSuccessStatusCode();
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
@@ -74,6 +74,13 @@ public class CreateReportFundsExpendituresCategoryTests : BaseTestClass
             "/api/ReportFundsExpendituresCategories/",
             new StringContent(serializedDto, Encoding.UTF8, "application/json"));
         response.EnsureSuccessStatusCode();
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        ReportFundsExpendituresCategoryDto? responseContent =
+            JsonConvert.DeserializeObject<ReportFundsExpendituresCategoryDto>(responseString);
+
+        Assert.NotNull(responseContent);
+        Assert.Equal(createDto.Name, responseContent.Name);
     }
 
     [Theory]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Create/CreateReportFundsExpendituresCategoryTests.cs
@@ -39,40 +39,6 @@ public class CreateReportFundsExpendituresCategoryTests : BaseTestClass
         Assert.Equal(createDto.Type, responseContent.Type);
     }
 
-    [Fact]
-    public async Task CreateCategory_ShouldNotCreateCategory_WhenNameIsReservedAndTypeIsExpense()
-    {
-        var createDto = new CreateReportFundsExpendituresCategoryDto
-        {
-            Name = "Програмні тест 2",
-            Type = ReportFundsExpendituresType.Expense
-        };
-        var serializedDto = JsonConvert.SerializeObject(createDto);
-
-        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
-            "/api/ReportFundsExpendituresCategories/",
-            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
-
-        Assert.False(response.IsSuccessStatusCode);
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task CreateCategory_ShouldCreateCategory_WhenNameIsReservedButTypeIsIncome()
-    {
-        var createDto = new CreateReportFundsExpendituresCategoryDto
-        {
-            Name = "Програмні тест 2",
-            Type = ReportFundsExpendituresType.Income
-        };
-        var serializedDto = JsonConvert.SerializeObject(createDto);
-
-        HttpResponseMessage response = await Fixture.HttpClient.PostAsync(
-            "/api/ReportFundsExpendituresCategories/",
-            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
-        response.EnsureSuccessStatusCode();
-    }
-
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Delete/DeleteReportFundsExpendituresCategoryTests.cs
@@ -50,6 +50,36 @@ public class DeleteReportFundsExpendituresCategoryTests : BaseTestClass
     }
 
     [Theory]
+    [InlineData("ПРОГРАМНІ")]
+    [InlineData("програмні тест")]
+    [InlineData("Програмні тест 2")]
+    public async Task DeleteCategory_ShouldNotDeleteCategory_WhenNameIsReservedAndTypeIsExpense(string name)
+    {
+        var category = await CreateCategoryAsync(name, ReportFundsExpendituresType.Expense);
+
+        HttpResponseMessage response = await Fixture.HttpClient.DeleteAsync(
+            $"/api/ReportFundsExpendituresCategories/{category.Id}");
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.NotNull(await Fixture.DbContext.ReportFundsExpendituresCategories
+            .FirstOrDefaultAsync(entity => entity.Id == category.Id));
+    }
+
+    [Fact]
+    public async Task DeleteCategory_ShouldDeleteCategory_WhenNameIsReservedButTypeIsIncome()
+    {
+        var category = await CreateCategoryAsync("Програмні тест 2", ReportFundsExpendituresType.Income);
+
+        HttpResponseMessage response = await Fixture.HttpClient.DeleteAsync(
+            $"/api/ReportFundsExpendituresCategories/{category.Id}");
+        response.EnsureSuccessStatusCode();
+
+        Assert.Null(await Fixture.DbContext.ReportFundsExpendituresCategories
+            .FirstOrDefaultAsync(entity => entity.Id == category.Id));
+    }
+
+    [Theory]
     [InlineData(-1)]
     [InlineData(0)]
     public async Task DeleteCategory_ShouldNotDeleteCategory_NotFound(long id)

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryTests.cs
@@ -133,6 +133,13 @@ public class UpdateReportFundsExpendituresCategoryTests : BaseTestClass
             $"/api/ReportFundsExpendituresCategories/{category.Id}",
             new StringContent(serializedDto, Encoding.UTF8, "application/json"));
         response.EnsureSuccessStatusCode();
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        ReportFundsExpendituresCategoryDto? responseContent =
+            JsonConvert.DeserializeObject<ReportFundsExpendituresCategoryDto>(responseString);
+
+        Assert.NotNull(responseContent);
+        Assert.Equal(updateDto.Name, responseContent.Name);
     }
 
     private async Task<ReportFundsExpendituresCategory> CreateCategoryAsync(

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/ReportFundsExpendituresCategories/Update/UpdateReportFundsExpendituresCategoryTests.cs
@@ -80,6 +80,61 @@ public class UpdateReportFundsExpendituresCategoryTests : BaseTestClass
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [Fact]
+    public async Task UpdateCategory_ShouldNotUpdateCategory_WhenExistingCategoryIsReserved()
+    {
+        var category = await CreateCategoryAsync("Програмні тест 2", ReportFundsExpendituresType.Expense);
+
+        var updateDto = new UpdateReportFundsExpendituresCategoryDto
+        {
+            Name = "Renamed category"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresCategories/{category.Id}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateCategory_ShouldNotUpdateCategory_WhenNewNameIsReserved()
+    {
+        var category = await CreateCategoryAsync("Initial expense category", ReportFundsExpendituresType.Expense);
+
+        var updateDto = new UpdateReportFundsExpendituresCategoryDto
+        {
+            Name = "Програмні тест 2"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresCategories/{category.Id}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.False(response.IsSuccessStatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateCategory_ShouldUpdateCategory_WhenNameIsReservedButTypeIsIncome()
+    {
+        var category = await CreateCategoryAsync("Програмні тест 2", ReportFundsExpendituresType.Income);
+
+        var updateDto = new UpdateReportFundsExpendituresCategoryDto
+        {
+            Name = "Renamed income category"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        HttpResponseMessage response = await Fixture.HttpClient.PutAsync(
+            $"/api/ReportFundsExpendituresCategories/{category.Id}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+        response.EnsureSuccessStatusCode();
+    }
+
     private async Task<ReportFundsExpendituresCategory> CreateCategoryAsync(
         string name,
         ReportFundsExpendituresType type)

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ReportFundsExpendituresCategoryValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ReportFundsExpendituresCategoryValidationHelperTests.cs
@@ -1,0 +1,46 @@
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.HelperTests;
+
+public class ReportFundsExpendituresCategoryValidationHelperTests
+{
+    [Fact]
+    public void IsReservedCategoryName_ExactReservedNameAndExpenseType_ReturnsTrue()
+    {
+        var result = ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+            "Програмні", ReportFundsExpendituresType.Expense);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("ПРОГРАМНІ")]
+    [InlineData("програмні тест")]
+    [InlineData("Програмні тест 2")]
+    public void IsReservedCategoryName_RealWorldNameVariant_ReturnsTrue(string name)
+    {
+        var result = ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+            name, ReportFundsExpendituresType.Expense);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsReservedCategoryName_IncomeType_ReturnsFalse()
+    {
+        var result = ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+            "Програмні тест 2", ReportFundsExpendituresType.Income);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsReservedCategoryName_UnrelatedName_ReturnsFalse()
+    {
+        var result = ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+            "Оренда офісу", ReportFundsExpendituresType.Expense);
+
+        Assert.False(result);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ReportFundsExpendituresCategoryValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ReportFundsExpendituresCategoryValidationHelperTests.cs
@@ -45,6 +45,17 @@ public class ReportFundsExpendituresCategoryValidationHelperTests
     }
 
     [Theory]
+    [InlineData("Непрограмні витрати")]
+    [InlineData("Витрати програмні")]
+    public void IsReservedCategoryName_ReservedWordNotAtStart_ReturnsFalse(string name)
+    {
+        var result = ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+            name, ReportFundsExpendituresType.Expense);
+
+        Assert.False(result);
+    }
+
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     public void IsReservedCategoryName_NullOrEmptyName_ReturnsFalse(string? name)

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ReportFundsExpendituresCategoryValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/ReportFundsExpendituresCategoryValidationHelperTests.cs
@@ -43,4 +43,15 @@ public class ReportFundsExpendituresCategoryValidationHelperTests
 
         Assert.False(result);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsReservedCategoryName_NullOrEmptyName_ReturnsFalse(string? name)
+    {
+        var result = ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(
+            name!, ReportFundsExpendituresType.Expense);
+
+        Assert.False(result);
+    }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
@@ -116,6 +116,49 @@ public class CreateReportFundsExpendituresCategoryTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenNameIsReservedAndTypeIsExpense()
+    {
+        // Arrange
+        var reservedDto = _createDto with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Expense };
+        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
+
+        var handler = new CreateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new CreateReportFundsExpendituresCategoryCommand(reservedDto),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ReportFundsExpendituresCategoryConstants.ReservedCategoryName, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateCategory_WhenNameIsReservedButTypeIsIncome()
+    {
+        // Arrange
+        var reservedNameIncomeDto = _createDto with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Income };
+        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
+
+        var handler = new CreateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new CreateReportFundsExpendituresCategoryCommand(reservedNameIncomeDto),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
     public async Task Handle_ShouldFail_WhenSaveChangesFails()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
@@ -95,6 +95,47 @@ public class CreateReportFundsExpendituresCategoryTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenNameIsReservedAndTypeIsExpense()
+    {
+        // Arrange
+        var reservedDto = _createDto with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Expense };
+        var handler = new CreateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new CreateReportFundsExpendituresCategoryCommand(reservedDto),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains(ReportFundsExpendituresCategoryConstants.ReservedCategoryName, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateCategory_WhenNameIsReservedButTypeIsIncome()
+    {
+        // Arrange
+        var reservedNameIncomeDto = _createDto with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Income };
+        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
+
+        var handler = new CreateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new CreateReportFundsExpendituresCategoryCommand(reservedNameIncomeDto),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
     public async Task Handle_ShouldFail_WhenDuplicateCategoryExists()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/CreateReportFundsExpendituresCategoryTests.cs
@@ -116,49 +116,6 @@ public class CreateReportFundsExpendituresCategoryTests
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenNameIsReservedAndTypeIsExpense()
-    {
-        // Arrange
-        var reservedDto = _createDto with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Expense };
-        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
-
-        var handler = new CreateReportFundsExpendituresCategoryHandler(
-            _mapperMock.Object,
-            _repositoryWrapperMock.Object,
-            _validator);
-
-        // Act
-        var result = await handler.Handle(
-            new CreateReportFundsExpendituresCategoryCommand(reservedDto),
-            CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        Assert.Equal(ReportFundsExpendituresCategoryConstants.ReservedCategoryName, result.Errors[0].Message);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldCreateCategory_WhenNameIsReservedButTypeIsIncome()
-    {
-        // Arrange
-        var reservedNameIncomeDto = _createDto with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Income };
-        SetupDependencies(duplicateCategoriesCount: 0, saveResult: 1);
-
-        var handler = new CreateReportFundsExpendituresCategoryHandler(
-            _mapperMock.Object,
-            _repositoryWrapperMock.Object,
-            _validator);
-
-        // Act
-        var result = await handler.Handle(
-            new CreateReportFundsExpendituresCategoryCommand(reservedNameIncomeDto),
-            CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-    }
-
-    [Fact]
     public async Task Handle_ShouldFail_WhenSaveChangesFails()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/DeleteReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/DeleteReportFundsExpendituresCategoryTests.cs
@@ -92,6 +92,55 @@ public class DeleteReportFundsExpendituresCategoryTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenCategoryIsReserved()
+    {
+        // Arrange
+        var reservedCategory = new ReportFundsExpendituresCategory
+        {
+            Id = 1,
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Expense
+        };
+
+        SetupDependencies(reservedCategory, saveResult: 1);
+        var handler = new DeleteReportFundsExpendituresCategoryHandler(_repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportFundsExpendituresCategoryCommand(reservedCategory.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ReportFundsExpendituresCategoryConstants.CantDeleteReservedCategory,
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteCategory_WhenReservedNameButIncomeType()
+    {
+        // Arrange
+        var incomeCategory = new ReportFundsExpendituresCategory
+        {
+            Id = 1,
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Income
+        };
+
+        SetupDependencies(incomeCategory, saveResult: 1);
+        var handler = new DeleteReportFundsExpendituresCategoryHandler(_repositoryWrapperMock.Object);
+
+        // Act
+        var result = await handler.Handle(
+            new DeleteReportFundsExpendituresCategoryCommand(incomeCategory.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
     public async Task Handle_ShouldFail_WhenSaveChangesFails()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresCategories/UpdateReportFundsExpendituresCategoryTests.cs
@@ -115,6 +115,87 @@ public class UpdateReportFundsExpendituresCategoryTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenExistingCategoryIsReserved()
+    {
+        // Arrange
+        var reservedCategory = new ReportFundsExpendituresCategory
+        {
+            Id = 1,
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Expense
+        };
+
+        SetupDependencies([reservedCategory], saveResult: 1);
+        var handler = new UpdateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new UpdateReportFundsExpendituresCategoryCommand(_updateDto, reservedCategory.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ReportFundsExpendituresCategoryConstants.CantUpdateReservedCategory, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenNewNameIsReserved()
+    {
+        // Arrange
+        var expenseCategory = new ReportFundsExpendituresCategory
+        {
+            Id = 1,
+            Name = "Old name",
+            Type = ReportFundsExpendituresType.Expense
+        };
+        var reservedNameDto = new UpdateReportFundsExpendituresCategoryDto { Name = "Програмні тест 2" };
+
+        SetupDependencies([expenseCategory], saveResult: 1);
+        var handler = new UpdateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new UpdateReportFundsExpendituresCategoryCommand(reservedNameDto, expenseCategory.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ReportFundsExpendituresCategoryConstants.ReservedCategoryName, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateCategory_WhenReservedNameButIncomeType()
+    {
+        // Arrange
+        var incomeCategory = new ReportFundsExpendituresCategory
+        {
+            Id = 1,
+            Name = "Програмні тест 2",
+            Type = ReportFundsExpendituresType.Income
+        };
+
+        SetupDependencies([incomeCategory], saveResult: 1);
+        var handler = new UpdateReportFundsExpendituresCategoryHandler(
+            _mapperMock.Object,
+            _repositoryWrapperMock.Object,
+            _validator);
+
+        // Act
+        var result = await handler.Handle(
+            new UpdateReportFundsExpendituresCategoryCommand(_updateDto, incomeCategory.Id),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
     public async Task Handle_ShouldFail_WhenDuplicateNameExistsForSameType()
     {
         // Arrange

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpendituresCategories/BaseReportFundsExpendituresCategoryValidatorTests.cs
@@ -68,6 +68,36 @@ public class BaseReportFundsExpendituresCategoryValidatorTests
     }
 
     [Theory]
+    [InlineData("ПРОГРАМНІ")]
+    [InlineData("програмні тест")]
+    [InlineData("Програмні тест 2")]
+    public void Validate_ShouldHaveError_WhenNameIsReservedAndTypeIsExpense(string name)
+    {
+        // Arrange
+        var dto = GetValidDto() with { Name = name, Type = ReportFundsExpendituresType.Expense };
+
+        // Act
+        var result = _validator.TestValidate(dto);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Name)
+            .WithErrorMessage(ReportFundsExpendituresCategoryConstants.ReservedCategoryName);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenNameIsReservedButTypeIsIncome()
+    {
+        // Arrange
+        var dto = GetValidDto() with { Name = "Програмні тест 2", Type = ReportFundsExpendituresType.Income };
+
+        // Act
+        var result = _validator.TestValidate(dto);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Theory]
     [InlineData(ReportFundsExpendituresType.Income)]
     [InlineData(ReportFundsExpendituresType.Expense)]
     public void Validate_ShouldNotHaveErrors_WhenDataIsValid(ReportFundsExpendituresType type)


### PR DESCRIPTION
dev
## JIRA

* [#3096](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3096)

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Categories in the `ReportFundsExpendituresCategories` table whose name contains the reserved "Програмні" label (the label used by the client for the system aggregate row on the "Доходи та витрати" tab) could be deleted via `DELETE /api/ReportFundsExpendituresCategories/{id}` and renamed via `PUT /api/ReportFundsExpendituresCategories/{id}`, since neither handler had any awareness of this reserved name. This allowed the protection to be bypassed entirely via direct API calls (e.g. Swagger/Postman), and even through the UI a category could be renamed away from the reserved name and then deleted. [Related client PR](https://github.com/ita-social-projects/VictoryCenter-Client/pull/498)

## Summary of change

- **New constants** in `ReportFundsExpendituresCategoryConstants.cs`: `ReservedCategoryNamePrefix` ("Програмні"), `CantDeleteReservedCategory`, `CantUpdateReservedCategory`, `ReservedCategoryName`.
- **New helper** `ReportFundsExpendituresCategoryValidationHelper.IsReservedCategoryName(name, type)` — returns `true` for Expense-type categories whose name contains the reserved prefix (case-insensitive).
- **`DeleteReportFundsExpendituresCategoryHandler`:** now rejects deletion of a reserved category with `CantDeleteReservedCategory`.
- **`UpdateReportFundsExpendituresCategoryHandler`:** now rejects (a) any update to an already-reserved category (`CantUpdateReservedCategory`) and (b) renaming any other category into a reserved name (`ReservedCategoryName`).
- **Unit Test Coverage:** added tests to `DeleteReportFundsExpendituresCategoryTests`, `UpdateReportFundsExpendituresCategoryTests`, and a new `ReportFundsExpendituresCategoryValidationHelperTests`.
- **Integration Test Coverage:** added matching HTTP-level scenarios to the Delete and Update integration test suites for `ReportFundsExpendituresCategories`.

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reserved category names are now protected for expense categories.
  * Users cannot create or rename expense categories to reserved names.
  * Reserved expense categories cannot be updated or deleted.
  * Reserved names remain available for income categories.

* **Bug Fixes**
  * Added consistent validation and error handling for reserved category operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->