### PR TITLE
[Events] Implement Admin CRUD API for event/news categories

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Create/CreateEventNewsCategoryCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Create/CreateEventNewsCategoryCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using VictoryCenter.BLL.Behaviors.Abstractions;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Create;
+
+public record CreateEventNewsCategoryCommand(CreateEventNewsCategoryDto Category)
+    : IValidatableRequest<Result<AdminEventNewsCategoryDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Create/CreateEventNewsCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Create/CreateEventNewsCategoryHandler.cs
@@ -1,0 +1,60 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Create;
+
+public class CreateEventNewsCategoryHandler
+    : IRequestHandler<CreateEventNewsCategoryCommand, Result<AdminEventNewsCategoryDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public CreateEventNewsCategoryHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<AdminEventNewsCategoryDto>> Handle(
+        CreateEventNewsCategoryCommand request,
+        CancellationToken cancellationToken)
+    {
+        var normalizedName = request.Category.Name.Trim();
+
+        if (await _repositoryWrapper.EventNewsCategoryRepository.ExistsAsync(
+                category => category.Name == normalizedName))
+        {
+            return Result.Fail<AdminEventNewsCategoryDto>(EventNewsCategoryConstants.DuplicateCategoryName);
+        }
+
+        var category = new EventNewsCategory
+        {
+            Name = normalizedName,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        await _repositoryWrapper.EventNewsCategoryRepository.CreateAsync(category);
+
+        try
+        {
+            if (await _repositoryWrapper.SaveChangesAsync() > 0)
+            {
+                return Result.Ok(_mapper.Map<AdminEventNewsCategoryDto>(category));
+            }
+        }
+        catch (DbUpdateException exception) when (exception.IsUniqueConstraintException())
+        {
+            return Result.Fail<AdminEventNewsCategoryDto>(EventNewsCategoryConstants.DuplicateCategoryName);
+        }
+
+        return Result.Fail<AdminEventNewsCategoryDto>(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(EventNewsCategory)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Delete/DeleteEventNewsCategoryCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Delete/DeleteEventNewsCategoryCommand.cs
@@ -1,0 +1,6 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Delete;
+
+public record DeleteEventNewsCategoryCommand(long Id) : IRequest<Result<long>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Delete/DeleteEventNewsCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Delete/DeleteEventNewsCategoryHandler.cs
@@ -1,0 +1,50 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Delete;
+
+public class DeleteEventNewsCategoryHandler
+    : IRequestHandler<DeleteEventNewsCategoryCommand, Result<long>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public DeleteEventNewsCategoryHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<long>> Handle(
+        DeleteEventNewsCategoryCommand request,
+        CancellationToken cancellationToken)
+    {
+        var category = await _repositoryWrapper.EventNewsCategoryRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<EventNewsCategory>
+            {
+                Filter = entity => entity.Id == request.Id,
+                AsNoTracking = false
+            });
+
+        if (category is null)
+        {
+            return Result.Fail<long>(ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsCategory)));
+        }
+
+        var isInUse = await _repositoryWrapper.EventNewsRepository.ExistsAsync(
+            eventNews => eventNews.Categories.Any(entity => entity.Id == request.Id));
+
+        if (isInUse)
+        {
+            return Result.Fail<long>(EventNewsCategoryConstants.CantDeleteCategoryWhileAssociatedWithEventNews);
+        }
+
+        _repositoryWrapper.EventNewsCategoryRepository.Delete(category);
+
+        return await _repositoryWrapper.SaveChangesAsync() > 0
+            ? Result.Ok(category.Id)
+            : Result.Fail<long>(ErrorMessagesConstants.FailedToDeleteEntity(typeof(EventNewsCategory)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Delete/DeleteEventNewsCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Delete/DeleteEventNewsCategoryHandler.cs
@@ -1,6 +1,8 @@
 using FluentResults;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -43,8 +45,15 @@ public class DeleteEventNewsCategoryHandler
 
         _repositoryWrapper.EventNewsCategoryRepository.Delete(category);
 
-        return await _repositoryWrapper.SaveChangesAsync() > 0
-            ? Result.Ok(category.Id)
-            : Result.Fail<long>(ErrorMessagesConstants.FailedToDeleteEntity(typeof(EventNewsCategory)));
+        try
+        {
+            return await _repositoryWrapper.SaveChangesAsync() > 0
+                ? Result.Ok(category.Id)
+                : Result.Fail<long>(ErrorMessagesConstants.FailedToDeleteEntity(typeof(EventNewsCategory)));
+        }
+        catch (DbUpdateException exception) when (exception.IsForeignKeyConstraintException())
+        {
+            return Result.Fail<long>(EventNewsCategoryConstants.CantDeleteCategoryWhileAssociatedWithEventNews);
+        }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Update/UpdateEventNewsCategoryCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Update/UpdateEventNewsCategoryCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using VictoryCenter.BLL.Behaviors.Abstractions;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Update;
+
+public record UpdateEventNewsCategoryCommand(long Id, UpdateEventNewsCategoryDto Category)
+    : IValidatableRequest<Result<AdminEventNewsCategoryDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Update/UpdateEventNewsCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNewsCategories/Update/UpdateEventNewsCategoryHandler.cs
@@ -1,0 +1,72 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Update;
+
+public class UpdateEventNewsCategoryHandler
+    : IRequestHandler<UpdateEventNewsCategoryCommand, Result<AdminEventNewsCategoryDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public UpdateEventNewsCategoryHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<AdminEventNewsCategoryDto>> Handle(
+        UpdateEventNewsCategoryCommand request,
+        CancellationToken cancellationToken)
+    {
+        var category = await _repositoryWrapper.EventNewsCategoryRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<EventNewsCategory>
+            {
+                Filter = entity => entity.Id == request.Id,
+                AsNoTracking = false
+            });
+
+        if (category is null)
+        {
+            return Result.Fail<AdminEventNewsCategoryDto>(
+                ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsCategory)));
+        }
+
+        var normalizedName = request.Category.Name.Trim();
+        if (await _repositoryWrapper.EventNewsCategoryRepository.ExistsAsync(
+                entity => entity.Id != request.Id && entity.Name == normalizedName))
+        {
+            return Result.Fail<AdminEventNewsCategoryDto>(EventNewsCategoryConstants.DuplicateCategoryName);
+        }
+
+        if (string.Equals(category.Name, normalizedName, StringComparison.Ordinal))
+        {
+            return Result.Ok(_mapper.Map<AdminEventNewsCategoryDto>(category));
+        }
+
+        category.Name = normalizedName;
+
+        try
+        {
+            if (await _repositoryWrapper.SaveChangesAsync() > 0)
+            {
+                return Result.Ok(_mapper.Map<AdminEventNewsCategoryDto>(category));
+            }
+        }
+        catch (DbUpdateException exception) when (exception.IsUniqueConstraintException())
+        {
+            return Result.Fail<AdminEventNewsCategoryDto>(EventNewsCategoryConstants.DuplicateCategoryName);
+        }
+
+        return Result.Fail<AdminEventNewsCategoryDto>(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(EventNewsCategory)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/EventNewsCategoryConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/EventNewsCategoryConstants.cs
@@ -1,0 +1,11 @@
+namespace VictoryCenter.BLL.Constants;
+
+public static class EventNewsCategoryConstants
+{
+    public const int MinNameLength = 2;
+    public const int MaxNameLength = 20;
+
+    public const string DuplicateCategoryName = "An event/news category with this name already exists";
+    public const string CantDeleteCategoryWhileAssociatedWithEventNews =
+        "Can't delete category while it is associated with any event/news item";
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNewsCategories/AdminEventNewsCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNewsCategories/AdminEventNewsCategoryDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+
+public record AdminEventNewsCategoryDto
+{
+    public long Id { get; init; }
+    public string Name { get; init; } = null!;
+    public DateTimeOffset CreatedAt { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNewsCategories/CreateEventNewsCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNewsCategories/CreateEventNewsCategoryDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+
+public record CreateEventNewsCategoryDto
+{
+    public string Name { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNewsCategories/UpdateEventNewsCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNewsCategories/UpdateEventNewsCategoryDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+
+public record UpdateEventNewsCategoryDto
+{
+    public string Name { get; init; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/DatabaseExceptionHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/DatabaseExceptionHelper.cs
@@ -15,4 +15,14 @@ public static class DatabaseExceptionHelper
             Number: uniqueIndexViolationErrorNumber or uniqueKeyConstraintViolationErrorNumber
         };
     }
+
+    public static bool IsForeignKeyConstraintException(this DbUpdateException exception)
+    {
+        const int foreignKeyConstraintViolationErrorNumber = 547;
+
+        return exception.InnerException is SqlException
+        {
+            Number: foreignKeyConstraintViolationErrorNumber
+        };
+    }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/EventNewsCategories/EventNewsCategoryProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/EventNewsCategories/EventNewsCategoryProfile.cs
@@ -1,0 +1,13 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.DAL.Entities;
+
+namespace VictoryCenter.BLL.Mapping.EventNewsCategories;
+
+public class EventNewsCategoryProfile : Profile
+{
+    public EventNewsCategoryProfile()
+    {
+        CreateMap<EventNewsCategory, AdminEventNewsCategoryDto>();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNewsCategories/GetAll/GetAllEventNewsCategoriesHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNewsCategories/GetAll/GetAllEventNewsCategoriesHandler.cs
@@ -1,0 +1,36 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.EventNewsCategories.GetAll;
+
+public class GetAllEventNewsCategoriesHandler
+    : IRequestHandler<GetAllEventNewsCategoriesQuery, Result<List<AdminEventNewsCategoryDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetAllEventNewsCategoriesHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<List<AdminEventNewsCategoryDto>>> Handle(
+        GetAllEventNewsCategoriesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var categories = await _repositoryWrapper.EventNewsCategoryRepository.GetAllAsync(
+            new QueryOptions<EventNewsCategory>
+            {
+                OrderByASC = category => category.Name,
+                AsNoTracking = true
+            });
+
+        return Result.Ok(_mapper.Map<List<AdminEventNewsCategoryDto>>(categories));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNewsCategories/GetAll/GetAllEventNewsCategoriesQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNewsCategories/GetAll/GetAllEventNewsCategoriesQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+
+namespace VictoryCenter.BLL.Queries.Admin.EventNewsCategories.GetAll;
+
+public record GetAllEventNewsCategoriesQuery : IRequest<Result<List<AdminEventNewsCategoryDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNewsCategories/CreateEventNewsCategoryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNewsCategories/CreateEventNewsCategoryValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Create;
+
+namespace VictoryCenter.BLL.Validators.EventNewsCategories;
+
+public class CreateEventNewsCategoryValidator : AbstractValidator<CreateEventNewsCategoryCommand>
+{
+    public CreateEventNewsCategoryValidator()
+    {
+        RuleFor(command => command.Category.Name)
+            .ValidEventNewsCategoryName();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNewsCategories/EventNewsCategoryNameValidationExtensions.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNewsCategories/EventNewsCategoryNameValidationExtensions.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+
+namespace VictoryCenter.BLL.Validators.EventNewsCategories;
+
+internal static class EventNewsCategoryNameValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string> ValidEventNewsCategoryName<T>(
+        this IRuleBuilderInitial<T, string> ruleBuilder)
+    {
+        return ruleBuilder
+            .Must(name => !string.IsNullOrWhiteSpace(name))
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired("Name"))
+            .Must(name => string.IsNullOrWhiteSpace(name)
+                || name.Trim().Length >= EventNewsCategoryConstants.MinNameLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                "Name",
+                EventNewsCategoryConstants.MinNameLength))
+            .Must(name => string.IsNullOrWhiteSpace(name)
+                || name.Trim().Length <= EventNewsCategoryConstants.MaxNameLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                "Name",
+                EventNewsCategoryConstants.MaxNameLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNewsCategories/UpdateEventNewsCategoryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNewsCategories/UpdateEventNewsCategoryValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Update;
+
+namespace VictoryCenter.BLL.Validators.EventNewsCategories;
+
+public class UpdateEventNewsCategoryValidator : AbstractValidator<UpdateEventNewsCategoryCommand>
+{
+    public UpdateEventNewsCategoryValidator()
+    {
+        RuleFor(command => command.Category.Name)
+            .ValidEventNewsCategoryName();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/EventNewsCategoryConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/EventNewsCategoryConfig.cs
@@ -14,7 +14,11 @@ public class EventNewsCategoryConfig : IEntityTypeConfiguration<EventNewsCategor
             .ValueGeneratedOnAdd();
 
         builder.Property(e => e.Name)
-            .IsRequired();
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.HasIndex(e => e.Name)
+            .IsUnique();
 
         builder.Property(e => e.CreatedAt)
             .IsRequired();

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/EventNewsConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/EventNewsConfig.cs
@@ -46,9 +46,18 @@ public class EventNewsConfig : IEntityTypeConfiguration<EventNews>
 
         builder.HasMany(e => e.Categories)
             .WithMany(e => e.EventsNews)
-            .UsingEntity(j =>
-            {
-                j.ToTable("EventNewsEventNewsCategories");
-            });
+            .UsingEntity<Dictionary<string, object>>(
+                "EventNewsEventNewsCategory",
+                category => category
+                    .HasOne<EventNewsCategory>()
+                    .WithMany()
+                    .HasForeignKey("CategoriesId")
+                    .OnDelete(DeleteBehavior.Restrict),
+                eventNews => eventNews
+                    .HasOne<EventNews>()
+                    .WithMany()
+                    .HasForeignKey("EventsNewsId")
+                    .OnDelete(DeleteBehavior.Cascade),
+                join => join.ToTable("EventNewsEventNewsCategories"));
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260726131954_ConfigureEventNewsCategoryName.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260726131954_ConfigureEventNewsCategoryName.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726131954_ConfigureEventNewsCategoryName")]
+    partial class ConfigureEventNewsCategoryName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260726131954_ConfigureEventNewsCategoryName.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260726131954_ConfigureEventNewsCategoryName.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConfigureEventNewsCategoryName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "EventNewsCategories",
+                type: "nvarchar(20)",
+                maxLength: 20,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EventNewsCategories_Name",
+                table: "EventNewsCategories",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_EventNewsCategories_Name",
+                table: "EventNewsCategories");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "EventNewsCategories",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(20)",
+                oldMaxLength: 20);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260726155008_RestrictEventNewsCategoryDeletion.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260726155008_RestrictEventNewsCategoryDeletion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726155008_RestrictEventNewsCategoryDeletion")]
+    partial class RestrictEventNewsCategoryDeletion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260726155008_RestrictEventNewsCategoryDeletion.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260726155008_RestrictEventNewsCategoryDeletion.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestrictEventNewsCategoryDeletion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_EventNewsEventNewsCategories_EventNewsCategories_CategoriesId",
+                table: "EventNewsEventNewsCategories");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EventNewsEventNewsCategories_EventNewsCategories_CategoriesId",
+                table: "EventNewsEventNewsCategories",
+                column: "CategoriesId",
+                principalTable: "EventNewsCategories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_EventNewsEventNewsCategories_EventNewsCategories_CategoriesId",
+                table: "EventNewsEventNewsCategories");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EventNewsEventNewsCategories_EventNewsCategories_CategoriesId",
+                table: "EventNewsEventNewsCategories",
+                column: "CategoriesId",
+                principalTable: "EventNewsCategories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNewsCategories/EventNewsCategoryManagementTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNewsCategories/EventNewsCategoryManagementTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.EventNewsCategories;
+
+public class EventNewsCategoryManagementTests : BaseTestClass
+{
+    public EventNewsCategoryManagementTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CategoryManagement_ShouldSupportAuthorizedCrud()
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var categoryName = $"Cat{suffix}";
+        var renamedCategory = $"Ren{suffix}";
+
+        var createResponse = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/EventNewsCategories",
+            new CreateEventNewsCategoryDto { Name = $"  {categoryName}  " });
+
+        Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+        var category = await createResponse.Content.ReadFromJsonAsync<AdminEventNewsCategoryDto>();
+        Assert.NotNull(category);
+        Assert.Equal(categoryName, category.Name);
+
+        var duplicateResponse = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/EventNewsCategories",
+            new CreateEventNewsCategoryDto { Name = categoryName });
+        Assert.Equal(HttpStatusCode.BadRequest, duplicateResponse.StatusCode);
+
+        var getResponse = await Fixture.HttpClient.GetAsync("/api/EventNewsCategories");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var categories = await getResponse.Content.ReadFromJsonAsync<List<AdminEventNewsCategoryDto>>();
+        Assert.Contains(categories!, item => item.Id == category.Id);
+
+        var updateResponse = await Fixture.HttpClient.PutAsJsonAsync(
+            $"/api/EventNewsCategories/{category.Id}",
+            new UpdateEventNewsCategoryDto { Name = $"  {renamedCategory}  " });
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        var updatedCategory = await updateResponse.Content.ReadFromJsonAsync<AdminEventNewsCategoryDto>();
+        Assert.NotNull(updatedCategory);
+        Assert.Equal(renamedCategory, updatedCategory.Name);
+
+        var deleteResponse = await Fixture.HttpClient.DeleteAsync($"/api/EventNewsCategories/{category.Id}");
+        Assert.Equal(HttpStatusCode.OK, deleteResponse.StatusCode);
+        Assert.False(await Fixture.DbContext.EventNewsCategories
+            .AsNoTracking()
+            .AnyAsync(item => item.Id == category.Id));
+    }
+
+    [Fact]
+    public async Task CategoryManagement_ShouldReturnNotFound_ForMissingCategory()
+    {
+        const long missingId = long.MaxValue;
+
+        var updateResponse = await Fixture.HttpClient.PutAsJsonAsync(
+            $"/api/EventNewsCategories/{missingId}",
+            new UpdateEventNewsCategoryDto { Name = "Missing" });
+        var deleteResponse = await Fixture.HttpClient.DeleteAsync($"/api/EventNewsCategories/{missingId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, updateResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, deleteResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task CategoryManagement_ShouldRequireAuthorization()
+    {
+        using var anonymousClient = Fixture.Factory.CreateClient();
+
+        var getResponse = await anonymousClient.GetAsync("/api/EventNewsCategories");
+        var createResponse = await anonymousClient.PostAsJsonAsync(
+            "/api/EventNewsCategories",
+            new CreateEventNewsCategoryDto { Name = "Unauthorized" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, getResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, createResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task SwaggerDocument_ShouldBeGenerated_WithAdminAndPublicCategoryDtos()
+    {
+        var response = await Fixture.HttpClient.GetAsync("/swagger/v1/swagger.json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCategory_ShouldReturnBadRequest_WhenCategoryIsInUse()
+    {
+        var categoryId = await Fixture.DbContext.EventNews
+            .AsNoTracking()
+            .SelectMany(eventNews => eventNews.Categories)
+            .Select(category => category.Id)
+            .FirstAsync();
+
+        var response = await Fixture.HttpClient.DeleteAsync($"/api/EventNewsCategories/{categoryId}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/CreateEventNewsTests.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using AutoMapper;
-using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
@@ -12,6 +10,7 @@ using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
+using VictoryCenter.UnitTests.Utils;
 using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNews;
@@ -185,7 +184,7 @@ public class CreateEventNewsTests
     public async Task Handle_SlugUniqueConstraintViolation_RegeneratesSlugAndRetriesSave()
     {
         var (sut, entity) = CreateSut(saveChanges: 1);
-        var exception = CreateUniqueConstraintException();
+        var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");
         _repo.SetupSequence(repository => repository.SaveChangesAsync())
             .ThrowsAsync(exception)
             .ReturnsAsync(1);
@@ -216,7 +215,7 @@ public class CreateEventNewsTests
     public async Task Handle_NonSlugUniqueConstraintViolation_PropagatesWithoutRetry()
     {
         var (sut, _) = CreateSut(saveChanges: 1);
-        var exception = CreateUniqueConstraintException();
+        var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");
         _repo.Setup(repository => repository.SaveChangesAsync()).ThrowsAsync(exception);
         _repo.Setup(repository => repository.EventNewsRepository.ExistsAsync(
                 It.IsAny<System.Linq.Expressions.Expression<Func<EventNewsEntity, bool>>>()))
@@ -342,65 +341,6 @@ public class CreateEventNewsTests
     }
 
     private static CreateEventNewsCommand Command(CreateEventNewsDto dto) => new(dto);
-
-    private static DbUpdateException CreateUniqueConstraintException()
-    {
-        var errorCollection = (SqlErrorCollection)Activator.CreateInstance(
-            typeof(SqlErrorCollection),
-            nonPublic: true)!;
-        var errorConstructor = typeof(SqlError)
-            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
-            .OrderByDescending(constructor => constructor.GetParameters().Length)
-            .First();
-        var errorArguments = errorConstructor.GetParameters()
-            .Select(parameter => CreateSqlErrorArgument(parameter, 2601))
-            .ToArray();
-        var error = (SqlError)errorConstructor.Invoke(errorArguments);
-
-        typeof(SqlErrorCollection)
-            .GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(errorCollection, [error]);
-
-        var createExceptionMethod = typeof(SqlException)
-            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
-            .First(method => method.Name == "CreateException"
-                && method.GetParameters().Length == 2);
-        var sqlException = (SqlException)createExceptionMethod.Invoke(
-            null,
-            [errorCollection, "15.0.0"])!;
-
-        return new DbUpdateException("Unique constraint violation", sqlException);
-    }
-
-    private static object? CreateSqlErrorArgument(ParameterInfo parameter, int errorNumber)
-    {
-        if (parameter.Name is "infoNumber" or "number")
-        {
-            return errorNumber;
-        }
-
-        if (parameter.ParameterType == typeof(byte))
-        {
-            return (byte)0;
-        }
-
-        if (parameter.ParameterType == typeof(int))
-        {
-            return 0;
-        }
-
-        if (parameter.ParameterType == typeof(uint))
-        {
-            return 0u;
-        }
-
-        if (parameter.ParameterType == typeof(string))
-        {
-            return parameter.Name == "errorMessage" ? "Unique constraint violation" : string.Empty;
-        }
-
-        return null;
-    }
 
     private static CreateEventNewsDto Dto(Status status, List<long>? categoryIds = null)
     {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNewsCategories/EventNewsCategoryBusinessRulesTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNewsCategories/EventNewsCategoryBusinessRulesTests.cs
@@ -13,6 +13,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNewsCategories;
 using VictoryCenter.DAL.Repositories.Options;
+using VictoryCenter.UnitTests.Utils;
 using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNewsCategories;
@@ -196,6 +197,47 @@ public class EventNewsCategoryBusinessRulesTests
             EventNewsCategoryConstants.CantDeleteCategoryWhileAssociatedWithEventNews,
             result.Errors[0].Message);
         _categoryRepository.Verify(repository => repository.Delete(It.IsAny<EventNewsCategory>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteCategory_ShouldFail_WhenCategoryIsAssignedConcurrently()
+    {
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync(new EventNewsCategory { Id = 10, Name = "News" });
+        _eventNewsRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsEntity, bool>>>()))
+            .ReturnsAsync(false);
+        _wrapper.Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(SqlExceptionFactory.CreateDbUpdateException(547, "Foreign key constraint violation"));
+        var handler = new DeleteEventNewsCategoryHandler(_wrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCategoryCommand(10), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            EventNewsCategoryConstants.CantDeleteCategoryWhileAssociatedWithEventNews,
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task DeleteCategory_ShouldPropagateUnexpectedDatabaseException()
+    {
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync(new EventNewsCategory { Id = 10, Name = "News" });
+        _eventNewsRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsEntity, bool>>>()))
+            .ReturnsAsync(false);
+        _wrapper.Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+        var handler = new DeleteEventNewsCategoryHandler(_wrapper.Object);
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => handler.Handle(
+            new DeleteEventNewsCategoryCommand(10),
+            CancellationToken.None));
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNewsCategories/EventNewsCategoryBusinessRulesTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNewsCategories/EventNewsCategoryBusinessRulesTests.cs
@@ -1,0 +1,221 @@
+using System.Linq.Expressions;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Create;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Delete;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.BLL.Queries.Admin.EventNewsCategories.GetAll;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
+using VictoryCenter.DAL.Repositories.Interfaces.EventNewsCategories;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNewsCategories;
+
+public class EventNewsCategoryBusinessRulesTests
+{
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<IRepositoryWrapper> _wrapper = new();
+    private readonly Mock<IEventNewsCategoryRepository> _categoryRepository = new();
+    private readonly Mock<IEventNewsRepository> _eventNewsRepository = new();
+
+    public EventNewsCategoryBusinessRulesTests()
+    {
+        _wrapper.SetupGet(item => item.EventNewsCategoryRepository).Returns(_categoryRepository.Object);
+        _wrapper.SetupGet(item => item.EventNewsRepository).Returns(_eventNewsRepository.Object);
+        _mapper.Setup(mapper => mapper.Map<AdminEventNewsCategoryDto>(It.IsAny<EventNewsCategory>()))
+            .Returns((EventNewsCategory category) => new AdminEventNewsCategoryDto
+            {
+                Id = category.Id,
+                Name = category.Name,
+                CreatedAt = category.CreatedAt
+            });
+    }
+
+    [Fact]
+    public async Task CreateCategory_ShouldTrimNameAndReturnCreatedCategory()
+    {
+        EventNewsCategory? createdCategory = null;
+        _categoryRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsCategory, bool>>>()))
+            .ReturnsAsync(false);
+        _categoryRepository
+            .Setup(repository => repository.CreateAsync(It.IsAny<EventNewsCategory>()))
+            .Callback<EventNewsCategory>(category => createdCategory = category)
+            .ReturnsAsync((EventNewsCategory category) => category);
+        _wrapper.Setup(repository => repository.SaveChangesAsync()).ReturnsAsync(1);
+        var handler = new CreateEventNewsCategoryHandler(_mapper.Object, _wrapper.Object);
+
+        var result = await handler.Handle(
+            new CreateEventNewsCategoryCommand(new CreateEventNewsCategoryDto { Name = "  News  " }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(createdCategory);
+        Assert.Equal("News", createdCategory.Name);
+        Assert.NotEqual(default, createdCategory.CreatedAt);
+    }
+
+    [Fact]
+    public async Task CreateCategory_ShouldFail_WhenNameAlreadyExists()
+    {
+        _categoryRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsCategory, bool>>>()))
+            .ReturnsAsync(true);
+        var handler = new CreateEventNewsCategoryHandler(_mapper.Object, _wrapper.Object);
+
+        var result = await handler.Handle(
+            new CreateEventNewsCategoryCommand(new CreateEventNewsCategoryDto { Name = "News" }),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(EventNewsCategoryConstants.DuplicateCategoryName, result.Errors[0].Message);
+        _categoryRepository.Verify(repository => repository.CreateAsync(It.IsAny<EventNewsCategory>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateCategory_ShouldPropagateUnexpectedDatabaseException()
+    {
+        _categoryRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsCategory, bool>>>()))
+            .ReturnsAsync(false);
+        _categoryRepository
+            .Setup(repository => repository.CreateAsync(It.IsAny<EventNewsCategory>()))
+            .ReturnsAsync((EventNewsCategory category) => category);
+        _wrapper.Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException());
+        var handler = new CreateEventNewsCategoryHandler(_mapper.Object, _wrapper.Object);
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => handler.Handle(
+            new CreateEventNewsCategoryCommand(new CreateEventNewsCategoryDto { Name = "News" }),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UpdateCategory_ShouldFail_WhenCategoryDoesNotExist()
+    {
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync((EventNewsCategory?)null);
+        var handler = new UpdateEventNewsCategoryHandler(_mapper.Object, _wrapper.Object);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCategoryCommand(10, new UpdateEventNewsCategoryDto { Name = "Updated" }),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains("not found", result.Errors[0].Message, StringComparison.OrdinalIgnoreCase);
+        _wrapper.Verify(repository => repository.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateCategory_ShouldFail_WhenNameAlreadyExists()
+    {
+        var category = new EventNewsCategory { Id = 10, Name = "News" };
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync(category);
+        _categoryRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsCategory, bool>>>()))
+            .ReturnsAsync(true);
+        var handler = new UpdateEventNewsCategoryHandler(_mapper.Object, _wrapper.Object);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCategoryCommand(10, new UpdateEventNewsCategoryDto { Name = "Existing" }),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(EventNewsCategoryConstants.DuplicateCategoryName, result.Errors[0].Message);
+        Assert.Equal("News", category.Name);
+        _wrapper.Verify(repository => repository.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateCategory_ShouldTrimAndPersistChangedName()
+    {
+        var category = new EventNewsCategory { Id = 10, Name = "News" };
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync(category);
+        _categoryRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsCategory, bool>>>()))
+            .ReturnsAsync(false);
+        _wrapper.Setup(repository => repository.SaveChangesAsync()).ReturnsAsync(1);
+        var handler = new UpdateEventNewsCategoryHandler(_mapper.Object, _wrapper.Object);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCategoryCommand(10, new UpdateEventNewsCategoryDto { Name = "  Updated  " }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Updated", category.Name);
+        _wrapper.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteCategory_ShouldFail_WhenCategoryDoesNotExist()
+    {
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync((EventNewsCategory?)null);
+        var handler = new DeleteEventNewsCategoryHandler(_wrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCategoryCommand(10), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains("not found", result.Errors[0].Message, StringComparison.OrdinalIgnoreCase);
+        _categoryRepository.Verify(repository => repository.Delete(It.IsAny<EventNewsCategory>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteCategory_ShouldFail_WhenCategoryIsAssignedToEventNews()
+    {
+        _categoryRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync(new EventNewsCategory { Id = 10, Name = "News" });
+        _eventNewsRepository
+            .Setup(repository => repository.ExistsAsync(
+                It.IsAny<Expression<Func<EventNewsEntity, bool>>>()))
+            .ReturnsAsync(true);
+        var handler = new DeleteEventNewsCategoryHandler(_wrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCategoryCommand(10), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            EventNewsCategoryConstants.CantDeleteCategoryWhileAssociatedWithEventNews,
+            result.Errors[0].Message);
+        _categoryRepository.Verify(repository => repository.Delete(It.IsAny<EventNewsCategory>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAllCategories_ShouldUseReadOnlyOrderedQuery()
+    {
+        QueryOptions<EventNewsCategory>? capturedOptions = null;
+        _categoryRepository
+            .Setup(repository => repository.GetAllAsync(It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .Callback<QueryOptions<EventNewsCategory>>(options => capturedOptions = options)
+            .ReturnsAsync([]);
+        _mapper.Setup(mapper => mapper.Map<List<AdminEventNewsCategoryDto>>(
+                It.IsAny<IEnumerable<EventNewsCategory>>()))
+            .Returns([]);
+        var handler = new GetAllEventNewsCategoriesHandler(_mapper.Object, _wrapper.Object);
+
+        var result = await handler.Handle(new GetAllEventNewsCategoriesQuery(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(capturedOptions);
+        Assert.True(capturedOptions.AsNoTracking);
+        Assert.NotNull(capturedOptions.OrderByASC);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/Utils/SqlExceptionFactory.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/Utils/SqlExceptionFactory.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace VictoryCenter.UnitTests.Utils;
+
+internal static class SqlExceptionFactory
+{
+    public static DbUpdateException CreateDbUpdateException(int errorNumber, string message)
+    {
+        var errorCollection = (SqlErrorCollection)Activator.CreateInstance(
+            typeof(SqlErrorCollection),
+            nonPublic: true)!;
+        var errorConstructor = typeof(SqlError)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            .OrderByDescending(constructor => constructor.GetParameters().Length)
+            .First();
+        var errorArguments = errorConstructor.GetParameters()
+            .Select(parameter => CreateSqlErrorArgument(parameter, errorNumber, message))
+            .ToArray();
+        var error = (SqlError)errorConstructor.Invoke(errorArguments);
+
+        typeof(SqlErrorCollection)
+            .GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(errorCollection, [error]);
+
+        var createExceptionMethod = typeof(SqlException)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .First(method => method.Name == "CreateException"
+                && method.GetParameters().Length == 2);
+        var sqlException = (SqlException)createExceptionMethod.Invoke(
+            null,
+            [errorCollection, "15.0.0"])!;
+
+        return new DbUpdateException(message, sqlException);
+    }
+
+    private static object? CreateSqlErrorArgument(ParameterInfo parameter, int errorNumber, string message)
+    {
+        if (parameter.Name is "infoNumber" or "number")
+        {
+            return errorNumber;
+        }
+
+        if (parameter.ParameterType == typeof(byte))
+        {
+            return (byte)0;
+        }
+
+        if (parameter.ParameterType == typeof(int))
+        {
+            return 0;
+        }
+
+        if (parameter.ParameterType == typeof(uint))
+        {
+            return 0u;
+        }
+
+        if (parameter.ParameterType == typeof(string))
+        {
+            return parameter.Name == "errorMessage" ? message : string.Empty;
+        }
+
+        return null;
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNewsCategories/EventNewsCategoryValidatorsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNewsCategories/EventNewsCategoryValidatorsTests.cs
@@ -1,0 +1,64 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Create;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.BLL.Validators.EventNewsCategories;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.EventNewsCategories;
+
+public class EventNewsCategoryValidatorsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void CreateCategory_ShouldRejectEmptyName(string? name)
+    {
+        var command = new CreateEventNewsCategoryCommand(
+            new CreateEventNewsCategoryDto { Name = name! });
+
+        var result = new CreateEventNewsCategoryValidator().TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(item => item.Category.Name);
+    }
+
+    [Fact]
+    public void CreateCategory_ShouldRejectNameBelowMinimumLengthAfterTrimming()
+    {
+        var command = new CreateEventNewsCategoryCommand(
+            new CreateEventNewsCategoryDto { Name = "  a  " });
+
+        var result = new CreateEventNewsCategoryValidator().TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(item => item.Category.Name);
+    }
+
+    [Fact]
+    public void UpdateCategory_ShouldRejectNameOverMaximumLengthAfterTrimming()
+    {
+        var command = new UpdateEventNewsCategoryCommand(
+            1,
+            new UpdateEventNewsCategoryDto
+            {
+                Name = $"  {new string('a', EventNewsCategoryConstants.MaxNameLength + 1)}  "
+            });
+
+        var result = new UpdateEventNewsCategoryValidator().TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(item => item.Category.Name);
+    }
+
+    [Theory]
+    [InlineData("  ab  ")]
+    [InlineData("  abcdefghijklmnopqrst  ")]
+    public void CreateCategory_ShouldAcceptBoundaryLengthAfterTrimming(string name)
+    {
+        var command = new CreateEventNewsCategoryCommand(
+            new CreateEventNewsCategoryDto { Name = name });
+
+        var result = new CreateEventNewsCategoryValidator().TestValidate(command);
+
+        result.ShouldNotHaveValidationErrorFor(item => item.Category.Name);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsCategoriesController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsCategoriesController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Create;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Delete;
+using VictoryCenter.BLL.Commands.Admin.EventNewsCategories.Update;
+using VictoryCenter.BLL.DTOs.Admin.EventNewsCategories;
+using VictoryCenter.BLL.Queries.Admin.EventNewsCategories.GetAll;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin;
+
+public class EventNewsCategoriesController : AuthorizedApiController
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(List<AdminEventNewsCategoryDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll()
+    {
+        return HandleResult(await Mediator.Send(new GetAllEventNewsCategoriesQuery()));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(AdminEventNewsCategoryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] CreateEventNewsCategoryDto category)
+    {
+        return HandleResult(await Mediator.Send(new CreateEventNewsCategoryCommand(category)));
+    }
+
+    [HttpPut("{id:long}")]
+    [ProducesResponseType(typeof(AdminEventNewsCategoryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(long id, [FromBody] UpdateEventNewsCategoryDto category)
+    {
+        return HandleResult(await Mediator.Send(new UpdateEventNewsCategoryCommand(id, category)));
+    }
+
+    [HttpDelete("{id:long}")]
+    [ProducesResponseType(typeof(long), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(long id)
+    {
+        return HandleResult(await Mediator.Send(new DeleteEventNewsCategoryCommand(id)));
+    }
+}


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin tools to list, create, update, and delete event/news categories.
  * Category names are automatically trimmed and sorted alphabetically.
* **Validation**
  * Names must be between 2 and 20 characters.
  * Duplicate category names are prevented.
* **Bug Fixes**
  * Categories linked to event/news items cannot be deleted.
  * Missing categories return clear not-found responses.
* **Tests**
  * Added coverage for category management, validation, authorization, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->