### PR TITLE
Feature/issue 1590, 2031, 1703 Publish and Cancel changes "Доходи та витрати", Publish changes in the Media Settings tab

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Cancel/CancelReportFundsExpendituresCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Cancel/CancelReportFundsExpendituresCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Cancel;
+
+public class CancelReportFundsExpendituresCommand : IRequest<Result<bool>>
+{
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Cancel/CancelReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Cancel/CancelReportFundsExpendituresHandler.cs
@@ -1,0 +1,186 @@
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Cancel;
+
+public class CancelReportFundsExpendituresHandler
+    : IRequestHandler<CancelReportFundsExpendituresCommand, Result<bool>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly TimeProvider _timeProvider;
+    public CancelReportFundsExpendituresHandler(
+        IRepositoryWrapper repositoryWrapper,
+        TimeProvider timeProvider)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<Result<bool>> Handle(
+        CancelReportFundsExpendituresCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var backupSettings = await _repositoryWrapper.BackupReportFundsExpendituresSettingsRepository
+                .GetFirstOrDefaultAsync();
+
+            if (backupSettings is null)
+            {
+                return Result.Fail<bool>("Неможливо відмінити зміни, оскільки не знайдено попередньої опублікованої версії. Будь ласка, спочатку збережіть та опублікуйте звіт.");
+            }
+
+            var backupSettingsLocalizations = (await _repositoryWrapper.BackupReportFundsExpendituresSettingsLocalizationsRepository
+                .GetAllAsync(new QueryOptions<BackupReportFundsExpendituresSettingsLocalization>
+                {
+                    Include = q => q.Include(l => l.Language),
+                    AsNoTracking = true
+                })).ToList();
+
+            var backupCategories = (await _repositoryWrapper.BackupReportFundsExpendituresCategoriesRepository
+                .GetAllAsync(new QueryOptions<BackupReportFundsExpendituresCategory>
+                {
+                    Include = q => q.Include(c => c.Localizations).ThenInclude(l => l.Language),
+                    AsNoTracking = true
+                })).ToList();
+
+            var backupFundsRecords = (await _repositoryWrapper.BackupReportFundsExpendituresRecordsRepository
+                .GetAllAsync(new QueryOptions<BackupReportFundsExpendituresRecord>
+                {
+                    AsNoTracking = true
+                })).ToList();
+
+            var backupProgramRecords = (await _repositoryWrapper.BackupReportProgramExpendituresRecordsRepository
+                .GetAllAsync(new QueryOptions<BackupReportProgramExpendituresRecord>
+                {
+                    AsNoTracking = true
+                })).ToList();
+
+            using var transaction = _repositoryWrapper.BeginTransaction();
+
+            await _repositoryWrapper.ReportFundsExpendituresRecordsRepository
+                .BulkDeleteAsync(_ => true);
+
+            await _repositoryWrapper.ReportProgramExpendituresRecordsRepository
+                .BulkDeleteAsync(_ => true);
+
+            await _repositoryWrapper.ReportFundsExpendituresCategoryLocalizationsRepository
+                .BulkDeleteAsync(_ => true);
+
+            await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository
+                .BulkDeleteAsync(_ => true);
+
+            await _repositoryWrapper.ReportFundsExpendituresSettingsLocalizationsRepository
+                .BulkDeleteAsync(_ => true);
+
+            var now = _timeProvider.GetUtcNow();
+
+            var oldToNewCategoryMap = new Dictionary<long, ReportFundsExpendituresCategory>();
+
+            var restoredCategories = backupCategories.Select(bc =>
+            {
+                var newCategory = new ReportFundsExpendituresCategory
+                {
+                    Name = bc.Name,
+                    Type = bc.Type,
+                    CreatedAt = bc.CreatedAt,
+                };
+                oldToNewCategoryMap[bc.Id] = newCategory;
+                return newCategory;
+            }).ToArray();
+
+            if (restoredCategories.Any())
+            {
+                await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository.CreateRangeAsync(restoredCategories);
+                await _repositoryWrapper.SaveChangesAsync();
+            }
+
+            var restoredCategoryLocalizations = backupCategories
+                .SelectMany(bc => bc.Localizations.Select(bl => new ReportFundsExpendituresCategoryLocalization
+                {
+                    EntityId = oldToNewCategoryMap[bl.EntityId].Id,
+                    LanguageId = bl.LanguageId,
+                    Name = bl.Name,
+                    TranslationStatus = bl.TranslationStatus,
+                    CreatedAt = bl.CreatedAt,
+                })).ToArray();
+
+            await _repositoryWrapper.ReportFundsExpendituresCategoryLocalizationsRepository
+                .CreateRangeAsync(restoredCategoryLocalizations);
+
+            var restoredFundsRecords = backupFundsRecords.Select(br => new ReportFundsExpendituresRecord
+            {
+                CategoryId = oldToNewCategoryMap[br.CategoryId].Id,
+                Type = br.Type,
+                ReportingYear = br.ReportingYear,
+                AmountUah = br.AmountUah,
+                AmountUsd = br.AmountUsd,
+                CreatedAt = br.CreatedAt,
+            }).ToArray();
+
+            if (restoredFundsRecords.Any())
+            {
+                await _repositoryWrapper.ReportFundsExpendituresRecordsRepository.CreateRangeAsync(restoredFundsRecords);
+            }
+
+            var restoredProgramRecords = backupProgramRecords.Select(br => new ReportProgramExpendituresRecord
+            {
+                HippotherapyProgramCategoryId = br.HippotherapyProgramCategoryId,
+                ReportingYear = br.ReportingYear,
+                AmountUah = br.AmountUah,
+                AmountUsd = br.AmountUsd,
+                CreatedAt = br.CreatedAt,
+            }).ToArray();
+
+            if (restoredProgramRecords.Any())
+            {
+                await _repositoryWrapper.ReportProgramExpendituresRecordsRepository.CreateRangeAsync(restoredProgramRecords);
+            }
+
+            var settingsResult = await ReportFundsExpendituresSettingsHelper
+                .GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider);
+
+            if (settingsResult.IsFailed)
+            {
+                return Result.Fail<bool>(settingsResult.Errors);
+            }
+
+            var settings = settingsResult.Value;
+            settings.DisclaimerTitle = backupSettings.DisclaimerTitle;
+            settings.ExchangeRate = backupSettings.ExchangeRate;
+            settings.ProgramExpendituresReportingYear = backupSettings.ProgramExpendituresReportingYear;
+            settings.HasUnpublishedChanges = false;
+
+            _repositoryWrapper.ReportFundsExpendituresSettingsRepository.Update(settings);
+
+            var restoredSettingsLocalizations = backupSettingsLocalizations.Select(bl =>
+                new ReportFundsExpendituresSettingsLocalization
+                {
+                    EntityId = settings.Id,
+                    LanguageId = bl.LanguageId,
+                    DisclaimerTitle = bl.DisclaimerTitle,
+                    TranslationStatus = bl.TranslationStatus,
+                    CreatedAt = bl.CreatedAt,
+                }).ToArray();
+
+            await _repositoryWrapper.ReportFundsExpendituresSettingsLocalizationsRepository
+                .CreateRangeAsync(restoredSettingsLocalizations);
+
+            await _repositoryWrapper.SaveChangesAsync();
+
+            transaction.Complete();
+
+            return Result.Ok(true);
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail<bool>($"Failed to cancel report funds expenditures changes: {ex.Message} {ex.InnerException?.Message}");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Cancel/CancelReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Cancel/CancelReportFundsExpendituresHandler.cs
@@ -1,6 +1,7 @@
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
@@ -33,7 +34,7 @@ public class CancelReportFundsExpendituresHandler
 
             if (backupSettings is null)
             {
-                return Result.Fail<bool>("Неможливо відмінити зміни, оскільки не знайдено попередньої опублікованої версії. Будь ласка, спочатку збережіть та опублікуйте звіт.");
+                return Result.Fail<bool>(ErrorMessagesConstants.CannotCancelChangesNoBackupFound());
             }
 
             var backupSettingsLocalizations = (await _repositoryWrapper.BackupReportFundsExpendituresSettingsLocalizationsRepository
@@ -62,7 +63,7 @@ public class CancelReportFundsExpendituresHandler
                     AsNoTracking = true
                 })).ToList();
 
-            using var transaction = _repositoryWrapper.BeginTransaction();
+            await using var transaction = await _repositoryWrapper.BeginTransactionAsync(cancellationToken);
 
             await _repositoryWrapper.ReportFundsExpendituresRecordsRepository
                 .BulkDeleteAsync(_ => true);
@@ -174,13 +175,17 @@ public class CancelReportFundsExpendituresHandler
 
             await _repositoryWrapper.SaveChangesAsync();
 
-            transaction.Complete();
+            await transaction.CommitAsync(cancellationToken);
 
             return Result.Ok(true);
         }
-        catch (Exception ex)
+        catch (DbUpdateException)
         {
-            return Result.Fail<bool>($"Failed to cancel report funds expenditures changes: {ex.Message} {ex.InnerException?.Message}");
+            return Result.Fail<bool>("Failed to cancel report funds expenditures changes.");
+        }
+        catch (Exception)
+        {
+            return Result.Fail<bool>("An unexpected error occurred while canceling report funds expenditures changes.");
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresCommand.cs
@@ -1,0 +1,6 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
+
+public record PublishReportFundsExpendituresCommand : IRequest<Result<bool>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresHandler.cs
@@ -73,7 +73,7 @@ public class PublishReportFundsExpendituresHandler
                     AsNoTracking = true
                 })).ToList();
 
-            using var transaction = _repositoryWrapper.BeginTransaction();
+            await using var transaction = await _repositoryWrapper.BeginTransactionAsync(cancellationToken);
 
             await _repositoryWrapper.PublishedReportFundsExpendituresRecordsRepository
                 .BulkDeleteAsync(_ => true);
@@ -218,7 +218,7 @@ public class PublishReportFundsExpendituresHandler
                 .CreateRangeAsync(backupProgramRecords);
 
             await _repositoryWrapper.SaveChangesAsync();
-            transaction.Complete();
+            await transaction.CommitAsync(cancellationToken);
 
             return Result.Ok(true);
         }
@@ -229,6 +229,10 @@ public class PublishReportFundsExpendituresHandler
         catch (DbUpdateException)
         {
             return Result.Fail<bool>("Failed to publish report funds expenditures data.");
+        }
+        catch (Exception)
+        {
+            return Result.Fail<bool>("An unexpected error occurred while publishing report funds expenditures data.");
         }
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresHandler.cs
@@ -1,0 +1,248 @@
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
+
+public class PublishReportFundsExpendituresHandler
+    : IRequestHandler<PublishReportFundsExpendituresCommand, Result<bool>>
+{
+    private const string EnglishLanguageCode = "en";
+
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IValidator<PublishReportFundsExpendituresCommand> _validator;
+    private readonly TimeProvider _timeProvider;
+
+    public PublishReportFundsExpendituresHandler(
+        IRepositoryWrapper repositoryWrapper,
+        IValidator<PublishReportFundsExpendituresCommand> validator,
+        TimeProvider timeProvider)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _validator = validator;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<Result<bool>> Handle(
+        PublishReportFundsExpendituresCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+
+            var fundsRecords = (await _repositoryWrapper.ReportFundsExpendituresRecordsRepository
+                .GetAllAsync(new QueryOptions<ReportFundsExpendituresRecord>
+                {
+                    Include = query => query
+                        .Include(record => record.Category)
+                        .ThenInclude(category => category.Localizations)
+                        .ThenInclude(localization => localization.Language),
+                    AsNoTracking = true
+                })).ToList();
+
+            var programRecords = (await _repositoryWrapper.ReportProgramExpendituresRecordsRepository
+                .GetAllAsync(new QueryOptions<ReportProgramExpendituresRecord>
+                {
+                    Include = query => query
+                        .Include(record => record.HippotherapyProgramCategory),
+                    AsNoTracking = true
+                })).ToList();
+
+            var settingsResult = await ReportFundsExpendituresSettingsHelper
+                .GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider);
+
+            if (settingsResult.IsFailed)
+            {
+                return Result.Fail<bool>(settingsResult.Errors);
+            }
+
+            var settings = settingsResult.Value;
+
+            var settingsLocalizations = (await _repositoryWrapper.ReportFundsExpendituresSettingsLocalizationsRepository
+                .GetAllAsync(new QueryOptions<ReportFundsExpendituresSettingsLocalization>
+                {
+                    Filter = localization => localization.EntityId == settings.Id,
+                    Include = query => query.Include(localization => localization.Language),
+                    AsNoTracking = true
+                })).ToList();
+
+            using var transaction = _repositoryWrapper.BeginTransaction();
+
+            await _repositoryWrapper.PublishedReportFundsExpendituresRecordsRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.PublishedReportProgramExpendituresRecordsRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.PublishedReportFundsExpendituresSnapshotRepository
+                .BulkDeleteAsync(_ => true);
+
+            var now = _timeProvider.GetUtcNow();
+
+            var publishedFundsRecords = fundsRecords.Select(record => new PublishedReportFundsExpendituresRecord
+            {
+                SourceRecordId = record.Id,
+                CategoryName = record.Category.Name,
+                CategoryNameEn = FindEnglishLocalizationName(record.Category.Localizations),
+                Type = record.Type,
+                ReportingYear = record.ReportingYear,
+                AmountUah = record.AmountUah,
+                AmountUsd = record.AmountUsd,
+                CreatedAt = now
+            }).ToArray();
+
+            var publishedProgramRecords = programRecords.Select(record => new PublishedReportProgramExpendituresRecord
+            {
+                SourceRecordId = record.Id,
+                CategoryName = record.HippotherapyProgramCategory.Name,
+                CategoryNameEn = null,
+                ReportingYear = record.ReportingYear,
+                AmountUah = record.AmountUah,
+                AmountUsd = record.AmountUsd,
+                CreatedAt = now
+            }).ToArray();
+
+            var publishedSnapshot = new PublishedReportFundsExpendituresSnapshot
+            {
+                DisclaimerTitle = settings.DisclaimerTitle,
+                DisclaimerTitleEn = FindEnglishDisclaimerTitle(settingsLocalizations),
+                ExchangeRate = settings.ExchangeRate,
+                ProgramExpendituresReportingYear = settings.ProgramExpendituresReportingYear,
+                PublishedAt = now,
+                CreatedAt = now
+            };
+
+            await _repositoryWrapper.PublishedReportFundsExpendituresRecordsRepository
+                .CreateRangeAsync(publishedFundsRecords);
+            await _repositoryWrapper.PublishedReportProgramExpendituresRecordsRepository
+                .CreateRangeAsync(publishedProgramRecords);
+            await _repositoryWrapper.PublishedReportFundsExpendituresSnapshotRepository
+                .CreateAsync(publishedSnapshot);
+
+            settings.HasUnpublishedChanges = false;
+            _repositoryWrapper.ReportFundsExpendituresSettingsRepository.Update(settings);
+
+            // --- Snapshot draft state into backup tables for Cancel support ---
+
+            await _repositoryWrapper.BackupReportFundsExpendituresRecordsRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.BackupReportProgramExpendituresRecordsRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.BackupReportFundsExpendituresCategoryLocalizationsRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.BackupReportFundsExpendituresCategoriesRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.BackupReportFundsExpendituresSettingsLocalizationsRepository
+                .BulkDeleteAsync(_ => true);
+            await _repositoryWrapper.BackupReportFundsExpendituresSettingsRepository
+                .BulkDeleteAsync(_ => true);
+
+            var backupSettings = new BackupReportFundsExpendituresSettings
+            {
+                Id = settings.Id,
+                DisclaimerTitle = settings.DisclaimerTitle,
+                ExchangeRate = settings.ExchangeRate,
+                ProgramExpendituresReportingYear = settings.ProgramExpendituresReportingYear,
+                CreatedAt = settings.CreatedAt,
+            };
+            await _repositoryWrapper.BackupReportFundsExpendituresSettingsRepository
+                .CreateAsync(backupSettings);
+
+            var backupSettingsLocalizations = settingsLocalizations.Select(sl =>
+                new BackupReportFundsExpendituresSettingsLocalization
+                {
+                    EntityId = sl.EntityId,
+                    LanguageId = sl.LanguageId,
+                    DisclaimerTitle = sl.DisclaimerTitle,
+                    TranslationStatus = sl.TranslationStatus,
+                    CreatedAt = sl.CreatedAt,
+                }).ToArray();
+            await _repositoryWrapper.BackupReportFundsExpendituresSettingsLocalizationsRepository
+                .CreateRangeAsync(backupSettingsLocalizations);
+
+            var backupCategories = fundsRecords
+                .Select(r => r.Category)
+                .DistinctBy(c => c.Id)
+                .Select(c => new BackupReportFundsExpendituresCategory
+                {
+                    Id = c.Id,
+                    Name = c.Name,
+                    Type = c.Type,
+                    CreatedAt = c.CreatedAt,
+                }).ToArray();
+            await _repositoryWrapper.BackupReportFundsExpendituresCategoriesRepository
+                .CreateRangeAsync(backupCategories);
+
+            var backupCategoryLocalizations = fundsRecords
+                .Select(r => r.Category)
+                .DistinctBy(c => c.Id)
+                .SelectMany(c => c.Localizations.Select(l => new BackupReportFundsExpendituresCategoryLocalization
+                {
+                    EntityId = l.EntityId,
+                    LanguageId = l.LanguageId,
+                    Name = l.Name,
+                    TranslationStatus = l.TranslationStatus,
+                    CreatedAt = l.CreatedAt,
+                })).ToArray();
+            await _repositoryWrapper.BackupReportFundsExpendituresCategoryLocalizationsRepository
+                .CreateRangeAsync(backupCategoryLocalizations);
+
+            var backupFundsRecords = fundsRecords.Select(r => new BackupReportFundsExpendituresRecord
+            {
+                Id = r.Id,
+                CategoryId = r.CategoryId,
+                Type = r.Type,
+                ReportingYear = r.ReportingYear,
+                AmountUah = r.AmountUah,
+                AmountUsd = r.AmountUsd,
+                CreatedAt = r.CreatedAt,
+            }).ToArray();
+            await _repositoryWrapper.BackupReportFundsExpendituresRecordsRepository
+                .CreateRangeAsync(backupFundsRecords);
+
+            var backupProgramRecords = programRecords.Select(r => new BackupReportProgramExpendituresRecord
+            {
+                Id = r.Id,
+                HippotherapyProgramCategoryId = r.HippotherapyProgramCategoryId,
+                ReportingYear = r.ReportingYear,
+                AmountUah = r.AmountUah,
+                AmountUsd = r.AmountUsd,
+                CreatedAt = r.CreatedAt,
+            }).ToArray();
+            await _repositoryWrapper.BackupReportProgramExpendituresRecordsRepository
+                .CreateRangeAsync(backupProgramRecords);
+
+            await _repositoryWrapper.SaveChangesAsync();
+            transaction.Complete();
+
+            return Result.Ok(true);
+        }
+        catch (ValidationException ex)
+        {
+            return Result.Fail<bool>(ex.Message);
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<bool>("Failed to publish report funds expenditures data.");
+        }
+    }
+
+    private static string? FindEnglishLocalizationName(
+        ICollection<ReportFundsExpendituresCategoryLocalization> localizations)
+    {
+        return localizations
+            .FirstOrDefault(l => l.Language.Code == EnglishLanguageCode)?.Name;
+    }
+
+    private static string? FindEnglishDisclaimerTitle(
+        List<ReportFundsExpendituresSettingsLocalization> localizations)
+    {
+        return localizations
+            .FirstOrDefault(l => l.Language.Code == EnglishLanguageCode)?.DisclaimerTitle;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresHandler.cs
@@ -165,9 +165,14 @@ public class PublishReportFundsExpendituresHandler
             await _repositoryWrapper.BackupReportFundsExpendituresSettingsLocalizationsRepository
                 .CreateRangeAsync(backupSettingsLocalizations);
 
-            var backupCategories = fundsRecords
-                .Select(r => r.Category)
-                .DistinctBy(c => c.Id)
+            var allCategories = (await _repositoryWrapper.ReportFundsExpendituresCategoriesRepository
+                .GetAllAsync(new QueryOptions<ReportFundsExpendituresCategory>
+                {
+                    Include = query => query.Include(category => category.Localizations),
+                    AsNoTracking = true
+                })).ToList();
+
+            var backupCategories = allCategories
                 .Select(c => new BackupReportFundsExpendituresCategory
                 {
                     Id = c.Id,
@@ -178,9 +183,7 @@ public class PublishReportFundsExpendituresHandler
             await _repositoryWrapper.BackupReportFundsExpendituresCategoriesRepository
                 .CreateRangeAsync(backupCategories);
 
-            var backupCategoryLocalizations = fundsRecords
-                .Select(r => r.Category)
-                .DistinctBy(c => c.Id)
+            var backupCategoryLocalizations = allCategories
                 .SelectMany(c => c.Localizations.Select(l => new BackupReportFundsExpendituresCategoryLocalization
                 {
                     EntityId = l.EntityId,

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpenditures/Publish/PublishReportFundsExpendituresValidator.cs
@@ -1,0 +1,51 @@
+using FluentValidation;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
+
+public class PublishReportFundsExpendituresValidator
+    : AbstractValidator<PublishReportFundsExpendituresCommand>
+{
+    private const int MinExpenseRecords = 2;
+    private const int MinIncomeRecords = 2;
+    private const int MinProgramExpenditureRecords = 1;
+
+    public PublishReportFundsExpendituresValidator(IRepositoryWrapper repositoryWrapper)
+    {
+        RuleFor(command => command)
+            .MustAsync(async (_, cancellationToken) =>
+            {
+                var expenseCount = await repositoryWrapper.ReportFundsExpendituresRecordsRepository
+                    .CountAsync(new QueryOptions<ReportFundsExpendituresRecord>
+                    {
+                        Filter = record => record.Type == ReportFundsExpendituresType.Expense
+                    });
+                return expenseCount >= MinExpenseRecords;
+            })
+            .WithMessage($"At least {MinExpenseRecords} expense records are required to publish.");
+
+        RuleFor(command => command)
+            .MustAsync(async (_, cancellationToken) =>
+            {
+                var incomeCount = await repositoryWrapper.ReportFundsExpendituresRecordsRepository
+                    .CountAsync(new QueryOptions<ReportFundsExpendituresRecord>
+                    {
+                        Filter = record => record.Type == ReportFundsExpendituresType.Income
+                    });
+                return incomeCount >= MinIncomeRecords;
+            })
+            .WithMessage($"At least {MinIncomeRecords} fund records are required to publish.");
+
+        RuleFor(command => command)
+            .MustAsync(async (_, cancellationToken) =>
+            {
+                var programCount = await repositoryWrapper.ReportProgramExpendituresRecordsRepository
+                    .CountAsync();
+                return programCount >= MinProgramExpenditureRecords;
+            })
+            .WithMessage($"At least {MinProgramExpenditureRecords} program expenditure record is required to publish.");
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportFundsExpendituresSettings/Update/UpdateReportFundsExpendituresSettingsHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportFundsExpendituresSettings;
 using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -18,6 +19,7 @@ public class UpdateReportFundsExpendituresSettingsHandler
     : IRequestHandler<UpdateReportFundsExpendituresSettingsCommand, Result<ReportFundsExpendituresSettingsDto>>
 {
     private readonly IMapper _mapper;
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly TimeProvider _timeProvider;
     private readonly IValidator<UpdateReportFundsExpendituresSettingsCommand> _validator;
@@ -26,12 +28,14 @@ public class UpdateReportFundsExpendituresSettingsHandler
         IMapper mapper,
         IRepositoryWrapper repositoryWrapper,
         IValidator<UpdateReportFundsExpendituresSettingsCommand> validator,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IMediator mediator)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
         _timeProvider = timeProvider;
+        _mediator = mediator;
     }
 
     public async Task<Result<ReportFundsExpendituresSettingsDto>> Handle(
@@ -76,6 +80,7 @@ public class UpdateReportFundsExpendituresSettingsHandler
 
             if (await _repositoryWrapper.SaveChangesAsync() > 0)
             {
+                await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
                 return Result.Ok(_mapper.Map<ReportFundsExpendituresSettingsDto>(entityToUpdate));
             }
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportMediaSettings;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -17,12 +18,18 @@ public class UpdateReportMediaSettingsHandler : IRequestHandler<UpdateReportMedi
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IMapper _mapper;
     private readonly IValidator<UpdateReportMediaSettingsCommand> _validator;
+    private readonly IMediator _mediator;
 
-    public UpdateReportMediaSettingsHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, IValidator<UpdateReportMediaSettingsCommand> validator)
+    public UpdateReportMediaSettingsHandler(
+        IRepositoryWrapper repositoryWrapper, 
+        IMapper mapper, 
+        IValidator<UpdateReportMediaSettingsCommand> validator,
+        IMediator mediator)
     {
         _repositoryWrapper = repositoryWrapper;
         _mapper = mapper;
         _validator = validator;
+        _mediator = mediator;
     }
 
     public async Task<Result<ReportMediaSettingsDto>> Handle(UpdateReportMediaSettingsCommand request, CancellationToken cancellationToken)
@@ -114,6 +121,8 @@ public class UpdateReportMediaSettingsHandler : IRequestHandler<UpdateReportMedi
                 return Result.Fail<ReportMediaSettingsDto>(
                     ErrorMessagesConstants.FailedToUpdateEntity(typeof(CollectedFundsBlock)));
             }
+
+            await _mediator.Publish(new ReportFundsChangedNotification(), cancellationToken);
 
             if (collectedFundsEntity != null)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
@@ -21,8 +21,8 @@ public class UpdateReportMediaSettingsHandler : IRequestHandler<UpdateReportMedi
     private readonly IMediator _mediator;
 
     public UpdateReportMediaSettingsHandler(
-        IRepositoryWrapper repositoryWrapper, 
-        IMapper mapper, 
+        IRepositoryWrapper repositoryWrapper,
+        IMapper mapper,
         IValidator<UpdateReportMediaSettingsCommand> validator,
         IMediator mediator)
     {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportMediaSettings/UpdateReportMediaSettings/UpdateReportMediaSettingsHandler.cs
@@ -31,30 +31,38 @@ public class UpdateReportMediaSettingsHandler : IRequestHandler<UpdateReportMedi
         {
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
-            var collectedFundsImageExists = await _repositoryWrapper.ImageRepository
-                .GetFirstOrDefaultAsync(new QueryOptions<Image>
-                {
-                    Filter = i => i.Id == request.Dto.CollectedFundsBlock.ImageId,
-                    AsNoTracking = true
-                });
-
-            if (collectedFundsImageExists == null)
+            Image? collectedFundsImageExists = null;
+            if (request.Dto.CollectedFundsBlock.ImageId.HasValue)
             {
-                return Result.Fail<ReportMediaSettingsDto>(
-                    ErrorMessagesConstants.NotFound(request.Dto.CollectedFundsBlock.ImageId, typeof(Image)));
+                collectedFundsImageExists = await _repositoryWrapper.ImageRepository
+                    .GetFirstOrDefaultAsync(new QueryOptions<Image>
+                    {
+                        Filter = i => i.Id == request.Dto.CollectedFundsBlock.ImageId,
+                        AsNoTracking = true
+                    });
+
+                if (collectedFundsImageExists == null)
+                {
+                    return Result.Fail<ReportMediaSettingsDto>(
+                        ErrorMessagesConstants.NotFound(request.Dto.CollectedFundsBlock.ImageId.Value, typeof(Image)));
+                }
             }
 
-            var changedLivesImageExists = await _repositoryWrapper.ImageRepository
-                .GetFirstOrDefaultAsync(new QueryOptions<Image>
-                {
-                    Filter = i => i.Id == request.Dto.ChangedLivesBlock.ImageId,
-                    AsNoTracking = true
-                });
-
-            if (changedLivesImageExists == null)
+            Image? changedLivesImageExists = null;
+            if (request.Dto.ChangedLivesBlock.ImageId.HasValue)
             {
-                return Result.Fail<ReportMediaSettingsDto>(
-                    ErrorMessagesConstants.NotFound(request.Dto.ChangedLivesBlock.ImageId, typeof(Image)));
+                changedLivesImageExists = await _repositoryWrapper.ImageRepository
+                    .GetFirstOrDefaultAsync(new QueryOptions<Image>
+                    {
+                        Filter = i => i.Id == request.Dto.ChangedLivesBlock.ImageId,
+                        AsNoTracking = true
+                    });
+
+                if (changedLivesImageExists == null)
+                {
+                    return Result.Fail<ReportMediaSettingsDto>(
+                        ErrorMessagesConstants.NotFound(request.Dto.ChangedLivesBlock.ImageId.Value, typeof(Image)));
+                }
             }
 
             var collectedFundsRepository = _repositoryWrapper.GetRepository<CollectedFundsBlock>();
@@ -107,24 +115,20 @@ public class UpdateReportMediaSettingsHandler : IRequestHandler<UpdateReportMedi
                     ErrorMessagesConstants.FailedToUpdateEntity(typeof(CollectedFundsBlock)));
             }
 
-            var updatedCollectedFunds = await collectedFundsRepository.GetFirstOrDefaultAsync(
-                new QueryOptions<CollectedFundsBlock>
-                {
-                    Filter = x => x.Id == collectedFundsEntity.Id,
-                    Include = q => q.Include(x => x.Image!)
-                });
+            if (collectedFundsEntity != null)
+            {
+                collectedFundsEntity.Image = collectedFundsImageExists;
+            }
 
-            var updatedChangedLives = await changedLivesRepository.GetFirstOrDefaultAsync(
-                new QueryOptions<ChangedLivesBlock>
-                {
-                    Filter = x => x.Id == changedLivesEntity.Id,
-                    Include = q => q.Include(x => x.Image!)
-                });
+            if (changedLivesEntity != null)
+            {
+                changedLivesEntity.Image = changedLivesImageExists;
+            }
 
             var resultDto = new ReportMediaSettingsDto
             {
-                CollectedFundsBlock = _mapper.Map<CollectedFundsBlockDto>(updatedCollectedFunds),
-                ChangedLivesBlock = _mapper.Map<ChangedLivesBlockDto>(updatedChangedLives)
+                CollectedFundsBlock = _mapper.Map<CollectedFundsBlockDto>(collectedFundsEntity),
+                ChangedLivesBlock = _mapper.Map<ChangedLivesBlockDto>(changedLivesEntity)
             };
 
             return Result.Ok(resultDto);

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Create/CreateReportProgramExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Create/CreateReportProgramExpendituresRecordHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
 using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -15,14 +16,17 @@ public class CreateReportProgramExpendituresRecordHandler :
     IRequestHandler<CreateReportProgramExpendituresRecordCommand, Result<ReportProgramExpendituresRecordDto>>
 {
     private readonly IMapper _mapper;
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
 
     public CreateReportProgramExpendituresRecordHandler(
         IRepositoryWrapper repositoryWrapper,
-        IMapper mapper)
+        IMapper mapper,
+        IMediator mediator)
     {
         _repositoryWrapper = repositoryWrapper;
         _mapper = mapper;
+        _mediator = mediator;
     }
 
     public async Task<Result<ReportProgramExpendituresRecordDto>> Handle(
@@ -73,6 +77,8 @@ public class CreateReportProgramExpendituresRecordHandler :
                 return Result.Fail(
                     ErrorMessagesConstants.FailedToCreateEntity(typeof(ReportProgramExpendituresRecord)));
             }
+
+            await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
         }
         catch (DbUpdateException dbUpdateException) when (dbUpdateException.IsUniqueConstraintException())
         {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Delete/DeleteReportProgramExpendituresRecordHandler.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -12,15 +13,18 @@ namespace VictoryCenter.BLL.Commands.Admin.ReportProgramExpendituresRecords.Dele
 public class DeleteReportProgramExpendituresRecordHandler
     : IRequestHandler<DeleteReportProgramExpendituresRecordCommand, Result<long>>
 {
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<DeleteReportProgramExpendituresRecordCommand> _validator;
 
     public DeleteReportProgramExpendituresRecordHandler(
         IRepositoryWrapper repositoryWrapper,
-        IValidator<DeleteReportProgramExpendituresRecordCommand> validator)
+        IValidator<DeleteReportProgramExpendituresRecordCommand> validator,
+        IMediator mediator)
     {
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
+        _mediator = mediator;
     }
 
     public async Task<Result<long>> Handle(
@@ -53,6 +57,8 @@ public class DeleteReportProgramExpendituresRecordHandler
                 return Result.Fail(
                     ErrorMessagesConstants.FailedToDeleteEntity(typeof(ReportProgramExpendituresRecord)));
             }
+
+            await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
 
             return Result.Ok(request.ReportProgramExpendituresRecordId);
         }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Update/UpdateReportProgramExpendituresRecordHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/ReportProgramExpendituresRecords/Update/UpdateReportProgramExpendituresRecordHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.ReportProgramExpendituresRecords;
 using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Notifications.ReportFunds;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -16,17 +17,20 @@ public class UpdateReportProgramExpendituresRecordHandler
     : IRequestHandler<UpdateReportProgramExpendituresRecordCommand, Result<ReportProgramExpendituresRecordDto>>
 {
     private readonly IMapper _mapper;
+    private readonly IMediator _mediator;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly IValidator<UpdateReportProgramExpendituresRecordCommand> _validator;
 
     public UpdateReportProgramExpendituresRecordHandler(
         IValidator<UpdateReportProgramExpendituresRecordCommand> validator,
         IRepositoryWrapper repositoryWrapper,
-        IMapper mapper)
+        IMapper mapper,
+        IMediator mediator)
     {
         _validator = validator;
         _repositoryWrapper = repositoryWrapper;
         _mapper = mapper;
+        _mediator = mediator;
     }
 
     public async Task<Result<ReportProgramExpendituresRecordDto>> Handle(
@@ -85,6 +89,8 @@ public class UpdateReportProgramExpendituresRecordHandler
                 return Result.Fail(
                     ErrorMessagesConstants.FailedToUpdateEntity(typeof(ReportProgramExpendituresRecord)));
             }
+
+            await _mediator.Publish(new ReportFundsChangedNotification(), CancellationToken.None);
         }
         catch (DbUpdateException dbUpdateException) when (dbUpdateException.IsUniqueConstraintException())
         {

--- a/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/ErrorMessagesConstants.cs
@@ -242,4 +242,9 @@ public static class ErrorMessagesConstants
     {
         return $"{property} must be a valid email address.";
     }
+
+    public static string CannotCancelChangesNoBackupFound()
+    {
+        return "Cannot cancel changes because no previous published version was found. Please save and publish the report first.";
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportFundsExpendituresSettings/ReportFundsExpendituresSettingsDto.cs
@@ -6,4 +6,5 @@ public record ReportFundsExpendituresSettingsDto
     public string DisclaimerTitle { get; init; } = null!;
     public decimal ExchangeRate { get; init; }
     public int ProgramExpendituresReportingYear { get; init; }
+    public bool HasUnpublishedChanges { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateChangedLivesBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateChangedLivesBlockDto.cs
@@ -5,5 +5,5 @@ public record UpdateChangedLivesBlockDto
     public string Title { get; init; } = null!;
     public string TitleEn { get; init; } = null!;
     public int ChangedLives { get; init; }
-    public long ImageId { get; init; }
+    public long? ImageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateCollectedFundsBlockDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/ReportMediaSettings/UpdateCollectedFundsBlockDto.cs
@@ -4,5 +4,5 @@ public record UpdateCollectedFundsBlockDto
 {
     public string Title { get; init; } = null!;
     public string TitleEn { get; init; } = null!;
-    public long ImageId { get; init; }
+    public long? ImageId { get; init; }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Public/ReportFundsExpenditures/PublishedReportFundsExpendituresDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Public/ReportFundsExpenditures/PublishedReportFundsExpendituresDto.cs
@@ -1,0 +1,61 @@
+namespace VictoryCenter.BLL.DTOs.Public.ReportFundsExpenditures;
+
+public record PublishedReportFundsExpendituresDto
+{
+    public PublishedReportSettingsDto Settings { get; init; } = null!;
+
+    public PublishedFundsExpendituresGroupDto Funding { get; init; } = null!;
+
+    public PublishedFundsExpendituresGroupDto Expenses { get; init; } = null!;
+
+    public PublishedProgramExpendituresGroupDto Programs { get; init; } = null!;
+}
+
+public record PublishedReportSettingsDto
+{
+    public string DisclaimerTitle { get; init; } = "";
+
+    public decimal ExchangeRate { get; init; }
+
+    public int ProgramExpendituresReportingYear { get; init; }
+
+    public DateTimeOffset PublishedAt { get; init; }
+}
+
+public record PublishedFundsExpendituresGroupDto
+{
+    public decimal TotalUah { get; init; }
+
+    public decimal TotalUsd { get; init; }
+
+    public IReadOnlyList<PublishedFundsExpendituresItemDto> Items { get; init; } = [];
+}
+
+public record PublishedFundsExpendituresItemDto
+{
+    public string Label { get; init; } = "";
+
+    public decimal AmountUah { get; init; }
+
+    public decimal AmountUsd { get; init; }
+}
+
+public record PublishedProgramExpendituresGroupDto
+{
+    public decimal TotalUah { get; init; }
+
+    public decimal TotalUsd { get; init; }
+
+    public IReadOnlyList<PublishedProgramExpendituresItemDto> Items { get; init; } = [];
+}
+
+public record PublishedProgramExpendituresItemDto
+{
+    public string Label { get; init; } = "";
+
+    public int ReportingYear { get; init; }
+
+    public decimal AmountUah { get; init; }
+
+    public decimal AmountUsd { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Public/ReportFundsExpenditures/PublishedReportFundsExpendituresDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Public/ReportFundsExpenditures/PublishedReportFundsExpendituresDto.cs
@@ -9,6 +9,8 @@ public record PublishedReportFundsExpendituresDto
     public PublishedFundsExpendituresGroupDto Expenses { get; init; } = null!;
 
     public PublishedProgramExpendituresGroupDto Programs { get; init; } = null!;
+
+    public PublishedReportMediaSettingsDto MediaSettings { get; init; } = new();
 }
 
 public record PublishedReportSettingsDto

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Public/ReportFundsExpenditures/PublishedReportMediaSettingsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Public/ReportFundsExpenditures/PublishedReportMediaSettingsDto.cs
@@ -1,0 +1,14 @@
+namespace VictoryCenter.BLL.DTOs.Public.ReportFundsExpenditures;
+
+public record PublishedMediaBlockDto
+{
+    public string Title { get; init; } = string.Empty;
+    public string? ImageUrl { get; init; }
+    public int? Value { get; init; }
+}
+
+public record PublishedReportMediaSettingsDto
+{
+    public PublishedMediaBlockDto CollectedFunds { get; init; } = new();
+    public PublishedMediaBlockDto ChangedLives { get; init; } = new();
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ReportFundsExpendituresSettingsHelper.cs
@@ -11,12 +11,14 @@ public static class ReportFundsExpendituresSettingsHelper
 {
     public static async Task<Result<ReportFundsExpendituresSettingsEntity>> GetOrCreateSettingsAsync(
         IRepositoryWrapper repositoryWrapper,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        bool asNoTracking = true)
     {
         var settings = await repositoryWrapper.ReportFundsExpendituresSettingsRepository
             .GetFirstOrDefaultAsync(new QueryOptions<ReportFundsExpendituresSettingsEntity>
             {
-                Filter = entity => entity.Id == ReportFundsExpendituresSettingsConstants.SingletonSettingsId
+                Filter = entity => entity.Id == ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
+                AsNoTracking = asNoTracking
             });
 
         if (settings is not null)

--- a/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/MarkReportFundsChangedHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/MarkReportFundsChangedHandler.cs
@@ -18,7 +18,7 @@ public class MarkReportFundsChangedHandler : INotificationHandler<ReportFundsCha
     public async Task Handle(ReportFundsChangedNotification notification, CancellationToken cancellationToken)
     {
         var settingsResult = await ReportFundsExpendituresSettingsHelper
-            .GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider);
+            .GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider, asNoTracking: false);
 
         if (settingsResult.IsFailed)
         {
@@ -30,7 +30,6 @@ public class MarkReportFundsChangedHandler : INotificationHandler<ReportFundsCha
         if (!settings.HasUnpublishedChanges)
         {
             settings.HasUnpublishedChanges = true;
-            _repositoryWrapper.ReportFundsExpendituresSettingsRepository.Update(settings);
             await _repositoryWrapper.SaveChangesAsync();
         }
     }

--- a/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/MarkReportFundsChangedHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Notifications/ReportFunds/MarkReportFundsChangedHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Notifications.ReportFunds;
+
+public class MarkReportFundsChangedHandler : INotificationHandler<ReportFundsChangedNotification>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly TimeProvider _timeProvider;
+
+    public MarkReportFundsChangedHandler(IRepositoryWrapper repositoryWrapper, TimeProvider timeProvider)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task Handle(ReportFundsChangedNotification notification, CancellationToken cancellationToken)
+    {
+        var settingsResult = await ReportFundsExpendituresSettingsHelper
+            .GetOrCreateSettingsAsync(_repositoryWrapper, _timeProvider);
+
+        if (settingsResult.IsFailed)
+        {
+            return;
+        }
+
+        var settings = settingsResult.Value;
+
+        if (!settings.HasUnpublishedChanges)
+        {
+            settings.HasUnpublishedChanges = true;
+            _repositoryWrapper.ReportFundsExpendituresSettingsRepository.Update(settings);
+            await _repositoryWrapper.SaveChangesAsync();
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/ReportFundsExpenditures/GetPublished/GetPublishedReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/ReportFundsExpenditures/GetPublished/GetPublishedReportFundsExpendituresHandler.cs
@@ -1,0 +1,142 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Public.ReportFundsExpenditures;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Public.ReportFundsExpenditures.GetPublished;
+
+public class GetPublishedReportFundsExpendituresHandler
+    : IRequestHandler<GetPublishedReportFundsExpendituresQuery, Result<PublishedReportFundsExpendituresDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetPublishedReportFundsExpendituresHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<PublishedReportFundsExpendituresDto>> Handle(
+        GetPublishedReportFundsExpendituresQuery request,
+        CancellationToken cancellationToken)
+    {
+        var snapshot = await _repositoryWrapper.PublishedReportFundsExpendituresSnapshotRepository
+            .GetFirstOrDefaultAsync(new QueryOptions<PublishedReportFundsExpendituresSnapshot>
+            {
+                AsNoTracking = true
+            });
+
+        if (snapshot is null)
+        {
+            return Result.Ok(new PublishedReportFundsExpendituresDto
+            {
+                Settings = new PublishedReportSettingsDto(),
+                Funding = new PublishedFundsExpendituresGroupDto(),
+                Expenses = new PublishedFundsExpendituresGroupDto(),
+                Programs = new PublishedProgramExpendituresGroupDto()
+            });
+        }
+
+        var fundsRecords = (await _repositoryWrapper.PublishedReportFundsExpendituresRecordsRepository
+            .GetAllAsync(new QueryOptions<PublishedReportFundsExpendituresRecord>
+            {
+                AsNoTracking = true
+            })).ToList();
+
+        var programRecords = (await _repositoryWrapper.PublishedReportProgramExpendituresRecordsRepository
+            .GetAllAsync(new QueryOptions<PublishedReportProgramExpendituresRecord>
+            {
+                AsNoTracking = true
+            })).ToList();
+
+        var isEnglish = await IsEnglishLanguage(request.LanguageId);
+
+        var settings = new PublishedReportSettingsDto
+        {
+            DisclaimerTitle = Resolve(isEnglish, snapshot.DisclaimerTitleEn, snapshot.DisclaimerTitle),
+            ExchangeRate = snapshot.ExchangeRate,
+            ProgramExpendituresReportingYear = snapshot.ProgramExpendituresReportingYear,
+            PublishedAt = snapshot.PublishedAt
+        };
+
+        var incomeRecords = fundsRecords
+            .Where(r => r.Type == ReportFundsExpendituresType.Income)
+            .ToList();
+
+        var expenseRecords = fundsRecords
+            .Where(r => r.Type == ReportFundsExpendituresType.Expense)
+            .ToList();
+
+        var funding = new PublishedFundsExpendituresGroupDto
+        {
+            TotalUah = incomeRecords.Sum(r => r.AmountUah),
+            TotalUsd = incomeRecords.Sum(r => r.AmountUsd),
+            Items = incomeRecords.Select(r => new PublishedFundsExpendituresItemDto
+            {
+                Label = Resolve(isEnglish, r.CategoryNameEn, r.CategoryName),
+                AmountUah = r.AmountUah,
+                AmountUsd = r.AmountUsd
+            }).ToList()
+        };
+
+        var expenses = new PublishedFundsExpendituresGroupDto
+        {
+            TotalUah = expenseRecords.Sum(r => r.AmountUah),
+            TotalUsd = expenseRecords.Sum(r => r.AmountUsd),
+            Items = expenseRecords.Select(r => new PublishedFundsExpendituresItemDto
+            {
+                Label = Resolve(isEnglish, r.CategoryNameEn, r.CategoryName),
+                AmountUah = r.AmountUah,
+                AmountUsd = r.AmountUsd
+            }).ToList()
+        };
+
+        var programs = new PublishedProgramExpendituresGroupDto
+        {
+            TotalUah = programRecords.Sum(r => r.AmountUah),
+            TotalUsd = programRecords.Sum(r => r.AmountUsd),
+            Items = programRecords.Select(r => new PublishedProgramExpendituresItemDto
+            {
+                Label = Resolve(isEnglish, r.CategoryNameEn, r.CategoryName),
+                ReportingYear = r.ReportingYear,
+                AmountUah = r.AmountUah,
+                AmountUsd = r.AmountUsd
+            }).ToList()
+        };
+
+        return Result.Ok(new PublishedReportFundsExpendituresDto
+        {
+            Settings = settings,
+            Funding = funding,
+            Expenses = expenses,
+            Programs = programs
+        });
+    }
+
+    private async Task<bool> IsEnglishLanguage(long? languageId)
+    {
+        if (!languageId.HasValue)
+        {
+            return false;
+        }
+
+        var language = await _repositoryWrapper.LocalizationLanguagesRepository
+            .GetFirstOrDefaultAsync(new QueryOptions<LocalizationLanguage>
+            {
+                Filter = l => l.Id == languageId.Value,
+                AsNoTracking = true
+            });
+
+        return language?.Code == "en";
+    }
+
+    private static string Resolve(bool isEnglish, string? englishValue, string defaultValue)
+    {
+        return isEnglish && !string.IsNullOrWhiteSpace(englishValue)
+            ? englishValue
+            : defaultValue;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/ReportFundsExpenditures/GetPublished/GetPublishedReportFundsExpendituresHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/ReportFundsExpenditures/GetPublished/GetPublishedReportFundsExpendituresHandler.cs
@@ -1,5 +1,6 @@
 using FluentResults;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Public.ReportFundsExpenditures;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
@@ -8,15 +9,18 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
 namespace VictoryCenter.BLL.Queries.Public.ReportFundsExpenditures.GetPublished;
+using VictoryCenter.BLL.Interfaces.BlobStorage;
 
 public class GetPublishedReportFundsExpendituresHandler
     : IRequestHandler<GetPublishedReportFundsExpendituresQuery, Result<PublishedReportFundsExpendituresDto>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IBlobService _blobService;
 
-    public GetPublishedReportFundsExpendituresHandler(IRepositoryWrapper repositoryWrapper)
+    public GetPublishedReportFundsExpendituresHandler(IRepositoryWrapper repositoryWrapper, IBlobService blobService)
     {
         _repositoryWrapper = repositoryWrapper;
+        _blobService = blobService;
     }
 
     public async Task<Result<PublishedReportFundsExpendituresDto>> Handle(
@@ -29,6 +33,37 @@ public class GetPublishedReportFundsExpendituresHandler
                 AsNoTracking = true
             });
 
+        var collectedFundsBlock = await _repositoryWrapper.GetRepository<CollectedFundsBlock>()
+            .GetFirstOrDefaultAsync(new QueryOptions<CollectedFundsBlock>
+            {
+                Include = q => q.Include(c => c.Image),
+                AsNoTracking = true
+            });
+
+        var changedLivesBlock = await _repositoryWrapper.GetRepository<ChangedLivesBlock>()
+            .GetFirstOrDefaultAsync(new QueryOptions<ChangedLivesBlock>
+            {
+                Include = q => q.Include(c => c.Image),
+                AsNoTracking = true
+            });
+
+        var isEnglish = await IsEnglishLanguage(request.LanguageId);
+
+        var mediaSettings = new PublishedReportMediaSettingsDto
+        {
+            CollectedFunds = new PublishedMediaBlockDto
+            {
+                Title = Resolve(isEnglish, collectedFundsBlock?.TitleEn, collectedFundsBlock?.Title ?? ""),
+                ImageUrl = collectedFundsBlock?.Image != null ? _blobService.GetFileUrl(collectedFundsBlock.Image.BlobName, collectedFundsBlock.Image.MimeType) : null
+            },
+            ChangedLives = new PublishedMediaBlockDto
+            {
+                Title = Resolve(isEnglish, changedLivesBlock?.TitleEn, changedLivesBlock?.Title ?? ""),
+                ImageUrl = changedLivesBlock?.Image != null ? _blobService.GetFileUrl(changedLivesBlock.Image.BlobName, changedLivesBlock.Image.MimeType) : null,
+                Value = changedLivesBlock?.ChangedLivesCount
+            }
+        };
+
         if (snapshot is null)
         {
             return Result.Ok(new PublishedReportFundsExpendituresDto
@@ -36,7 +71,8 @@ public class GetPublishedReportFundsExpendituresHandler
                 Settings = new PublishedReportSettingsDto(),
                 Funding = new PublishedFundsExpendituresGroupDto(),
                 Expenses = new PublishedFundsExpendituresGroupDto(),
-                Programs = new PublishedProgramExpendituresGroupDto()
+                Programs = new PublishedProgramExpendituresGroupDto(),
+                MediaSettings = mediaSettings
             });
         }
 
@@ -51,8 +87,6 @@ public class GetPublishedReportFundsExpendituresHandler
             {
                 AsNoTracking = true
             })).ToList();
-
-        var isEnglish = await IsEnglishLanguage(request.LanguageId);
 
         var settings = new PublishedReportSettingsDto
         {
@@ -112,7 +146,8 @@ public class GetPublishedReportFundsExpendituresHandler
             Settings = settings,
             Funding = funding,
             Expenses = expenses,
-            Programs = programs
+            Programs = programs,
+            MediaSettings = mediaSettings
         });
     }
 

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/ReportFundsExpenditures/GetPublished/GetPublishedReportFundsExpendituresQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/ReportFundsExpenditures/GetPublished/GetPublishedReportFundsExpendituresQuery.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Public.ReportFundsExpenditures;
+
+namespace VictoryCenter.BLL.Queries.Public.ReportFundsExpenditures.GetPublished;
+
+public record GetPublishedReportFundsExpendituresQuery(long? LanguageId)
+    : IRequest<Result<PublishedReportFundsExpendituresDto>>;

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresCategoryConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresCategoryConfig.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class BackupReportFundsExpendituresCategoryConfig : IEntityTypeConfiguration<BackupReportFundsExpendituresCategory>
+{
+    public void Configure(EntityTypeBuilder<BackupReportFundsExpendituresCategory> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.Name)
+            .IsRequired();
+
+        builder.Property(e => e.Type)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresRecordConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresRecordConfig.cs
@@ -4,31 +4,14 @@ using VictoryCenter.DAL.Entities;
 
 namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
 
-public class BackupReportFundsExpendituresRecordConfig : IEntityTypeConfiguration<BackupReportFundsExpendituresRecord>
+public class BackupReportFundsExpendituresRecordConfig : BaseReportFundsExpendituresRecordConfig<BackupReportFundsExpendituresRecord>
 {
-    public void Configure(EntityTypeBuilder<BackupReportFundsExpendituresRecord> builder)
+    public override void Configure(EntityTypeBuilder<BackupReportFundsExpendituresRecord> builder)
     {
-        builder.HasKey(e => e.Id);
+        base.Configure(builder);
 
         builder.Property(e => e.Id)
             .ValueGeneratedNever();
-
-        builder.Property(e => e.Type)
-            .IsRequired();
-
-        builder.Property(e => e.ReportingYear)
-            .IsRequired();
-
-        builder.Property(e => e.AmountUah)
-            .HasPrecision(13, 2)
-            .IsRequired();
-
-        builder.Property(e => e.AmountUsd)
-            .HasPrecision(13, 2)
-            .IsRequired();
-
-        builder.Property(e => e.CreatedAt)
-            .IsRequired();
 
         builder.HasOne(e => e.Category)
             .WithMany(e => e.Records)

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresRecordConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresRecordConfig.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class BackupReportFundsExpendituresRecordConfig : IEntityTypeConfiguration<BackupReportFundsExpendituresRecord>
+{
+    public void Configure(EntityTypeBuilder<BackupReportFundsExpendituresRecord> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.Type)
+            .IsRequired();
+
+        builder.Property(e => e.ReportingYear)
+            .IsRequired();
+
+        builder.Property(e => e.AmountUah)
+            .HasPrecision(13, 2)
+            .IsRequired();
+
+        builder.Property(e => e.AmountUsd)
+            .HasPrecision(13, 2)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(e => e.Category)
+            .WithMany(e => e.Records)
+            .HasForeignKey(e => e.CategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresSettingsConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportFundsExpendituresSettingsConfig.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class BackupReportFundsExpendituresSettingsConfig : IEntityTypeConfiguration<BackupReportFundsExpendituresSettings>
+{
+    public void Configure(EntityTypeBuilder<BackupReportFundsExpendituresSettings> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.DisclaimerTitle)
+            .IsRequired();
+
+        builder.Property(e => e.ExchangeRate)
+            .HasPrecision(18, 6)
+            .IsRequired();
+
+        builder.Property(e => e.ProgramExpendituresReportingYear)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportProgramExpendituresRecordConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BackupReportProgramExpendituresRecordConfig.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public class BackupReportProgramExpendituresRecordConfig : IEntityTypeConfiguration<BackupReportProgramExpendituresRecord>
+{
+    public void Configure(EntityTypeBuilder<BackupReportProgramExpendituresRecord> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(e => e.ReportingYear)
+            .IsRequired();
+
+        builder.Property(e => e.AmountUah)
+            .HasPrecision(13, 2)
+            .IsRequired();
+
+        builder.Property(e => e.AmountUsd)
+            .HasPrecision(13, 2)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.HasOne(e => e.HippotherapyProgramCategory)
+            .WithMany()
+            .HasForeignKey(e => e.HippotherapyProgramCategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BaseReportFundsExpendituresRecordConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/BaseReportFundsExpendituresRecordConfig.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
+
+public abstract class BaseReportFundsExpendituresRecordConfig<TEntity> : IEntityTypeConfiguration<TEntity>
+    where TEntity : BaseReportFundsExpendituresRecord
+{
+    public virtual void Configure(EntityTypeBuilder<TEntity> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Type)
+            .IsRequired();
+
+        builder.Property(e => e.ReportingYear)
+            .IsRequired();
+
+        builder.Property(e => e.AmountUah)
+            .HasPrecision(13, 2)
+            .IsRequired();
+
+        builder.Property(e => e.AmountUsd)
+            .HasPrecision(13, 2)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/BackupReportFundsExpendituresCategoryLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/BackupReportFundsExpendituresCategoryLocalizationConfig.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class BackupReportFundsExpendituresCategoryLocalizationConfig
+    : IEntityTypeConfiguration<BackupReportFundsExpendituresCategoryLocalization>
+{
+    public void Configure(EntityTypeBuilder<BackupReportFundsExpendituresCategoryLocalization> entity)
+    {
+        entity.HasKey(e => new { e.EntityId, e.LanguageId });
+
+        entity.Property(e => e.Name)
+            .IsRequired();
+
+        entity.Property(e => e.TranslationStatus)
+            .IsRequired()
+            .HasDefaultValue(TranslationStatus.Relevant);
+
+        entity.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        entity.HasOne(e => e.Entity)
+            .WithMany(e => e.Localizations)
+            .HasForeignKey(e => e.EntityId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne(e => e.Language)
+            .WithMany()
+            .HasForeignKey(e => e.LanguageId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/BackupReportFundsExpendituresSettingsLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/BackupReportFundsExpendituresSettingsLocalizationConfig.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class BackupReportFundsExpendituresSettingsLocalizationConfig
+    : IEntityTypeConfiguration<BackupReportFundsExpendituresSettingsLocalization>
+{
+    public void Configure(EntityTypeBuilder<BackupReportFundsExpendituresSettingsLocalization> entity)
+    {
+        entity.HasKey(e => new { e.EntityId, e.LanguageId });
+
+        entity.Property(e => e.DisclaimerTitle)
+            .IsRequired();
+
+        entity.Property(e => e.TranslationStatus)
+            .IsRequired()
+            .HasDefaultValue(TranslationStatus.Relevant);
+
+        entity.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        entity.HasOne(e => e.Entity)
+            .WithMany()
+            .HasForeignKey(e => e.EntityId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        entity.HasOne(e => e.Language)
+            .WithMany()
+            .HasForeignKey(e => e.LanguageId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ReportFundsExpendituresRecordConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/ReportFundsExpendituresRecordConfig.cs
@@ -4,31 +4,14 @@ using VictoryCenter.DAL.Entities;
 
 namespace VictoryCenter.DAL.Data.EntityTypeConfigurations;
 
-public class ReportFundsExpendituresRecordConfig : IEntityTypeConfiguration<ReportFundsExpendituresRecord>
+public class ReportFundsExpendituresRecordConfig : BaseReportFundsExpendituresRecordConfig<ReportFundsExpendituresRecord>
 {
-    public void Configure(EntityTypeBuilder<ReportFundsExpendituresRecord> builder)
+    public override void Configure(EntityTypeBuilder<ReportFundsExpendituresRecord> builder)
     {
-        builder.HasKey(e => e.Id);
+        base.Configure(builder);
 
         builder.Property(e => e.Id)
             .ValueGeneratedOnAdd();
-
-        builder.Property(e => e.Type)
-            .IsRequired();
-
-        builder.Property(e => e.ReportingYear)
-            .IsRequired();
-
-        builder.Property(e => e.AmountUah)
-            .HasPrecision(13, 2)
-            .IsRequired();
-
-        builder.Property(e => e.AmountUsd)
-            .HasPrecision(13, 2)
-            .IsRequired();
-
-        builder.Property(e => e.CreatedAt)
-            .IsRequired();
 
         builder.HasOne(e => e.Category)
             .WithMany(e => e.Records)

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -102,6 +102,12 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<ReportProgramExpendituresRecord> ReportProgramExpendituresRecords { get; set; }
 
+    public DbSet<PublishedReportFundsExpendituresRecord> PublishedReportFundsExpendituresRecords { get; set; }
+
+    public DbSet<PublishedReportProgramExpendituresRecord> PublishedReportProgramExpendituresRecords { get; set; }
+
+    public DbSet<PublishedReportFundsExpendituresSnapshot> PublishedReportFundsExpendituresSnapshots { get; set; }
+
     public DbSet<MainPage> MainPages { get; set; }
 
     public DbSet<MainAboutUs> MainAboutUs { get; set; }

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -108,6 +108,18 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<PublishedReportFundsExpendituresSnapshot> PublishedReportFundsExpendituresSnapshots { get; set; }
 
+    public DbSet<BackupReportFundsExpendituresSettings> BackupReportFundsExpendituresSettings { get; set; }
+
+    public DbSet<BackupReportFundsExpendituresSettingsLocalization> BackupReportFundsExpendituresSettingsLocalizations { get; set; }
+
+    public DbSet<BackupReportFundsExpendituresCategory> BackupReportFundsExpendituresCategories { get; set; }
+
+    public DbSet<BackupReportFundsExpendituresCategoryLocalization> BackupReportFundsExpendituresCategoryLocalizations { get; set; }
+
+    public DbSet<BackupReportFundsExpendituresRecord> BackupReportFundsExpendituresRecords { get; set; }
+
+    public DbSet<BackupReportProgramExpendituresRecord> BackupReportProgramExpendituresRecords { get; set; }
+
     public DbSet<MainPage> MainPages { get; set; }
 
     public DbSet<MainAboutUs> MainAboutUs { get; set; }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresCategory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresCategory.cs
@@ -1,0 +1,14 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class BackupReportFundsExpendituresCategory : BaseEntity
+{
+    public string Name { get; set; } = "";
+    public ReportFundsExpendituresType Type { get; set; }
+
+    public ICollection<BackupReportFundsExpendituresCategoryLocalization> Localizations { get; set; } = [];
+    public ICollection<BackupReportFundsExpendituresRecord> Records { get; set; } = [];
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresRecord.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class BackupReportFundsExpendituresRecord : BaseEntity
+{
+    public long CategoryId { get; set; }
+    public ReportFundsExpendituresType Type { get; set; }
+    public int ReportingYear { get; set; }
+    public decimal AmountUah { get; set; }
+    public decimal AmountUsd { get; set; }
+
+    public BackupReportFundsExpendituresCategory Category { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresRecord.cs
@@ -1,15 +1,6 @@
-using VictoryCenter.DAL.Data.BaseEntity;
-using VictoryCenter.DAL.Enums;
-
 namespace VictoryCenter.DAL.Entities;
 
-public class BackupReportFundsExpendituresRecord : BaseEntity
+public class BackupReportFundsExpendituresRecord : BaseReportFundsExpendituresRecord
 {
-    public long CategoryId { get; set; }
-    public ReportFundsExpendituresType Type { get; set; }
-    public int ReportingYear { get; set; }
-    public decimal AmountUah { get; set; }
-    public decimal AmountUsd { get; set; }
-
     public BackupReportFundsExpendituresCategory Category { get; set; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportFundsExpendituresSettings.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class BackupReportFundsExpendituresSettings : BaseEntity
+{
+    public string DisclaimerTitle { get; set; } = "";
+    public decimal ExchangeRate { get; set; }
+    public int ProgramExpendituresReportingYear { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportProgramExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/BackupReportProgramExpendituresRecord.cs
@@ -1,0 +1,13 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class BackupReportProgramExpendituresRecord : BaseEntity
+{
+    public int ReportingYear { get; set; }
+    public long HippotherapyProgramCategoryId { get; set; }
+    public decimal AmountUah { get; set; }
+    public decimal AmountUsd { get; set; }
+
+    public HippotherapyProgramCategory HippotherapyProgramCategory { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/BaseReportFundsExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/BaseReportFundsExpendituresRecord.cs
@@ -1,0 +1,13 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Entities;
+
+public abstract class BaseReportFundsExpendituresRecord : BaseEntity
+{
+    public long CategoryId { get; set; }
+    public ReportFundsExpendituresType Type { get; set; }
+    public int ReportingYear { get; set; }
+    public decimal AmountUah { get; set; }
+    public decimal AmountUsd { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/BackupReportFundsExpendituresCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/BackupReportFundsExpendituresCategoryLocalization.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class BackupReportFundsExpendituresCategoryLocalization
+{
+    public long EntityId { get; set; }
+    public long LanguageId { get; set; }
+    public string Name { get; set; } = null!;
+    public TranslationStatus TranslationStatus { get; set; } = TranslationStatus.Relevant;
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public BackupReportFundsExpendituresCategory Entity { get; set; } = null!;
+    public LocalizationLanguage Language { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/BackupReportFundsExpendituresSettingsLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/BackupReportFundsExpendituresSettingsLocalization.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class BackupReportFundsExpendituresSettingsLocalization
+{
+    public long EntityId { get; set; }
+    public long LanguageId { get; set; }
+    public string DisclaimerTitle { get; set; } = null!;
+    public TranslationStatus TranslationStatus { get; set; } = TranslationStatus.Relevant;
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public BackupReportFundsExpendituresSettings Entity { get; set; } = null!;
+    public LocalizationLanguage Language { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/PublishedReportFundsExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/PublishedReportFundsExpendituresRecord.cs
@@ -1,0 +1,21 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class PublishedReportFundsExpendituresRecord : BaseEntity
+{
+    public long SourceRecordId { get; set; }
+
+    public string CategoryName { get; set; } = "";
+
+    public string? CategoryNameEn { get; set; }
+
+    public ReportFundsExpendituresType Type { get; set; }
+
+    public int ReportingYear { get; set; }
+
+    public decimal AmountUah { get; set; }
+
+    public decimal AmountUsd { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/PublishedReportFundsExpendituresSnapshot.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/PublishedReportFundsExpendituresSnapshot.cs
@@ -1,0 +1,16 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class PublishedReportFundsExpendituresSnapshot : BaseEntity
+{
+    public string DisclaimerTitle { get; set; } = "";
+
+    public string? DisclaimerTitleEn { get; set; }
+
+    public decimal ExchangeRate { get; set; }
+
+    public int ProgramExpendituresReportingYear { get; set; }
+
+    public DateTimeOffset PublishedAt { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/PublishedReportProgramExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/PublishedReportProgramExpendituresRecord.cs
@@ -1,0 +1,18 @@
+using VictoryCenter.DAL.Data.BaseEntity;
+
+namespace VictoryCenter.DAL.Entities;
+
+public class PublishedReportProgramExpendituresRecord : BaseEntity
+{
+    public long SourceRecordId { get; set; }
+
+    public string CategoryName { get; set; } = "";
+
+    public string? CategoryNameEn { get; set; }
+
+    public int ReportingYear { get; set; }
+
+    public decimal AmountUah { get; set; }
+
+    public decimal AmountUsd { get; set; }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresRecord.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresRecord.cs
@@ -1,19 +1,6 @@
-using VictoryCenter.DAL.Data.BaseEntity;
-using VictoryCenter.DAL.Enums;
-
 namespace VictoryCenter.DAL.Entities;
 
-public class ReportFundsExpendituresRecord : BaseEntity
+public class ReportFundsExpendituresRecord : BaseReportFundsExpendituresRecord
 {
-    public long CategoryId { get; set; }
-
-    public ReportFundsExpendituresType Type { get; set; }
-
-    public int ReportingYear { get; set; }
-
-    public decimal AmountUah { get; set; }
-
-    public decimal AmountUsd { get; set; }
-
     public ReportFundsExpendituresCategory Category { get; set; } = null!;
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/ReportFundsExpendituresSettings.cs
@@ -9,6 +9,7 @@ public class ReportFundsExpendituresSettings : BaseEntity, ITranslatedEntity<Rep
     public string DisclaimerTitle { get; set; } = "";
     public decimal ExchangeRate { get; set; }
     public int ProgramExpendituresReportingYear { get; set; }
+    public bool HasUnpublishedChanges { get; set; }
 
     public ICollection<ReportFundsExpendituresSettingsLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260719172632_AddPublishedReportFundsExpendituresSnapshot.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260719172632_AddPublishedReportFundsExpendituresSnapshot.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719172632_AddPublishedReportFundsExpendituresSnapshot")]
+    partial class AddPublishedReportFundsExpendituresSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -2027,9 +2030,6 @@ namespace VictoryCenter.DAL.Migrations
                     b.Property<decimal>("ExchangeRate")
                         .HasPrecision(18, 6)
                         .HasColumnType("decimal(18,6)");
-
-                    b.Property<bool>("HasUnpublishedChanges")
-                        .HasColumnType("bit");
 
                     b.Property<int>("ProgramExpendituresReportingYear")
                         .HasColumnType("int");

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260719172632_AddPublishedReportFundsExpendituresSnapshot.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260719172632_AddPublishedReportFundsExpendituresSnapshot.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPublishedReportFundsExpendituresSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PublishedReportFundsExpendituresRecords",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SourceRecordId = table.Column<long>(type: "bigint", nullable: false),
+                    CategoryName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CategoryNameEn = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    ReportingYear = table.Column<int>(type: "int", nullable: false),
+                    AmountUah = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    AmountUsd = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PublishedReportFundsExpendituresRecords", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PublishedReportFundsExpendituresSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    DisclaimerTitle = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DisclaimerTitleEn = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ExchangeRate = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    ProgramExpendituresReportingYear = table.Column<int>(type: "int", nullable: false),
+                    PublishedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PublishedReportFundsExpendituresSnapshots", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PublishedReportProgramExpendituresRecords",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SourceRecordId = table.Column<long>(type: "bigint", nullable: false),
+                    CategoryName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CategoryNameEn = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ReportingYear = table.Column<int>(type: "int", nullable: false),
+                    AmountUah = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    AmountUsd = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PublishedReportProgramExpendituresRecords", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PublishedReportFundsExpendituresRecords");
+
+            migrationBuilder.DropTable(
+                name: "PublishedReportFundsExpendituresSnapshots");
+
+            migrationBuilder.DropTable(
+                name: "PublishedReportProgramExpendituresRecords");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260720142056_AddHasUnpublishedChangesToSettings.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260720142056_AddHasUnpublishedChangesToSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720142056_AddHasUnpublishedChangesToSettings")]
+    partial class AddHasUnpublishedChangesToSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260720142056_AddHasUnpublishedChangesToSettings.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260720142056_AddHasUnpublishedChangesToSettings.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHasUnpublishedChangesToSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "HasUnpublishedChanges",
+                table: "ReportFundsExpendituresSettings",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HasUnpublishedChanges",
+                table: "ReportFundsExpendituresSettings");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260720162921_AddReportFundsExpendituresBackupTables.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260720162921_AddReportFundsExpendituresBackupTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720162921_AddReportFundsExpendituresBackupTables")]
+    partial class AddReportFundsExpendituresBackupTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260720162921_AddReportFundsExpendituresBackupTables.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260720162921_AddReportFundsExpendituresBackupTables.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReportFundsExpendituresBackupTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BackupReportFundsExpendituresCategories",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupReportFundsExpendituresCategories", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BackupReportFundsExpendituresSettings",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    DisclaimerTitle = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ExchangeRate = table.Column<decimal>(type: "decimal(18,6)", precision: 18, scale: 6, nullable: false),
+                    ProgramExpendituresReportingYear = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupReportFundsExpendituresSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BackupReportProgramExpendituresRecords",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    ReportingYear = table.Column<int>(type: "int", nullable: false),
+                    HippotherapyProgramCategoryId = table.Column<long>(type: "bigint", nullable: false),
+                    AmountUah = table.Column<decimal>(type: "decimal(13,2)", precision: 13, scale: 2, nullable: false),
+                    AmountUsd = table.Column<decimal>(type: "decimal(13,2)", precision: 13, scale: 2, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupReportProgramExpendituresRecords", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BackupReportProgramExpendituresRecords_HippotherapyProgramCategories_HippotherapyProgramCategoryId",
+                        column: x => x.HippotherapyProgramCategoryId,
+                        principalTable: "HippotherapyProgramCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BackupReportFundsExpendituresCategoryLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupReportFundsExpendituresCategoryLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_BackupReportFundsExpendituresCategoryLocalizations_BackupReportFundsExpendituresCategories_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "BackupReportFundsExpendituresCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BackupReportFundsExpendituresCategoryLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BackupReportFundsExpendituresRecords",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    CategoryId = table.Column<long>(type: "bigint", nullable: false),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    ReportingYear = table.Column<int>(type: "int", nullable: false),
+                    AmountUah = table.Column<decimal>(type: "decimal(13,2)", precision: 13, scale: 2, nullable: false),
+                    AmountUsd = table.Column<decimal>(type: "decimal(13,2)", precision: 13, scale: 2, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupReportFundsExpendituresRecords", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BackupReportFundsExpendituresRecords_BackupReportFundsExpendituresCategories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "BackupReportFundsExpendituresCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "BackupReportFundsExpendituresSettingsLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    DisclaimerTitle = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BackupReportFundsExpendituresSettingsLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_BackupReportFundsExpendituresSettingsLocalizations_BackupReportFundsExpendituresSettings_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "BackupReportFundsExpendituresSettings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BackupReportFundsExpendituresSettingsLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BackupReportFundsExpendituresCategoryLocalizations_LanguageId",
+                table: "BackupReportFundsExpendituresCategoryLocalizations",
+                column: "LanguageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BackupReportFundsExpendituresRecords_CategoryId",
+                table: "BackupReportFundsExpendituresRecords",
+                column: "CategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BackupReportFundsExpendituresSettingsLocalizations_LanguageId",
+                table: "BackupReportFundsExpendituresSettingsLocalizations",
+                column: "LanguageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BackupReportProgramExpendituresRecords_HippotherapyProgramCategoryId",
+                table: "BackupReportProgramExpendituresRecords",
+                column: "HippotherapyProgramCategoryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BackupReportFundsExpendituresCategoryLocalizations");
+
+            migrationBuilder.DropTable(
+                name: "BackupReportFundsExpendituresRecords");
+
+            migrationBuilder.DropTable(
+                name: "BackupReportFundsExpendituresSettingsLocalizations");
+
+            migrationBuilder.DropTable(
+                name: "BackupReportProgramExpendituresRecords");
+
+            migrationBuilder.DropTable(
+                name: "BackupReportFundsExpendituresCategories");
+
+            migrationBuilder.DropTable(
+                name: "BackupReportFundsExpendituresSettings");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresCategoriesRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresCategoriesRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+
+public interface IBackupReportFundsExpendituresCategoriesRepository : IRepositoryBase<BackupReportFundsExpendituresCategory>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresCategoryLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+
+public interface IBackupReportFundsExpendituresCategoryLocalizationsRepository : IRepositoryBase<BackupReportFundsExpendituresCategoryLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresRecordsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+
+public interface IBackupReportFundsExpendituresRecordsRepository : IRepositoryBase<BackupReportFundsExpendituresRecord>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresSettingsLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresSettingsLocalizationsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+
+public interface IBackupReportFundsExpendituresSettingsLocalizationsRepository : IRepositoryBase<BackupReportFundsExpendituresSettingsLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresSettingsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportFundsExpendituresSettingsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+
+public interface IBackupReportFundsExpendituresSettingsRepository : IRepositoryBase<BackupReportFundsExpendituresSettings>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportProgramExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/BackupReportFundsExpenditures/IBackupReportProgramExpendituresRecordsRepository.cs
@@ -1,0 +1,8 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+
+public interface IBackupReportProgramExpendituresRecordsRepository : IRepositoryBase<BackupReportProgramExpendituresRecord>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -37,6 +37,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.EventNewsCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -89,6 +90,13 @@ public interface IRepositoryWrapper
     IPublishedReportFundsExpendituresRecordsRepository PublishedReportFundsExpendituresRecordsRepository { get; }
     IPublishedReportProgramExpendituresRecordsRepository PublishedReportProgramExpendituresRecordsRepository { get; }
     IPublishedReportFundsExpendituresSnapshotRepository PublishedReportFundsExpendituresSnapshotRepository { get; }
+
+    IBackupReportFundsExpendituresSettingsRepository BackupReportFundsExpendituresSettingsRepository { get; }
+    IBackupReportFundsExpendituresSettingsLocalizationsRepository BackupReportFundsExpendituresSettingsLocalizationsRepository { get; }
+    IBackupReportFundsExpendituresCategoriesRepository BackupReportFundsExpendituresCategoriesRepository { get; }
+    IBackupReportFundsExpendituresCategoryLocalizationsRepository BackupReportFundsExpendituresCategoryLocalizationsRepository { get; }
+    IBackupReportFundsExpendituresRecordsRepository BackupReportFundsExpendituresRecordsRepository { get; }
+    IBackupReportProgramExpendituresRecordsRepository BackupReportProgramExpendituresRecordsRepository { get; }
 
     ICompanyProfileRepository CompanyProfileRepository { get; }
     ICompanyProfileContactRepository CompanyProfileContactRepository { get; }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -34,6 +34,9 @@ using VictoryCenter.DAL.Repositories.Interfaces.WhoWeAreSections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.History;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNewsCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
 
 namespace VictoryCenter.DAL.Repositories.Interfaces.Base;
 
@@ -82,6 +85,10 @@ public interface IRepositoryWrapper
     IReportFundsExpendituresSettingsRepository ReportFundsExpendituresSettingsRepository { get; }
 
     IReportProgramExpendituresRecordsRepository ReportProgramExpendituresRecordsRepository { get; }
+
+    IPublishedReportFundsExpendituresRecordsRepository PublishedReportFundsExpendituresRecordsRepository { get; }
+    IPublishedReportProgramExpendituresRecordsRepository PublishedReportProgramExpendituresRecordsRepository { get; }
+    IPublishedReportFundsExpendituresSnapshotRepository PublishedReportFundsExpendituresSnapshotRepository { get; }
 
     ICompanyProfileRepository CompanyProfileRepository { get; }
     ICompanyProfileContactRepository CompanyProfileContactRepository { get; }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -1,4 +1,5 @@
 using System.Transactions;
+using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Interfaces.Donate;
 using VictoryCenter.DAL.Repositories.Interfaces.FaqPlacements;
@@ -130,5 +131,12 @@ public interface IRepositoryWrapper
 
     Task<int> SaveChangesAsync();
 
+    /// <summary>Legacy ambient-scope transaction. Prefer <see cref="BeginTransactionAsync"/> for new code.</summary>
+    /// <returns>A <see cref="TransactionScope"/> with async flow enabled.</returns>
     TransactionScope BeginTransaction();
+
+    /// <summary>Begins an explicit EF Core database transaction on the single underlying connection, avoiding MSDTC escalation.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An <see cref="IDbContextTransaction"/> that must be committed or disposed.</returns>
+    Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
 }

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/PublishedReportFundsExpendituresRecords/IPublishedReportFundsExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/PublishedReportFundsExpendituresRecords/IPublishedReportFundsExpendituresRecordsRepository.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
+
+public interface IPublishedReportFundsExpendituresRecordsRepository
+    : IRepositoryBase<PublishedReportFundsExpendituresRecord>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/PublishedReportFundsExpendituresSnapshot/IPublishedReportFundsExpendituresSnapshotRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/PublishedReportFundsExpendituresSnapshot/IPublishedReportFundsExpendituresSnapshotRepository.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using PublishedSnapshotEntity = VictoryCenter.DAL.Entities.PublishedReportFundsExpendituresSnapshot;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
+
+public interface IPublishedReportFundsExpendituresSnapshotRepository
+    : IRepositoryBase<PublishedSnapshotEntity>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/PublishedReportProgramExpendituresRecords/IPublishedReportProgramExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/PublishedReportProgramExpendituresRecords/IPublishedReportProgramExpendituresRecordsRepository.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
+
+public interface IPublishedReportProgramExpendituresRecordsRepository
+    : IRepositoryBase<PublishedReportProgramExpendituresRecord>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresCategoriesRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresCategoriesRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
+
+public class BackupReportFundsExpendituresCategoriesRepository
+    : RepositoryBase<BackupReportFundsExpendituresCategory>, IBackupReportFundsExpendituresCategoriesRepository
+{
+    public BackupReportFundsExpendituresCategoriesRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresCategoryLocalizationsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
+
+public class BackupReportFundsExpendituresCategoryLocalizationsRepository
+    : RepositoryBase<BackupReportFundsExpendituresCategoryLocalization>, IBackupReportFundsExpendituresCategoryLocalizationsRepository
+{
+    public BackupReportFundsExpendituresCategoryLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresRecordsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
+
+public class BackupReportFundsExpendituresRecordsRepository
+    : RepositoryBase<BackupReportFundsExpendituresRecord>, IBackupReportFundsExpendituresRecordsRepository
+{
+    public BackupReportFundsExpendituresRecordsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresSettingsLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresSettingsLocalizationsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
+
+public class BackupReportFundsExpendituresSettingsLocalizationsRepository
+    : RepositoryBase<BackupReportFundsExpendituresSettingsLocalization>, IBackupReportFundsExpendituresSettingsLocalizationsRepository
+{
+    public BackupReportFundsExpendituresSettingsLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresSettingsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportFundsExpendituresSettingsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
+
+public class BackupReportFundsExpendituresSettingsRepository
+    : RepositoryBase<BackupReportFundsExpendituresSettings>, IBackupReportFundsExpendituresSettingsRepository
+{
+    public BackupReportFundsExpendituresSettingsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportProgramExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/BackupReportFundsExpenditures/BackupReportProgramExpendituresRecordsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
+
+public class BackupReportProgramExpendituresRecordsRepository
+    : RepositoryBase<BackupReportProgramExpendituresRecord>, IBackupReportProgramExpendituresRecordsRepository
+{
+    public BackupReportProgramExpendituresRecordsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -72,6 +72,12 @@ using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNewsCategories;
 using VictoryCenter.DAL.Repositories.Realizations.EventNews;
 using VictoryCenter.DAL.Repositories.Realizations.EventNewsCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
+using VictoryCenter.DAL.Repositories.Realizations.PublishedReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Realizations.PublishedReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Realizations.PublishedReportFundsExpendituresSnapshot;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -137,6 +143,9 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IHistorySectionContentLocalizationsRepository? _historySectionContentLocalizationsRepository;
     private IEventNewsRepository? _eventNewsRepository;
     private IEventNewsCategoryRepository? _eventNewsCategoryRepository;
+    private IPublishedReportFundsExpendituresRecordsRepository? _publishedReportFundsExpendituresRecordsRepository;
+    private IPublishedReportProgramExpendituresRecordsRepository? _publishedReportProgramExpendituresRecordsRepository;
+    private IPublishedReportFundsExpendituresSnapshotRepository? _publishedReportFundsExpendituresSnapshotRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -326,6 +335,18 @@ public class RepositoryWrapper : IRepositoryWrapper
 
     public IEventNewsCategoryRepository EventNewsCategoryRepository =>
         _eventNewsCategoryRepository ??= new EventNewsCategoryRepository(_victoryCenterDbContext);
+
+    public IPublishedReportFundsExpendituresRecordsRepository PublishedReportFundsExpendituresRecordsRepository =>
+        _publishedReportFundsExpendituresRecordsRepository ??=
+            new PublishedReportFundsExpendituresRecordsRepository(_victoryCenterDbContext);
+
+    public IPublishedReportProgramExpendituresRecordsRepository PublishedReportProgramExpendituresRecordsRepository =>
+        _publishedReportProgramExpendituresRecordsRepository ??=
+            new PublishedReportProgramExpendituresRecordsRepository(_victoryCenterDbContext);
+
+    public IPublishedReportFundsExpendituresSnapshotRepository PublishedReportFundsExpendituresSnapshotRepository =>
+        _publishedReportFundsExpendituresSnapshotRepository ??=
+            new PublishedReportFundsExpendituresSnapshotRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -78,6 +78,8 @@ using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpenditures
 using VictoryCenter.DAL.Repositories.Realizations.PublishedReportFundsExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Realizations.PublishedReportProgramExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Realizations.PublishedReportFundsExpendituresSnapshot;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Realizations.BackupReportFundsExpenditures;
 
 namespace VictoryCenter.DAL.Repositories.Realizations.Base;
 
@@ -146,6 +148,12 @@ public class RepositoryWrapper : IRepositoryWrapper
     private IPublishedReportFundsExpendituresRecordsRepository? _publishedReportFundsExpendituresRecordsRepository;
     private IPublishedReportProgramExpendituresRecordsRepository? _publishedReportProgramExpendituresRecordsRepository;
     private IPublishedReportFundsExpendituresSnapshotRepository? _publishedReportFundsExpendituresSnapshotRepository;
+    private IBackupReportFundsExpendituresSettingsRepository? _backupReportFundsExpendituresSettingsRepository;
+    private IBackupReportFundsExpendituresSettingsLocalizationsRepository? _backupReportFundsExpendituresSettingsLocalizationsRepository;
+    private IBackupReportFundsExpendituresCategoriesRepository? _backupReportFundsExpendituresCategoriesRepository;
+    private IBackupReportFundsExpendituresCategoryLocalizationsRepository? _backupReportFundsExpendituresCategoryLocalizationsRepository;
+    private IBackupReportFundsExpendituresRecordsRepository? _backupReportFundsExpendituresRecordsRepository;
+    private IBackupReportProgramExpendituresRecordsRepository? _backupReportProgramExpendituresRecordsRepository;
 
     public RepositoryWrapper(VictoryCenterDbContext context)
     {
@@ -347,6 +355,30 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IPublishedReportFundsExpendituresSnapshotRepository PublishedReportFundsExpendituresSnapshotRepository =>
         _publishedReportFundsExpendituresSnapshotRepository ??=
             new PublishedReportFundsExpendituresSnapshotRepository(_victoryCenterDbContext);
+
+    public IBackupReportFundsExpendituresSettingsRepository BackupReportFundsExpendituresSettingsRepository =>
+        _backupReportFundsExpendituresSettingsRepository ??=
+            new BackupReportFundsExpendituresSettingsRepository(_victoryCenterDbContext);
+
+    public IBackupReportFundsExpendituresSettingsLocalizationsRepository BackupReportFundsExpendituresSettingsLocalizationsRepository =>
+        _backupReportFundsExpendituresSettingsLocalizationsRepository ??=
+            new BackupReportFundsExpendituresSettingsLocalizationsRepository(_victoryCenterDbContext);
+
+    public IBackupReportFundsExpendituresCategoriesRepository BackupReportFundsExpendituresCategoriesRepository =>
+        _backupReportFundsExpendituresCategoriesRepository ??=
+            new BackupReportFundsExpendituresCategoriesRepository(_victoryCenterDbContext);
+
+    public IBackupReportFundsExpendituresCategoryLocalizationsRepository BackupReportFundsExpendituresCategoryLocalizationsRepository =>
+        _backupReportFundsExpendituresCategoryLocalizationsRepository ??=
+            new BackupReportFundsExpendituresCategoryLocalizationsRepository(_victoryCenterDbContext);
+
+    public IBackupReportFundsExpendituresRecordsRepository BackupReportFundsExpendituresRecordsRepository =>
+        _backupReportFundsExpendituresRecordsRepository ??=
+            new BackupReportFundsExpendituresRecordsRepository(_victoryCenterDbContext);
+
+    public IBackupReportProgramExpendituresRecordsRepository BackupReportProgramExpendituresRecordsRepository =>
+        _backupReportProgramExpendituresRecordsRepository ??=
+            new BackupReportProgramExpendituresRecordsRepository(_victoryCenterDbContext);
 
     public int SaveChanges()
     {

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Transactions;
+using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.DAL.Data;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.CompanyProfile;
@@ -388,6 +389,11 @@ public class RepositoryWrapper : IRepositoryWrapper
     public async Task<int> SaveChangesAsync()
     {
         return await _victoryCenterDbContext.SaveChangesAsync();
+    }
+
+    public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        return _victoryCenterDbContext.Database.BeginTransactionAsync(cancellationToken);
     }
 
     public TransactionScope BeginTransaction()

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/PublishedReportFundsExpendituresRecords/PublishedReportFundsExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/PublishedReportFundsExpendituresRecords/PublishedReportFundsExpendituresRecordsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.PublishedReportFundsExpendituresRecords;
+
+public class PublishedReportFundsExpendituresRecordsRepository
+    : RepositoryBase<PublishedReportFundsExpendituresRecord>, IPublishedReportFundsExpendituresRecordsRepository
+{
+    public PublishedReportFundsExpendituresRecordsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/PublishedReportFundsExpendituresSnapshot/PublishedReportFundsExpendituresSnapshotRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/PublishedReportFundsExpendituresSnapshot/PublishedReportFundsExpendituresSnapshotRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+using PublishedSnapshotEntity = VictoryCenter.DAL.Entities.PublishedReportFundsExpendituresSnapshot;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.PublishedReportFundsExpendituresSnapshot;
+
+public class PublishedReportFundsExpendituresSnapshotRepository
+    : RepositoryBase<PublishedSnapshotEntity>, IPublishedReportFundsExpendituresSnapshotRepository
+{
+    public PublishedReportFundsExpendituresSnapshotRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/PublishedReportProgramExpendituresRecords/PublishedReportProgramExpendituresRecordsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/PublishedReportProgramExpendituresRecords/PublishedReportProgramExpendituresRecordsRepository.cs
@@ -1,0 +1,15 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.PublishedReportProgramExpendituresRecords;
+
+public class PublishedReportProgramExpendituresRecordsRepository
+    : RepositoryBase<PublishedReportProgramExpendituresRecord>, IPublishedReportProgramExpendituresRecordsRepository
+{
+    public PublishedReportProgramExpendituresRecordsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Notifications/ReportFunds/MarkReportFundsChangedHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Notifications/ReportFunds/MarkReportFundsChangedHandlerTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Notifications.ReportFunds;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Notifications.ReportFunds;
+
+public class MarkReportFundsChangedHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IReportFundsExpendituresSettingsRepository> _settingsRepoMock;
+    private readonly TimeProvider _timeProvider;
+
+    public MarkReportFundsChangedHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _settingsRepoMock = new Mock<IReportFundsExpendituresSettingsRepository>();
+
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresSettingsRepository).Returns(_settingsRepoMock.Object);
+        _timeProvider = TimeProvider.System;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEarly_WhenGetOrCreateSettingsFails()
+    {
+        // Arrange
+        _settingsRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings>>()))
+            .ReturnsAsync((global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings?)null);
+
+        _repositoryWrapperMock.Setup(w => w.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = new MarkReportFundsChangedHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        _repositoryWrapperMock.Verify(w => w.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSetHasUnpublishedChanges_WhenFalse()
+    {
+        // Arrange
+        var settings = new global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings { HasUnpublishedChanges = false };
+        _settingsRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(settings);
+
+        var handler = new MarkReportFundsChangedHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        Assert.True(settings.HasUnpublishedChanges);
+        _repositoryWrapperMock.Verify(w => w.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotSaveChanges_WhenHasUnpublishedChangesIsTrue()
+    {
+        // Arrange
+        var settings = new global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings { HasUnpublishedChanges = true };
+        _settingsRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(settings);
+
+        var handler = new MarkReportFundsChangedHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        await handler.Handle(new ReportFundsChangedNotification(), CancellationToken.None);
+
+        // Assert
+        Assert.True(settings.HasUnpublishedChanges);
+        _repositoryWrapperMock.Verify(w => w.SaveChangesAsync(), Times.Never);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpenditures/CancelReportFundsExpendituresHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpenditures/CancelReportFundsExpendituresHandlerTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Cancel;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpenditures;
+
+public class CancelReportFundsExpendituresHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IBackupReportFundsExpendituresSettingsRepository> _backupSettingsRepositoryMock;
+    private readonly Mock<IBackupReportFundsExpendituresSettingsLocalizationsRepository> _backupSettingsLocalizationsRepositoryMock;
+    private readonly Mock<IBackupReportFundsExpendituresCategoriesRepository> _backupCategoriesRepositoryMock;
+    private readonly Mock<IBackupReportFundsExpendituresRecordsRepository> _backupFundsRecordsRepositoryMock;
+    private readonly Mock<IBackupReportProgramExpendituresRecordsRepository> _backupProgramRecordsRepositoryMock;
+
+    private readonly Mock<IReportFundsExpendituresSettingsRepository> _settingsRepositoryMock;
+    private readonly Mock<IReportFundsExpendituresSettingsLocalizationsRepository> _settingsLocalizationsRepositoryMock;
+    private readonly Mock<IReportFundsExpendituresCategoriesRepository> _categoriesRepositoryMock;
+    private readonly Mock<IReportFundsExpendituresCategoryLocalizationsRepository> _categoryLocalizationsRepositoryMock;
+    private readonly Mock<IReportFundsExpendituresRecordsRepository> _fundsRecordsRepositoryMock;
+    private readonly Mock<IReportProgramExpendituresRecordsRepository> _programRecordsRepositoryMock;
+    private readonly Mock<IDbContextTransaction> _transactionMock;
+
+    private readonly TimeProvider _timeProvider;
+
+    public CancelReportFundsExpendituresHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+
+        _backupSettingsRepositoryMock = new Mock<IBackupReportFundsExpendituresSettingsRepository>();
+        _backupSettingsLocalizationsRepositoryMock = new Mock<IBackupReportFundsExpendituresSettingsLocalizationsRepository>();
+        _backupCategoriesRepositoryMock = new Mock<IBackupReportFundsExpendituresCategoriesRepository>();
+        _backupFundsRecordsRepositoryMock = new Mock<IBackupReportFundsExpendituresRecordsRepository>();
+        _backupProgramRecordsRepositoryMock = new Mock<IBackupReportProgramExpendituresRecordsRepository>();
+
+        _settingsRepositoryMock = new Mock<IReportFundsExpendituresSettingsRepository>();
+        _settingsLocalizationsRepositoryMock = new Mock<IReportFundsExpendituresSettingsLocalizationsRepository>();
+        _categoriesRepositoryMock = new Mock<IReportFundsExpendituresCategoriesRepository>();
+        _categoryLocalizationsRepositoryMock = new Mock<IReportFundsExpendituresCategoryLocalizationsRepository>();
+        _fundsRecordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
+        _programRecordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
+        _transactionMock = new Mock<IDbContextTransaction>();
+
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresSettingsRepository).Returns(_backupSettingsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresSettingsLocalizationsRepository).Returns(_backupSettingsLocalizationsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresCategoriesRepository).Returns(_backupCategoriesRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresRecordsRepository).Returns(_backupFundsRecordsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.BackupReportProgramExpendituresRecordsRepository).Returns(_backupProgramRecordsRepositoryMock.Object);
+
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresSettingsRepository).Returns(_settingsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresSettingsLocalizationsRepository).Returns(_settingsLocalizationsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresCategoriesRepository).Returns(_categoriesRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresCategoryLocalizationsRepository).Returns(_categoryLocalizationsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresRecordsRepository).Returns(_fundsRecordsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.ReportProgramExpendituresRecordsRepository).Returns(_programRecordsRepositoryMock.Object);
+
+        _repositoryWrapperMock.Setup(w => w.BeginTransactionAsync(It.IsAny<CancellationToken>())).ReturnsAsync(_transactionMock.Object);
+
+        _settingsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(new global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings { Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId });
+
+        _timeProvider = TimeProvider.System;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenBackupSettingsNotFound()
+    {
+        // Arrange
+        _backupSettingsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresSettings>>()))
+            .ReturnsAsync((BackupReportFundsExpendituresSettings?)null);
+
+        var handler = new CancelReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        var result = await handler.Handle(new CancelReportFundsExpendituresCommand(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal(ErrorMessagesConstants.CannotCancelChangesNoBackupFound(), result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCancelSuccessfully_WhenDataExists()
+    {
+        // Arrange
+        var backupSettings = new BackupReportFundsExpendituresSettings { DisclaimerTitle = "Backup Title" };
+        _backupSettingsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(backupSettings);
+
+        var backupSettingsLocalizations = new List<BackupReportFundsExpendituresSettingsLocalization>
+        {
+            new() { LanguageId = 1, DisclaimerTitle = "Title EN" }
+        };
+        _backupSettingsLocalizationsRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresSettingsLocalization>>()))
+            .ReturnsAsync(backupSettingsLocalizations);
+
+        var backupCategories = new List<BackupReportFundsExpendituresCategory>
+        {
+            new()
+            {
+                Id = 1,
+                Name = "Cat1",
+                Localizations = new List<BackupReportFundsExpendituresCategoryLocalization>
+                {
+                    new() { EntityId = 1, LanguageId = 1, Name = "Cat1 EN" }
+                }
+            }
+        };
+        _backupCategoriesRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresCategory>>()))
+            .ReturnsAsync(backupCategories);
+
+        var backupFundsRecords = new List<BackupReportFundsExpendituresRecord>
+        {
+            new() { CategoryId = 1, AmountUah = 100 }
+        };
+        _backupFundsRecordsRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresRecord>>()))
+            .ReturnsAsync(backupFundsRecords);
+
+        var backupProgramRecords = new List<BackupReportProgramExpendituresRecord>
+        {
+            new() { HippotherapyProgramCategoryId = 1, AmountUah = 200 }
+        };
+        _backupProgramRecordsRepositoryMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<BackupReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(backupProgramRecords);
+
+        var handler = new CancelReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        var result = await handler.Handle(new CancelReportFundsExpendituresCommand(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        _fundsRecordsRepositoryMock.Verify(r => r.BulkDeleteAsync(It.IsAny<System.Linq.Expressions.Expression<Func<ReportFundsExpendituresRecord, bool>>>()), Times.Once);
+        _programRecordsRepositoryMock.Verify(r => r.BulkDeleteAsync(It.IsAny<System.Linq.Expressions.Expression<Func<ReportProgramExpendituresRecord, bool>>>()), Times.Once);
+        _categoriesRepositoryMock.Verify(r => r.CreateRangeAsync(It.IsAny<ReportFundsExpendituresCategory[]>()), Times.Once);
+        _repositoryWrapperMock.Verify(w => w.SaveChangesAsync(), Times.AtLeastOnce);
+        _transactionMock.Verify(t => t.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenDbUpdateExceptionOccurs()
+    {
+        // Arrange
+        _backupSettingsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(new BackupReportFundsExpendituresSettings());
+
+        _repositoryWrapperMock.Setup(w => w.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+
+        var handler = new CancelReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        var result = await handler.Handle(new CancelReportFundsExpendituresCommand(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal("Failed to cancel report funds expenditures changes.", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenExceptionOccurs()
+    {
+        // Arrange
+        _backupSettingsRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<BackupReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(new BackupReportFundsExpendituresSettings());
+
+        _repositoryWrapperMock.Setup(w => w.SaveChangesAsync())
+            .ThrowsAsync(new Exception());
+
+        var handler = new CancelReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _timeProvider);
+
+        // Act
+        var result = await handler.Handle(new CancelReportFundsExpendituresCommand(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal("An unexpected error occurred while canceling report funds expenditures changes.", result.Errors[0].Message);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpenditures/GetPublishedReportFundsExpendituresHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpenditures/GetPublishedReportFundsExpendituresHandlerTests.cs
@@ -1,0 +1,130 @@
+using Moq;
+using VictoryCenter.BLL.Interfaces.BlobStorage;
+using VictoryCenter.BLL.Queries.Public.ReportFundsExpenditures.GetPublished;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpenditures;
+
+public class GetPublishedReportFundsExpendituresHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IBlobService> _blobServiceMock;
+
+    private readonly Mock<IPublishedReportFundsExpendituresSnapshotRepository> _snapshotRepoMock;
+    private readonly Mock<IPublishedReportFundsExpendituresRecordsRepository> _fundsRecordsRepoMock;
+    private readonly Mock<IPublishedReportProgramExpendituresRecordsRepository> _programRecordsRepoMock;
+    private readonly Mock<ILocalizationLanguagesRepository> _languageRepoMock;
+    private readonly Mock<IRepositoryBase<CollectedFundsBlock>> _collectedFundsRepoMock;
+    private readonly Mock<IRepositoryBase<ChangedLivesBlock>> _changedLivesRepoMock;
+
+    public GetPublishedReportFundsExpendituresHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _blobServiceMock = new Mock<IBlobService>();
+
+        _snapshotRepoMock = new Mock<IPublishedReportFundsExpendituresSnapshotRepository>();
+        _fundsRecordsRepoMock = new Mock<IPublishedReportFundsExpendituresRecordsRepository>();
+        _programRecordsRepoMock = new Mock<IPublishedReportProgramExpendituresRecordsRepository>();
+        _languageRepoMock = new Mock<ILocalizationLanguagesRepository>();
+        _collectedFundsRepoMock = new Mock<IRepositoryBase<CollectedFundsBlock>>();
+        _changedLivesRepoMock = new Mock<IRepositoryBase<ChangedLivesBlock>>();
+
+        _repositoryWrapperMock.Setup(w => w.PublishedReportFundsExpendituresSnapshotRepository).Returns(_snapshotRepoMock.Object);
+        _repositoryWrapperMock.Setup(w => w.PublishedReportFundsExpendituresRecordsRepository).Returns(_fundsRecordsRepoMock.Object);
+        _repositoryWrapperMock.Setup(w => w.PublishedReportProgramExpendituresRecordsRepository).Returns(_programRecordsRepoMock.Object);
+        _repositoryWrapperMock.Setup(w => w.LocalizationLanguagesRepository).Returns(_languageRepoMock.Object);
+        _repositoryWrapperMock.Setup(w => w.GetRepository<CollectedFundsBlock>()).Returns(_collectedFundsRepoMock.Object);
+        _repositoryWrapperMock.Setup(w => w.GetRepository<ChangedLivesBlock>()).Returns(_changedLivesRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmpty_WhenNoSnapshotFound()
+    {
+        // Arrange
+        _snapshotRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PublishedReportFundsExpendituresSnapshot>>()))
+            .ReturnsAsync((PublishedReportFundsExpendituresSnapshot?)null);
+
+        var handler = new GetPublishedReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _blobServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(new GetPublishedReportFundsExpendituresQuery(null), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value.Settings);
+        Assert.NotNull(result.Value.Funding);
+        Assert.NotNull(result.Value.Expenses);
+        Assert.NotNull(result.Value.Programs);
+        Assert.NotNull(result.Value.MediaSettings);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnData_WhenSnapshotAndRecordsExist()
+    {
+        // Arrange
+        var snapshot = new PublishedReportFundsExpendituresSnapshot
+        {
+            DisclaimerTitle = "Title",
+            DisclaimerTitleEn = "Title EN",
+            ExchangeRate = 38m,
+            ProgramExpendituresReportingYear = 2024
+        };
+        _snapshotRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<PublishedReportFundsExpendituresSnapshot>>()))
+            .ReturnsAsync(snapshot);
+
+        var fundsRecords = new List<PublishedReportFundsExpendituresRecord>
+        {
+            new() { Type = ReportFundsExpendituresType.Income, AmountUah = 100, CategoryName = "Cat", CategoryNameEn = "Cat EN" },
+            new() { Type = ReportFundsExpendituresType.Expense, AmountUah = 50, CategoryName = "Exp", CategoryNameEn = "Exp EN" }
+        };
+        _fundsRecordsRepoMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<PublishedReportFundsExpendituresRecord>>()))
+            .ReturnsAsync(fundsRecords);
+
+        var programRecords = new List<PublishedReportProgramExpendituresRecord>
+        {
+            new() { AmountUah = 200, CategoryName = "Prog", CategoryNameEn = "Prog EN" }
+        };
+        _programRecordsRepoMock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<PublishedReportProgramExpendituresRecord>>()))
+            .ReturnsAsync(programRecords);
+
+        _languageRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync(new LocalizationLanguage { Code = "en" });
+
+        _collectedFundsRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<CollectedFundsBlock>>()))
+            .ReturnsAsync(new CollectedFundsBlock { Title = "UA", TitleEn = "EN", Image = new Image { BlobName = "a.jpg", MimeType = "image/jpeg" } });
+
+        _changedLivesRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<ChangedLivesBlock>>()))
+            .ReturnsAsync(new ChangedLivesBlock { Title = "UA", TitleEn = "EN" });
+
+        _blobServiceMock.Setup(b => b.GetFileUrl(It.IsAny<string>(), It.IsAny<string>())).Returns("http://url");
+
+        var handler = new GetPublishedReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _blobServiceMock.Object);
+
+        // Act
+        var result = await handler.Handle(new GetPublishedReportFundsExpendituresQuery(1), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Title EN", result.Value.Settings.DisclaimerTitle);
+        Assert.Single(result.Value.Funding.Items);
+        Assert.Equal(100, result.Value.Funding.TotalUah);
+        Assert.Equal("Cat EN", result.Value.Funding.Items[0].Label);
+
+        Assert.Single(result.Value.Expenses.Items);
+        Assert.Equal(50, result.Value.Expenses.TotalUah);
+
+        Assert.Single(result.Value.Programs.Items);
+        Assert.Equal(200, result.Value.Programs.TotalUah);
+
+        Assert.Equal("EN", result.Value.MediaSettings.CollectedFunds.Title);
+        Assert.Equal("http://url", result.Value.MediaSettings.CollectedFunds.ImageUrl);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpenditures/PublishReportFundsExpendituresHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpenditures/PublishReportFundsExpendituresHandlerTests.cs
@@ -1,0 +1,173 @@
+using FluentValidation;
+using Microsoft.EntityFrameworkCore.Storage;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.BackupReportFundsExpenditures;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportFundsExpendituresSnapshot;
+using VictoryCenter.DAL.Repositories.Interfaces.PublishedReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresCategories;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpenditures;
+
+public class PublishReportFundsExpendituresHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IValidator<PublishReportFundsExpendituresCommand>> _validatorMock;
+    private readonly Mock<IDbContextTransaction> _transactionMock;
+    private readonly TimeProvider _timeProvider;
+
+    public PublishReportFundsExpendituresHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _validatorMock = new Mock<IValidator<PublishReportFundsExpendituresCommand>>();
+        _transactionMock = new Mock<IDbContextTransaction>();
+        _timeProvider = TimeProvider.System;
+
+        _repositoryWrapperMock.Setup(w => w.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_transactionMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldPublishSuccessfully_WhenDataIsValid()
+    {
+        // Arrange
+        var fundsRecords = new List<ReportFundsExpendituresRecord>
+        {
+            new()
+            {
+                Id = 1,
+                Category = new ReportFundsExpendituresCategory
+                {
+                    Name = "Cat",
+                    Localizations = new List<ReportFundsExpendituresCategoryLocalization>
+                    {
+                        new() { Language = new LocalizationLanguage { Code = "en" }, Name = "Cat EN" }
+                    }
+                }
+            }
+        };
+
+        var programRecords = new List<ReportProgramExpendituresRecord>
+        {
+            new()
+            {
+                Id = 1,
+                HippotherapyProgramCategory = new HippotherapyProgramCategory { Name = "ProgCat" }
+            }
+        };
+
+        var settings = new global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings
+        {
+            Id = ReportFundsExpendituresSettingsConstants.SingletonSettingsId,
+            DisclaimerTitle = "Disclaimer"
+        };
+
+        var settingsLocalizations = new List<ReportFundsExpendituresSettingsLocalization>
+        {
+            new() { Language = new LocalizationLanguage { Code = "en" }, DisclaimerTitle = "Disclaimer EN" }
+        };
+
+        var categories = new List<ReportFundsExpendituresCategory>();
+
+        SetupRepository<IReportFundsExpendituresRecordsRepository, ReportFundsExpendituresRecord>(
+            w => w.ReportFundsExpendituresRecordsRepository, fundsRecords);
+
+        SetupRepository<IReportProgramExpendituresRecordsRepository, ReportProgramExpendituresRecord>(
+            w => w.ReportProgramExpendituresRecordsRepository, programRecords);
+
+        SetupRepository<IReportFundsExpendituresSettingsLocalizationsRepository, ReportFundsExpendituresSettingsLocalization>(
+            w => w.ReportFundsExpendituresSettingsLocalizationsRepository, settingsLocalizations);
+
+        SetupRepository<IReportFundsExpendituresCategoriesRepository, ReportFundsExpendituresCategory>(
+            w => w.ReportFundsExpendituresCategoriesRepository, categories);
+
+        var settingsRepoMock = new Mock<IReportFundsExpendituresSettingsRepository>();
+        settingsRepoMock.Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<global::VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings>>()))
+            .ReturnsAsync(settings);
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresSettingsRepository).Returns(settingsRepoMock.Object);
+
+        var publishedFundsRepoMock = new Mock<IPublishedReportFundsExpendituresRecordsRepository>();
+        _repositoryWrapperMock.Setup(w => w.PublishedReportFundsExpendituresRecordsRepository).Returns(publishedFundsRepoMock.Object);
+        var publishedProgramRepoMock = new Mock<IPublishedReportProgramExpendituresRecordsRepository>();
+        _repositoryWrapperMock.Setup(w => w.PublishedReportProgramExpendituresRecordsRepository).Returns(publishedProgramRepoMock.Object);
+        var publishedSnapshotRepoMock = new Mock<IPublishedReportFundsExpendituresSnapshotRepository>();
+        _repositoryWrapperMock.Setup(w => w.PublishedReportFundsExpendituresSnapshotRepository).Returns(publishedSnapshotRepoMock.Object);
+
+        var backupFundsRepoMock = new Mock<IBackupReportFundsExpendituresRecordsRepository>();
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresRecordsRepository).Returns(backupFundsRepoMock.Object);
+        var backupProgramRepoMock = new Mock<IBackupReportProgramExpendituresRecordsRepository>();
+        _repositoryWrapperMock.Setup(w => w.BackupReportProgramExpendituresRecordsRepository).Returns(backupProgramRepoMock.Object);
+        var backupCatLocsRepoMock = new Mock<IBackupReportFundsExpendituresCategoryLocalizationsRepository>();
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresCategoryLocalizationsRepository).Returns(backupCatLocsRepoMock.Object);
+        var backupCatsRepoMock = new Mock<IBackupReportFundsExpendituresCategoriesRepository>();
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresCategoriesRepository).Returns(backupCatsRepoMock.Object);
+        var backupSetLocsRepoMock = new Mock<IBackupReportFundsExpendituresSettingsLocalizationsRepository>();
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresSettingsLocalizationsRepository).Returns(backupSetLocsRepoMock.Object);
+        var backupSettingsRepoMock = new Mock<IBackupReportFundsExpendituresSettingsRepository>();
+        _repositoryWrapperMock.Setup(w => w.BackupReportFundsExpendituresSettingsRepository).Returns(backupSettingsRepoMock.Object);
+
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+
+        var handler = new PublishReportFundsExpendituresHandler(
+            _repositoryWrapperMock.Object,
+            _validatorMock.Object,
+            _timeProvider);
+
+        // Act
+        var result = await handler.Handle(new PublishReportFundsExpendituresCommand(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        publishedFundsRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<PublishedReportFundsExpendituresRecord[]>()), Times.Once);
+        publishedProgramRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<PublishedReportProgramExpendituresRecord[]>()), Times.Once);
+        publishedSnapshotRepoMock.Verify(r => r.CreateAsync(It.IsAny<PublishedReportFundsExpendituresSnapshot>()), Times.Once);
+
+        backupFundsRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<BackupReportFundsExpendituresRecord[]>()), Times.Once);
+        backupProgramRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<BackupReportProgramExpendituresRecord[]>()), Times.Once);
+        backupCatsRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<BackupReportFundsExpendituresCategory[]>()), Times.Once);
+        backupCatLocsRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<BackupReportFundsExpendituresCategoryLocalization[]>()), Times.Once);
+        backupSettingsRepoMock.Verify(r => r.CreateAsync(It.IsAny<BackupReportFundsExpendituresSettings>()), Times.Once);
+        backupSetLocsRepoMock.Verify(r => r.CreateRangeAsync(It.IsAny<BackupReportFundsExpendituresSettingsLocalization[]>()), Times.Once);
+
+        _repositoryWrapperMock.Verify(w => w.SaveChangesAsync(), Times.AtLeastOnce);
+        _transactionMock.Verify(t => t.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFail_WhenValidationFails()
+    {
+        // Arrange
+        _validatorMock.Setup(v => v.ValidateAsync(It.IsAny<IValidationContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult(new[] { new FluentValidation.Results.ValidationFailure("Prop", "Error") }));
+
+        var handler = new PublishReportFundsExpendituresHandler(_repositoryWrapperMock.Object, _validatorMock.Object, _timeProvider);
+
+        // Act
+        var result = await handler.Handle(new PublishReportFundsExpendituresCommand(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal("An unexpected error occurred while publishing report funds expenditures data.", result.Errors[0].Message);
+    }
+
+    private void SetupRepository<TRepo, TEntity>(System.Linq.Expressions.Expression<Func<IRepositoryWrapper, TRepo>> expression, List<TEntity> items)
+        where TRepo : class, IRepositoryBase<TEntity>
+        where TEntity : class
+    {
+        var mock = new Mock<TRepo>();
+        mock.Setup(r => r.GetAllAsync(It.IsAny<QueryOptions<TEntity>>())).ReturnsAsync(items);
+        _repositoryWrapperMock.Setup(expression).Returns(mock.Object);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportFundsExpendituresSettings/UpdateReportFundsExpendituresSettingsTests.cs
@@ -11,6 +11,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresSettings;
 using VictoryCenter.DAL.Repositories.Options;
+using MediatR;
 using ReportFundsExpendituresSettingsEntity = VictoryCenter.DAL.Entities.ReportFundsExpendituresSettings;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportFundsExpendituresSettings;
@@ -21,6 +22,7 @@ public class UpdateReportFundsExpendituresSettingsTests
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
     private readonly Mock<IReportFundsExpendituresSettingsRepository> _settingsRepositoryMock;
     private readonly Mock<IReportFundsExpendituresSettingsLocalizationsRepository> _localizationsRepositoryMock;
+    private readonly Mock<IMediator> _mediatorMock;
     private readonly IValidator<UpdateReportFundsExpendituresSettingsCommand> _validator;
 
     private readonly UpdateReportFundsExpendituresSettingsDto _updateDto = new()
@@ -52,6 +54,7 @@ public class UpdateReportFundsExpendituresSettingsTests
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _settingsRepositoryMock = new Mock<IReportFundsExpendituresSettingsRepository>();
         _localizationsRepositoryMock = new Mock<IReportFundsExpendituresSettingsLocalizationsRepository>();
+        _mediatorMock = new Mock<IMediator>();
         _validator = new UpdateReportFundsExpendituresSettingsValidator(new BaseReportFundsExpendituresSettingsValidator());
     }
 
@@ -64,7 +67,8 @@ public class UpdateReportFundsExpendituresSettingsTests
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
             _validator,
-            TimeProvider.System);
+            TimeProvider.System,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -90,7 +94,8 @@ public class UpdateReportFundsExpendituresSettingsTests
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
             _validator,
-            TimeProvider.System);
+            TimeProvider.System,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -111,7 +116,8 @@ public class UpdateReportFundsExpendituresSettingsTests
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
             _validator,
-            TimeProvider.System);
+            TimeProvider.System,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -136,7 +142,8 @@ public class UpdateReportFundsExpendituresSettingsTests
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
             _validator,
-            TimeProvider.System);
+            TimeProvider.System,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -161,7 +168,8 @@ public class UpdateReportFundsExpendituresSettingsTests
             _mapperMock.Object,
             _repositoryWrapperMock.Object,
             _validator,
-            TimeProvider.System);
+            TimeProvider.System,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/UpdateReportMediaSettingsHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportMediaSettings/UpdateReportMediaSettingsHandlerTests.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using FluentValidation;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.ReportMediaSettings.UpdateReportMediaSettings;
@@ -15,6 +16,7 @@ public class UpdateReportMediaSettingsHandlerTests
     private readonly Mock<IMapper> _mockMapper;
     private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
     private readonly Mock<IValidator<UpdateReportMediaSettingsCommand>> _mockValidator;
+    private readonly Mock<IMediator> _mockMediator;
 
     private readonly UpdateReportMediaSettingsDto _updateDto = new()
     {
@@ -60,6 +62,7 @@ public class UpdateReportMediaSettingsHandlerTests
         _mockMapper = new Mock<IMapper>();
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
         _mockValidator = new Mock<IValidator<UpdateReportMediaSettingsCommand>>();
+        _mockMediator = new Mock<IMediator>();
     }
 
     [Fact]
@@ -83,7 +86,8 @@ public class UpdateReportMediaSettingsHandlerTests
         var handler = new UpdateReportMediaSettingsHandler(
             _mockRepositoryWrapper.Object,
             _mockMapper.Object,
-            _mockValidator.Object);
+            _mockValidator.Object,
+            _mockMediator.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -119,7 +123,8 @@ public class UpdateReportMediaSettingsHandlerTests
         var handler = new UpdateReportMediaSettingsHandler(
             _mockRepositoryWrapper.Object,
             _mockMapper.Object,
-            _mockValidator.Object);
+            _mockValidator.Object,
+            _mockMediator.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -153,7 +158,8 @@ public class UpdateReportMediaSettingsHandlerTests
         var handler = new UpdateReportMediaSettingsHandler(
             _mockRepositoryWrapper.Object,
             _mockMapper.Object,
-            _mockValidator.Object);
+            _mockValidator.Object,
+            _mockMediator.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -178,7 +184,8 @@ public class UpdateReportMediaSettingsHandlerTests
         var handler = new UpdateReportMediaSettingsHandler(
             _mockRepositoryWrapper.Object,
             _mockMapper.Object,
-            _mockValidator.Object);
+            _mockValidator.Object,
+            _mockMediator.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -207,7 +214,8 @@ public class UpdateReportMediaSettingsHandlerTests
         var handler = new UpdateReportMediaSettingsHandler(
             _mockRepositoryWrapper.Object,
             _mockMapper.Object,
-            _mockValidator.Object);
+            _mockValidator.Object,
+            _mockMediator.Object);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/CreateReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/CreateReportProgramExpendituresRecordTests.cs
@@ -9,6 +9,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Options;
+using MediatR;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportProgramExpendituresRecords;
 
@@ -52,6 +53,7 @@ public class CreateReportProgramExpendituresRecordTests
 
     private readonly Mock<IReportProgramExpendituresRecordsRepository> _recordsRepositoryMock;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IMediator> _mediatorMock;
 
     public CreateReportProgramExpendituresRecordTests()
     {
@@ -59,6 +61,7 @@ public class CreateReportProgramExpendituresRecordTests
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _recordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
         _hippotherapyProgramCategoriesRepositoryMock = new Mock<IHippotherapyProgramCategoriesRepository>();
+        _mediatorMock = new Mock<IMediator>();
     }
 
     [Fact]
@@ -68,7 +71,8 @@ public class CreateReportProgramExpendituresRecordTests
         SetupDependencies(_category, 1);
         var handler = new CreateReportProgramExpendituresRecordHandler(
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -88,7 +92,8 @@ public class CreateReportProgramExpendituresRecordTests
         SetupDependencies(null, 1);
         var handler = new CreateReportProgramExpendituresRecordHandler(
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -111,7 +116,8 @@ public class CreateReportProgramExpendituresRecordTests
         SetupDependencies(_category, 1, true);
         var handler = new CreateReportProgramExpendituresRecordHandler(
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -133,7 +139,8 @@ public class CreateReportProgramExpendituresRecordTests
         SetupDependencies(_category, 0);
         var handler = new CreateReportProgramExpendituresRecordHandler(
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -156,7 +163,8 @@ public class CreateReportProgramExpendituresRecordTests
 
         var handler = new CreateReportProgramExpendituresRecordHandler(
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordTests.cs
@@ -8,6 +8,7 @@ using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Options;
+using MediatR;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportProgramExpendituresRecords;
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/DeleteReportProgramExpendituresRecordTests.cs
@@ -38,7 +38,7 @@ public class DeleteReportProgramExpendituresRecordTests
     {
         // Arrange
         SetupDependencies(_record, saveResult: 1);
-        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator, new Mock<IMediator>().Object);
 
         // Act
         var result = await handler.Handle(
@@ -54,7 +54,7 @@ public class DeleteReportProgramExpendituresRecordTests
     public async Task Handle_ShouldFail_WhenValidationFails()
     {
         // Arrange
-        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator, new Mock<IMediator>().Object);
 
         // Act
         var result = await handler.Handle(
@@ -73,7 +73,7 @@ public class DeleteReportProgramExpendituresRecordTests
     {
         // Arrange
         SetupDependencies(null, saveResult: 1);
-        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator, new Mock<IMediator>().Object);
 
         // Act
         var result = await handler.Handle(
@@ -92,7 +92,7 @@ public class DeleteReportProgramExpendituresRecordTests
     {
         // Arrange
         SetupDependencies(_record, saveResult: 0);
-        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator, new Mock<IMediator>().Object);
 
         // Act
         var result = await handler.Handle(
@@ -114,7 +114,7 @@ public class DeleteReportProgramExpendituresRecordTests
         _repositoryWrapperMock
             .Setup(wrapper => wrapper.SaveChangesAsync())
             .ThrowsAsync(new DbUpdateException("Database error"));
-        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator);
+        var handler = new DeleteReportProgramExpendituresRecordHandler(_repositoryWrapperMock.Object, _validator, new Mock<IMediator>().Object);
 
         // Act
         var result = await handler.Handle(

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/UpdateReportProgramExpendituresRecordTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/ReportProgramExpendituresRecords/UpdateReportProgramExpendituresRecordTests.cs
@@ -11,6 +11,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
 using VictoryCenter.DAL.Repositories.Options;
+using MediatR;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.ReportProgramExpendituresRecords;
 
@@ -39,6 +40,7 @@ public class UpdateReportProgramExpendituresRecordTests
     private readonly Mock<IHippotherapyProgramCategoriesRepository> _hippotherapyProgramCategoriesRepositoryMock;
     private readonly Mock<IReportProgramExpendituresRecordsRepository> _recordsRepositoryMock;
     private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IMediator> _mediatorMock;
     private readonly IValidator<UpdateReportProgramExpendituresRecordCommand> _validator;
 
     public UpdateReportProgramExpendituresRecordTests()
@@ -56,6 +58,7 @@ public class UpdateReportProgramExpendituresRecordTests
         _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
         _hippotherapyProgramCategoriesRepositoryMock = new Mock<IHippotherapyProgramCategoriesRepository>();
         _recordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
+        _mediatorMock = new Mock<IMediator>();
         _validator = new UpdateReportProgramExpendituresRecordCommandValidator(_repositoryWrapperMock.Object);
     }
 
@@ -68,7 +71,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -88,7 +92,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -109,7 +114,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -132,7 +138,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -156,7 +163,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -179,7 +187,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(
@@ -203,7 +212,8 @@ public class UpdateReportProgramExpendituresRecordTests
         var handler = new UpdateReportProgramExpendituresRecordHandler(
             _validator,
             _repositoryWrapperMock.Object,
-            _mapperMock.Object);
+            _mapperMock.Object,
+            _mediatorMock.Object);
 
         // Act
         var result = await handler.Handle(

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpenditures/PublishReportFundsExpendituresValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/ReportFundsExpenditures/PublishReportFundsExpendituresValidatorTests.cs
@@ -1,0 +1,92 @@
+using FluentValidation.TestHelper;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportFundsExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Interfaces.ReportProgramExpendituresRecords;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.ReportFundsExpenditures;
+
+public class PublishReportFundsExpendituresValidatorTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IReportFundsExpendituresRecordsRepository> _fundsRecordsRepositoryMock;
+    private readonly Mock<IReportProgramExpendituresRecordsRepository> _programRecordsRepositoryMock;
+
+    public PublishReportFundsExpendituresValidatorTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _fundsRecordsRepositoryMock = new Mock<IReportFundsExpendituresRecordsRepository>();
+        _programRecordsRepositoryMock = new Mock<IReportProgramExpendituresRecordsRepository>();
+
+        _repositoryWrapperMock.Setup(w => w.ReportFundsExpendituresRecordsRepository).Returns(_fundsRecordsRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(w => w.ReportProgramExpendituresRecordsRepository).Returns(_programRecordsRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Validate_ShouldNotHaveError_WhenAllConditionsMet()
+    {
+        // Arrange
+        _fundsRecordsRepositoryMock.Setup(r => r.CountAsync(It.Is<QueryOptions<ReportFundsExpendituresRecord>>(q =>
+            q.Filter != null && q.Filter.Compile().Invoke(new ReportFundsExpendituresRecord { Type = ReportFundsExpendituresType.Expense }))))
+            .ReturnsAsync(2);
+
+        _fundsRecordsRepositoryMock.Setup(r => r.CountAsync(It.Is<QueryOptions<ReportFundsExpendituresRecord>>(q =>
+            q.Filter != null && q.Filter.Compile().Invoke(new ReportFundsExpendituresRecord { Type = ReportFundsExpendituresType.Income }))))
+            .ReturnsAsync(2);
+
+        _programRecordsRepositoryMock.Setup(r => r.CountAsync(null))
+            .ReturnsAsync(1);
+
+        var validator = new PublishReportFundsExpendituresValidator(_repositoryWrapperMock.Object);
+
+        // Act
+        var result = await validator.TestValidateAsync(new PublishReportFundsExpendituresCommand());
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task Validate_ShouldHaveError_WhenNotEnoughExpenseRecords()
+    {
+        // Arrange
+        _fundsRecordsRepositoryMock.Setup(r => r.CountAsync(It.IsAny<QueryOptions<ReportFundsExpendituresRecord>>()))
+            .ReturnsAsync(1);
+
+        _programRecordsRepositoryMock.Setup(r => r.CountAsync(null))
+            .ReturnsAsync(1);
+
+        var validator = new PublishReportFundsExpendituresValidator(_repositoryWrapperMock.Object);
+
+        // Act
+        var result = await validator.TestValidateAsync(new PublishReportFundsExpendituresCommand());
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c)
+            .WithErrorMessage("At least 2 expense records are required to publish.");
+    }
+
+    [Fact]
+    public async Task Validate_ShouldHaveError_WhenNotEnoughProgramRecords()
+    {
+        // Arrange
+        _fundsRecordsRepositoryMock.Setup(r => r.CountAsync(It.IsAny<QueryOptions<ReportFundsExpendituresRecord>>()))
+            .ReturnsAsync(2);
+
+        _programRecordsRepositoryMock.Setup(r => r.CountAsync(null))
+            .ReturnsAsync(0);
+
+        var validator = new PublishReportFundsExpendituresValidator(_repositoryWrapperMock.Object);
+
+        // Act
+        var result = await validator.TestValidateAsync(new PublishReportFundsExpendituresCommand());
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c)
+            .WithErrorMessage("At least 1 program expenditure record is required to publish.");
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportFundsExpendituresPublishController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportFundsExpendituresPublishController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+[Route("api/admin/report-funds-expenditures")]
+public class ReportFundsExpendituresPublishController : AuthorizedApiController
+{
+    [HttpPost("publish")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Publish()
+    {
+        return HandleResult(await Mediator.Send(new PublishReportFundsExpendituresCommand()));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportFundsExpendituresPublishController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/ReportFundsExpendituresPublishController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Cancel;
 using VictoryCenter.BLL.Commands.Admin.ReportFundsExpenditures.Publish;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -13,5 +14,13 @@ public class ReportFundsExpendituresPublishController : AuthorizedApiController
     public async Task<IActionResult> Publish()
     {
         return HandleResult(await Mediator.Send(new PublishReportFundsExpendituresCommand()));
+    }
+
+    [HttpPost("cancel")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Cancel()
+    {
+        return HandleResult(await Mediator.Send(new CancelReportFundsExpendituresCommand()));
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/ReportFundsExpendituresController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Public/ReportFundsExpendituresController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.DTOs.Public.ReportFundsExpenditures;
+using VictoryCenter.BLL.Queries.Public.ReportFundsExpenditures.GetPublished;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Public;
+
+public class ReportFundsExpendituresController : BaseApiController
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(PublishedReportFundsExpendituresDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPublishedReportFundsExpenditures(
+        [FromQuery] long? languageId)
+    {
+        return HandleResult(await Mediator.Send(
+            new GetPublishedReportFundsExpendituresQuery(languageId)));
+    }
+}


### PR DESCRIPTION
dev
## Github ticket
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1590)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2031)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1703)


## Summary of issue

The "Доходи та витрати" (Funds and Expenditures) and Media Settings tabs lacked complete publication and cancellation flows.

## Summary of change

*   **Snapshot-Based Publishing Pipeline**: Introduced dedicated snapshot tables (e.g., `PublishedReportFundsExpendituresSnapshot`, `PublishedReportFundsExpendituresRecord`) and corresponding MediatR handlers to synchronize and isolate production-ready financial data from ongoing draft edits.
*   **Draft Cancellation Endpoint**: Implemented a cancellation command handler that safely drops unsaved draft changes by overwriting the draft tables with the most recent stable data stored in the published snapshot tables.
*   **Independent Media Settings Pipeline**: Created `UpdateReportMediaSettingsHandler` to independently manage `CollectedFundsBlock` and `ChangedLivesBlock`. The handler includes robust foreign-key mapping, `AsNoTracking` querying, and validation via the `ImageRepository` to ensure safe, transaction-bound entity updates without unnecessary database round-trips.

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin publishing and cancelation for funds/expenditures reports.
  * Added a public endpoint to retrieve the latest published report (funding, expenses, programs, media, totals, currency amounts, reporting details), with optional language selection.
  * Added pre-publish validation and automatic “unpublished changes” tracking when report data is modified.
  * Report media settings now support optional images.
* **Bug Fixes**
  * Improved cancelation to reliably restore the previously published version, including localized disclaimer/category titles and reporting values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->