### PR TITLE
Feature/issue-1510 [Single program] Sync New Section to Translation Page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -10,6 +10,8 @@ using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -203,7 +205,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         }
     }
 
-    private static void MarkProgramLocalizationsOutdated(HippotherapyProgram program)
+    private static void MarkProgramLocalizationsOutdated(ITranslatedEntity<HippotherapyProgramLocalization> program)
     {
         foreach (var loc in program.Localizations)
         {
@@ -310,7 +312,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static ProgramSectionContent? FindMatchingContent(
         CreateProgramSectionContentDto newContentDto,
-        Dictionary<long, ProgramSectionContent> oldContentsById)
+        IDictionary<long, ProgramSectionContent> oldContentsById)
     {
         if (newContentDto.Id is > 0
             && oldContentsById.TryGetValue(newContentDto.Id.Value, out var found)
@@ -345,7 +347,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static void RemoveUnmatchedContents(
         HippotherapyProgramSection existingSection,
-        HashSet<long> matchedOldContentIds)
+        ICollection<long> matchedOldContentIds)
     {
         var contentsToRemove = existingSection.Contents
             .Where(c => c.Id > 0 && !matchedOldContentIds.Contains(c.Id))

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -10,6 +10,8 @@ using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -203,7 +205,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         }
     }
 
-    private static void MarkProgramLocalizationsOutdated(HippotherapyProgram program)
+    private static void MarkProgramLocalizationsOutdated(ITranslatedEntity<HippotherapyProgramLocalization> program)
     {
         foreach (var loc in program.Localizations)
         {
@@ -288,27 +290,12 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
         foreach (var newContentDto in newContents.OrderBy(c => c.Order))
         {
-            var existingContent = newContentDto.Id is > 0
-                && oldContentsById.TryGetValue(newContentDto.Id.Value, out var found)
-                && found.ContentType == newContentDto.ContentType
-                ? found
-                : null;
+            var existingContent = FindMatchingContent(newContentDto, oldContentsById);
 
             if (existingContent is not null)
             {
                 matchedOldContentIds.Add(existingContent.Id);
-
-                if (TryApplyContentFieldUpdates(existingContent, newContentDto, imagesById, out var contentChanged)
-                    && contentChanged
-                    && existingContent.ContentType != ContentType.Image)
-                {
-                    anyContentChanged = true;
-
-                    foreach (var loc in existingContent.Localizations)
-                    {
-                        loc.TranslationStatus = TranslationStatus.Outdated;
-                    }
-                }
+                ApplyExistingContentUpdate(existingContent, newContentDto, imagesById, ref anyContentChanged);
             }
             else
             {
@@ -320,6 +307,48 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
             }
         }
 
+        RemoveUnmatchedContents(existingSection, matchedOldContentIds);
+    }
+
+    private static ProgramSectionContent? FindMatchingContent(
+        CreateProgramSectionContentDto newContentDto,
+        Dictionary<long, ProgramSectionContent> oldContentsById)
+    {
+        if (newContentDto.Id is > 0
+            && oldContentsById.TryGetValue(newContentDto.Id.Value, out var found)
+            && found.ContentType == newContentDto.ContentType)
+        {
+            return found;
+        }
+
+        return null;
+    }
+
+    private static void ApplyExistingContentUpdate(
+        ProgramSectionContent existingContent,
+        CreateProgramSectionContentDto newContentDto,
+        IReadOnlyDictionary<long, Image> imagesById,
+        ref bool anyContentChanged)
+    {
+        var updated = TryApplyContentFieldUpdates(existingContent, newContentDto, imagesById, out var contentChanged);
+
+        if (!updated || !contentChanged || existingContent.ContentType == ContentType.Image)
+        {
+            return;
+        }
+
+        anyContentChanged = true;
+
+        foreach (var loc in existingContent.Localizations)
+        {
+            loc.TranslationStatus = TranslationStatus.Outdated;
+        }
+    }
+
+    private static void RemoveUnmatchedContents(
+        HippotherapyProgramSection existingSection,
+        HashSet<long> matchedOldContentIds)
+    {
         var contentsToRemove = existingSection.Contents
             .Where(c => c.Id > 0 && !matchedOldContentIds.Contains(c.Id))
             .ToList();

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -128,16 +128,17 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
             var oldSections = program.Sections.ToList();
 
-            var sectionsMatched = EnsureReplaceSameSections(
+            var sectionAdded = MergeSections(
+                program,
                 oldSections,
                 request.UpdateProgramDto.Sections,
+                now,
                 imagesByIdResult.Value,
                 out var programContentsChanged);
 
-            if (!sectionsMatched)
+            if (sectionAdded)
             {
-                ReplaceSections(program, request.UpdateProgramDto.Sections, now, imagesByIdResult.Value);
-                program.Localizations.Clear();
+                MarkProgramLocalizationsOutdated(program);
             }
 
             if (programFieldsChanged || programContentsChanged)
@@ -179,10 +180,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static void SerTranslationsToOutdated(HippotherapyProgram program)
     {
-        foreach (var loc in program.Localizations)
-        {
-            loc.TranslationStatus = TranslationStatus.Outdated;
-        }
+        MarkProgramLocalizationsOutdated(program);
 
         var sections = program.Sections.ToList();
         var contentsToOutdated = sections
@@ -205,100 +203,131 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         }
     }
 
-    private static bool EnsureReplaceSameSections(
+    private static void MarkProgramLocalizationsOutdated(HippotherapyProgram program)
+    {
+        foreach (var loc in program.Localizations)
+        {
+            loc.TranslationStatus = TranslationStatus.Outdated;
+        }
+    }
+
+    private static bool MergeSections(
+        HippotherapyProgram program,
         List<HippotherapyProgramSection> oldSections,
         List<CreateHippotherapyProgramSectionDto> newSections,
+        DateTimeOffset now,
         IReadOnlyDictionary<long, Image> imagesById,
         out bool anyContentChanged)
     {
         anyContentChanged = false;
+        var sectionAdded = false;
 
-        if (oldSections.Count != newSections.Count)
+        var oldSectionsById = oldSections
+            .Where(s => s.Id > 0)
+            .ToDictionary(s => s.Id);
+
+        var matchedOldSectionIds = new HashSet<long>();
+
+        foreach (var newSectionDto in newSections)
         {
-            return false;
-        }
+            var existingSection = newSectionDto.Id is > 0
+                && oldSectionsById.TryGetValue(newSectionDto.Id.Value, out var found)
+                ? found
+                : null;
 
-        Dictionary<int, HippotherapyProgramSection> oldSectionsMap;
-        Dictionary<int, CreateHippotherapyProgramSectionDto> newSectionsMap;
-
-        try
-        {
-            oldSectionsMap = oldSections.ToDictionary(section => section.Order);
-            newSectionsMap = newSections.ToDictionary(section => section.Order);
-        }
-        catch (ArgumentException)
-        {
-            return false;
-        }
-
-        if (oldSectionsMap.Count != newSectionsMap.Count)
-        {
-            return false;
-        }
-
-        foreach (var (sectionOrder, newSection) in newSectionsMap)
-        {
-            if (!oldSectionsMap.TryGetValue(sectionOrder, out var oldSection))
+            if (existingSection is not null)
             {
-                return false;
+                matchedOldSectionIds.Add(existingSection.Id);
+                existingSection.Template = newSectionDto.Template;
+                existingSection.Order = newSectionDto.Order;
+
+                MergeSectionContents(existingSection, newSectionDto, now, imagesById, ref anyContentChanged);
             }
-
-            if (oldSection.Template != newSection.Template)
+            else
             {
-                return false;
-            }
+                var builtSections = HippotherapyProgramSectionsBuilder.Build(
+                    [newSectionDto],
+                    now,
+                    imagesById);
 
-            var newContents = newSection.Contents ?? [];
-            var oldContents = oldSection.Contents;
-
-            Dictionary<int, CreateProgramSectionContentDto> newContentsMap;
-            Dictionary<int, ProgramSectionContent> oldContentsMap;
-
-            try
-            {
-                newContentsMap = newContents.ToDictionary(content => content.Order);
-                oldContentsMap = oldContents.ToDictionary(content => content.Order);
-            }
-            catch (ArgumentException)
-            {
-                return false;
-            }
-
-            if (newContentsMap.Count != oldContentsMap.Count)
-            {
-                return false;
-            }
-
-            foreach (var (contentOrder, newContent) in newContentsMap)
-            {
-                if (!oldContentsMap.TryGetValue(contentOrder, out var oldContent))
+                foreach (var built in builtSections)
                 {
-                    return false;
+                    program.Sections.Add(built);
                 }
 
-                if (newContent.ContentType != oldContent.ContentType)
-                {
-                    return false;
-                }
+                sectionAdded = true;
+            }
+        }
 
-                if (!TryApplyContentFieldUpdates(oldContent, newContent, imagesById, out var contentChanged))
-                {
-                    return false;
-                }
+        var sectionsToRemove = oldSections
+            .Where(s => !matchedOldSectionIds.Contains(s.Id))
+            .ToList();
 
-                if (contentChanged && oldContent.ContentType != ContentType.Image)
+        foreach (var sectionToRemove in sectionsToRemove)
+        {
+            program.Sections.Remove(sectionToRemove);
+        }
+
+        return sectionAdded;
+    }
+
+    private static void MergeSectionContents(
+        HippotherapyProgramSection existingSection,
+        CreateHippotherapyProgramSectionDto newSectionDto,
+        DateTimeOffset now,
+        IReadOnlyDictionary<long, Image> imagesById,
+        ref bool anyContentChanged)
+    {
+        var newContents = newSectionDto.Contents ?? [];
+
+        var oldContentsById = existingSection.Contents
+            .Where(c => c.Id > 0)
+            .ToDictionary(c => c.Id);
+
+        var matchedOldContentIds = new HashSet<long>();
+
+        foreach (var newContentDto in newContents.OrderBy(c => c.Order))
+        {
+            var existingContent = newContentDto.Id is > 0
+                && oldContentsById.TryGetValue(newContentDto.Id.Value, out var found)
+                && found.ContentType == newContentDto.ContentType
+                ? found
+                : null;
+
+            if (existingContent is not null)
+            {
+                matchedOldContentIds.Add(existingContent.Id);
+
+                if (TryApplyContentFieldUpdates(existingContent, newContentDto, imagesById, out var contentChanged)
+                    && contentChanged
+                    && existingContent.ContentType != ContentType.Image)
                 {
                     anyContentChanged = true;
 
-                    foreach (var loc in oldContent.Localizations)
+                    foreach (var loc in existingContent.Localizations)
                     {
                         loc.TranslationStatus = TranslationStatus.Outdated;
                     }
                 }
             }
+            else
+            {
+                var newContent = HippotherapyProgramSectionsBuilder.CreateContent(newContentDto, imagesById, now);
+                if (newContent is not null)
+                {
+                    existingSection.Contents.Add(newContent);
+                }
+            }
         }
 
-        return true;
+        var contentsToRemove = existingSection.Contents
+            .Where(c => c.Id > 0 && !matchedOldContentIds.Contains(c.Id))
+            .ToList();
+
+        foreach (var contentToRemove in contentsToRemove)
+        {
+            existingSection.Contents.Remove(contentToRemove);
+        }
     }
 
     private static bool TryApplyContentFieldUpdates(
@@ -460,25 +489,6 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
             var dto = incomingById[content.FaqQuestionId];
             content.FaqQuestion!.QuestionText = dto.QuestionText.Trim();
             content.FaqQuestion!.AnswerText = dto.AnswerText.Trim();
-        }
-    }
-
-    private static void ReplaceSections(
-        HippotherapyProgram program,
-        ICollection<CreateHippotherapyProgramSectionDto>? sections,
-        DateTimeOffset createdAt,
-        IReadOnlyDictionary<long, Image> imagesById)
-    {
-        program.Sections.Clear();
-
-        var builtSections = HippotherapyProgramSectionsBuilder.Build(
-            sections,
-            createdAt,
-            imagesById);
-
-        foreach (var section in builtSections)
-        {
-            program.Sections.Add(section);
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -310,7 +310,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static ProgramSectionContent? FindMatchingContent(
         CreateProgramSectionContentDto newContentDto,
-        IDictionary<long, ProgramSectionContent> oldContentsById)
+        Dictionary<long, ProgramSectionContent> oldContentsById)
     {
         if (newContentDto.Id is > 0
             && oldContentsById.TryGetValue(newContentDto.Id.Value, out var found)
@@ -345,7 +345,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static void RemoveUnmatchedContents(
         HippotherapyProgramSection existingSection,
-        ICollection<long> matchedOldContentIds)
+        HashSet<long> matchedOldContentIds)
     {
         var contentsToRemove = existingSection.Contents
             .Where(c => c.Id > 0 && !matchedOldContentIds.Contains(c.Id))

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -10,8 +10,6 @@ using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
-using VictoryCenter.DAL.Entities.Interfaces;
-using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -205,7 +203,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         }
     }
 
-    private static void MarkProgramLocalizationsOutdated(ITranslatedEntity<HippotherapyProgramLocalization> program)
+    private static void MarkProgramLocalizationsOutdated(HippotherapyProgram program)
     {
         foreach (var loc in program.Localizations)
         {
@@ -312,7 +310,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static ProgramSectionContent? FindMatchingContent(
         CreateProgramSectionContentDto newContentDto,
-        Dictionary<long, ProgramSectionContent> oldContentsById)
+        IDictionary<long, ProgramSectionContent> oldContentsById)
     {
         if (newContentDto.Id is > 0
             && oldContentsById.TryGetValue(newContentDto.Id.Value, out var found)
@@ -347,7 +345,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
 
     private static void RemoveUnmatchedContents(
         HippotherapyProgramSection existingSection,
-        HashSet<long> matchedOldContentIds)
+        ICollection<long> matchedOldContentIds)
     {
         var contentsToRemove = existingSection.Contents
             .Where(c => c.Id > 0 && !matchedOldContentIds.Contains(c.Id))
@@ -366,6 +364,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         out bool contentChanged)
     {
         contentChanged = false;
+        oldContent.Order = newContent.Order;
         oldContent.GroupIndex = newContent.GroupIndex;
 
         return newContent.ContentType switch

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -12,6 +12,7 @@ using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
 using VictoryCenter.BLL.Interfaces.Localization;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 using HippotherapyProgramEntity = VictoryCenter.DAL.Entities.HippotherapyProgram;
@@ -83,9 +84,37 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
             {
                 contentLocalizations[i].EntityId = contentDtos[i].EntityId;
                 contentLocalizations[i].LanguageId = request.LanguageId;
+                contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
             }
 
-            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizations, true);
+            var contentIds = contentLocalizations.Select(l => l.EntityId).ToList();
+
+            var existingContentLocalizations = (await _repositoryWrapper.ProgramSectionContentLocalizationsRepository
+                .GetAllAsync(new QueryOptions<ProgramSectionContentLocalization>
+                {
+                    Filter = l => l.LanguageId == request.LanguageId && contentIds.Contains(l.EntityId)
+                })).ToList();
+
+            var existingContentIds = existingContentLocalizations.Select(l => l.EntityId).ToHashSet();
+
+            var contentLocalizationsToUpdate = contentLocalizations.Where(l => existingContentIds.Contains(l.EntityId)).ToList();
+            var contentLocalizationsToCreate = contentLocalizations.Where(l => !existingContentIds.Contains(l.EntityId)).ToList();
+
+            if (contentLocalizationsToUpdate.Count > 0)
+            {
+                await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToUpdate, true);
+            }
+
+            if (contentLocalizationsToCreate.Count > 0)
+            {
+                var utcNow = DateTimeOffset.UtcNow;
+                foreach (var loc in contentLocalizationsToCreate)
+                {
+                    loc.CreatedAt = utcNow;
+                }
+
+                await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToCreate, false);
+            }
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -10,9 +10,7 @@ using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
 using VictoryCenter.BLL.Interfaces.Localization;
-using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Entities.Localization;
-using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 using HippotherapyProgramEntity = VictoryCenter.DAL.Entities.HippotherapyProgram;
@@ -25,8 +23,7 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
     private readonly IValidator<UpdateHippotherapyProgramLocalizationCommand> _validator;
     private readonly IProgramSectionContentService _programSectionContentService;
     private readonly ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization> _programLocalizationService;
-    private readonly ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> _contentLocalizationService;
-    private readonly TimeProvider _timeProvider;
+    private readonly IProgramSectionContentLocalizationTracker _contentLocalizationTracker;
 
     public UpdateHippotherapyProgramLocalizationHandler(
         IMapper mapper,
@@ -34,16 +31,14 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         IValidator<UpdateHippotherapyProgramLocalizationCommand> validator,
         IProgramSectionContentService programSectionContentService,
         ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization> programLocalizationService,
-        ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> contentLocalizationService,
-        TimeProvider timeProvider)
+        IProgramSectionContentLocalizationTracker contentLocalizationTracker)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
         _validator = validator;
         _programSectionContentService = programSectionContentService;
         _programLocalizationService = programLocalizationService;
-        _contentLocalizationService = contentLocalizationService;
-        _timeProvider = timeProvider;
+        _contentLocalizationTracker = contentLocalizationTracker;
     }
 
     public async Task<Result<HippotherapyProgramLocalizationDto>> Handle(UpdateHippotherapyProgramLocalizationCommand request, CancellationToken cancellationToken)
@@ -77,7 +72,8 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
             programLocalizationEntity.LanguageId = request.LanguageId;
             await _programLocalizationService.TrackEntityLocalizationForUpdateAsync(programLocalizationEntity);
 
-            await TrackContentLocalizationsAsync(dto, request.LanguageId);
+            var contentDtos = dto.Sections.SelectMany(section => section.Contents ?? []);
+            await _contentLocalizationTracker.TrackAsync(contentDtos, request.LanguageId);
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
@@ -116,51 +112,6 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         {
             return Result.Fail<HippotherapyProgramLocalizationDto>(
                 ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)));
-        }
-    }
-
-    private async Task TrackContentLocalizationsAsync(UpdateHippotherapyProgramLocalizationDto dto, long languageId)
-    {
-        var contentDtos = dto.Sections
-            .SelectMany(section => section.Contents ?? [])
-            .ToList();
-
-        var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtos);
-
-        for (int i = 0; i < contentLocalizations.Count; i++)
-        {
-            contentLocalizations[i].EntityId = contentDtos[i].EntityId;
-            contentLocalizations[i].LanguageId = languageId;
-            contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
-        }
-
-        var contentIds = contentLocalizations.Select(l => l.EntityId).ToList();
-
-        var existingContentLocalizations = (await _repositoryWrapper.ProgramSectionContentLocalizationsRepository
-            .GetAllAsync(new QueryOptions<ProgramSectionContentLocalization>
-            {
-                Filter = l => l.LanguageId == languageId && contentIds.Contains(l.EntityId)
-            })).ToList();
-
-        var existingContentIds = existingContentLocalizations.Select(l => l.EntityId).ToHashSet();
-
-        var contentLocalizationsToUpdate = contentLocalizations.Where(l => existingContentIds.Contains(l.EntityId)).ToList();
-        var contentLocalizationsToCreate = contentLocalizations.Where(l => !existingContentIds.Contains(l.EntityId)).ToList();
-
-        if (contentLocalizationsToUpdate.Count > 0)
-        {
-            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToUpdate, true);
-        }
-
-        if (contentLocalizationsToCreate.Count > 0)
-        {
-            var utcNow = _timeProvider.GetUtcNow();
-            foreach (var loc in contentLocalizationsToCreate)
-            {
-                loc.CreatedAt = utcNow;
-            }
-
-            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToCreate, false);
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgram/Update/UpdateHippotherapyProgramLocalizationHandler.cs
@@ -26,6 +26,7 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
     private readonly IProgramSectionContentService _programSectionContentService;
     private readonly ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization> _programLocalizationService;
     private readonly ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> _contentLocalizationService;
+    private readonly TimeProvider _timeProvider;
 
     public UpdateHippotherapyProgramLocalizationHandler(
         IMapper mapper,
@@ -33,7 +34,8 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         IValidator<UpdateHippotherapyProgramLocalizationCommand> validator,
         IProgramSectionContentService programSectionContentService,
         ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization> programLocalizationService,
-        ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> contentLocalizationService)
+        ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> contentLocalizationService,
+        TimeProvider timeProvider)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
@@ -41,6 +43,7 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         _programSectionContentService = programSectionContentService;
         _programLocalizationService = programLocalizationService;
         _contentLocalizationService = contentLocalizationService;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Result<HippotherapyProgramLocalizationDto>> Handle(UpdateHippotherapyProgramLocalizationCommand request, CancellationToken cancellationToken)
@@ -74,47 +77,7 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
             programLocalizationEntity.LanguageId = request.LanguageId;
             await _programLocalizationService.TrackEntityLocalizationForUpdateAsync(programLocalizationEntity);
 
-            var contentDtos = dto.Sections
-                .SelectMany(section => section.Contents ?? [])
-                .ToList();
-
-            var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtos);
-
-            for (int i = 0; i < contentLocalizations.Count; i++)
-            {
-                contentLocalizations[i].EntityId = contentDtos[i].EntityId;
-                contentLocalizations[i].LanguageId = request.LanguageId;
-                contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
-            }
-
-            var contentIds = contentLocalizations.Select(l => l.EntityId).ToList();
-
-            var existingContentLocalizations = (await _repositoryWrapper.ProgramSectionContentLocalizationsRepository
-                .GetAllAsync(new QueryOptions<ProgramSectionContentLocalization>
-                {
-                    Filter = l => l.LanguageId == request.LanguageId && contentIds.Contains(l.EntityId)
-                })).ToList();
-
-            var existingContentIds = existingContentLocalizations.Select(l => l.EntityId).ToHashSet();
-
-            var contentLocalizationsToUpdate = contentLocalizations.Where(l => existingContentIds.Contains(l.EntityId)).ToList();
-            var contentLocalizationsToCreate = contentLocalizations.Where(l => !existingContentIds.Contains(l.EntityId)).ToList();
-
-            if (contentLocalizationsToUpdate.Count > 0)
-            {
-                await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToUpdate, true);
-            }
-
-            if (contentLocalizationsToCreate.Count > 0)
-            {
-                var utcNow = DateTimeOffset.UtcNow;
-                foreach (var loc in contentLocalizationsToCreate)
-                {
-                    loc.CreatedAt = utcNow;
-                }
-
-                await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToCreate, false);
-            }
+            await TrackContentLocalizationsAsync(dto, request.LanguageId);
 
             if (await _repositoryWrapper.SaveChangesAsync() <= 0)
             {
@@ -153,6 +116,51 @@ public class UpdateHippotherapyProgramLocalizationHandler : IRequestHandler<Upda
         {
             return Result.Fail<HippotherapyProgramLocalizationDto>(
                 ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramLocalization)));
+        }
+    }
+
+    private async Task TrackContentLocalizationsAsync(UpdateHippotherapyProgramLocalizationDto dto, long languageId)
+    {
+        var contentDtos = dto.Sections
+            .SelectMany(section => section.Contents ?? [])
+            .ToList();
+
+        var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtos);
+
+        for (int i = 0; i < contentLocalizations.Count; i++)
+        {
+            contentLocalizations[i].EntityId = contentDtos[i].EntityId;
+            contentLocalizations[i].LanguageId = languageId;
+            contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
+        }
+
+        var contentIds = contentLocalizations.Select(l => l.EntityId).ToList();
+
+        var existingContentLocalizations = (await _repositoryWrapper.ProgramSectionContentLocalizationsRepository
+            .GetAllAsync(new QueryOptions<ProgramSectionContentLocalization>
+            {
+                Filter = l => l.LanguageId == languageId && contentIds.Contains(l.EntityId)
+            })).ToList();
+
+        var existingContentIds = existingContentLocalizations.Select(l => l.EntityId).ToHashSet();
+
+        var contentLocalizationsToUpdate = contentLocalizations.Where(l => existingContentIds.Contains(l.EntityId)).ToList();
+        var contentLocalizationsToCreate = contentLocalizations.Where(l => !existingContentIds.Contains(l.EntityId)).ToList();
+
+        if (contentLocalizationsToUpdate.Count > 0)
+        {
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToUpdate, true);
+        }
+
+        if (contentLocalizationsToCreate.Count > 0)
+        {
+            var utcNow = _timeProvider.GetUtcNow();
+            foreach (var loc in contentLocalizationsToCreate)
+            {
+                loc.CreatedAt = utcNow;
+            }
+
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToCreate, false);
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateHippotherapyProgramSectionDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateHippotherapyProgramSectionDto.cs
@@ -4,6 +4,8 @@ namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 
 public record CreateHippotherapyProgramSectionDto
 {
+    public long? Id { get; set; }
+
     public ProgramSectionTemplate Template { get; set; }
 
     public int Order { get; set; }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramSection/CreateProgramSectionContentDto.cs
@@ -4,6 +4,8 @@ namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramSection;
 
 public record CreateProgramSectionContentDto
 {
+    public long? Id { get; init; }
+
     public ContentType ContentType { get; init; }
 
     public int Order { get; init; }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
@@ -38,100 +38,97 @@ public static class HippotherapyProgramSectionsBuilder
         IReadOnlyDictionary<long, Image> imagesById,
         DateTimeOffset createdAt)
     {
-        if (dto.ContentType == ContentType.Title)
+        return dto.ContentType switch
         {
-            return new TitleProgramContent
-            {
-                ContentType = ContentType.Title,
-                Order = dto.Order,
-                GroupIndex = dto.GroupIndex,
-                Title = dto.Title!.Trim()
-            };
+            ContentType.Title => CreateTitleContent(dto),
+            ContentType.Description => CreateDescriptionContent(dto),
+            ContentType.Image => CreateImageContent(dto, imagesById),
+            ContentType.Author => CreateAuthorContent(dto),
+            ContentType.FaqQuestion => CreateFaqQuestionContent(dto, createdAt),
+            _ => null,
+        };
+    }
+
+    private static TitleProgramContent CreateTitleContent(CreateProgramSectionContentDto dto) => new()
+    {
+        ContentType = ContentType.Title,
+        Order = dto.Order,
+        GroupIndex = dto.GroupIndex,
+        Title = dto.Title!.Trim()
+    };
+
+    private static DescriptionProgramContent CreateDescriptionContent(CreateProgramSectionContentDto dto) => new()
+    {
+        ContentType = ContentType.Description,
+        Order = dto.Order,
+        GroupIndex = dto.GroupIndex,
+        Description = dto.Description!.Trim()
+    };
+
+    private static ImageProgramContent? CreateImageContent(
+        CreateProgramSectionContentDto dto,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        if (dto.ImageId is null or <= 0 || !imagesById.TryGetValue(dto.ImageId.Value, out var image))
+        {
+            return null;
         }
 
-        if (dto.ContentType == ContentType.Description)
+        return new ImageProgramContent
         {
-            return new DescriptionProgramContent
-            {
-                ContentType = ContentType.Description,
-                Order = dto.Order,
-                GroupIndex = dto.GroupIndex,
-                Description = dto.Description!.Trim()
-            };
+            ContentType = ContentType.Image,
+            Order = dto.Order,
+            GroupIndex = dto.GroupIndex,
+            ImageId = dto.ImageId.Value,
+            Image = image
+        };
+    }
+
+    private static AuthorProgramContent CreateAuthorContent(CreateProgramSectionContentDto dto) => new()
+    {
+        ContentType = ContentType.Author,
+        Order = dto.Order,
+        GroupIndex = dto.GroupIndex,
+        Name = dto.Author!.Trim()
+    };
+
+    private static FaqQuestionProgramContent? CreateFaqQuestionContent(
+        CreateProgramSectionContentDto dto,
+        DateTimeOffset createdAt)
+    {
+        if (dto.FaqQuestion is null)
+        {
+            return null;
         }
 
-        if (dto.ContentType == ContentType.Image)
+        var content = new FaqQuestionProgramContent
         {
-            if (dto.ImageId is null or <= 0)
-            {
-                return null;
-            }
+            ContentType = ContentType.FaqQuestion,
+            Order = dto.Order,
+            GroupIndex = dto.GroupIndex,
+        };
 
-            if (!imagesById.TryGetValue(dto.ImageId.Value, out var image))
-            {
-                return null;
-            }
-
-            return new ImageProgramContent
-            {
-                ContentType = ContentType.Image,
-                Order = dto.Order,
-                GroupIndex = dto.GroupIndex,
-                ImageId = dto.ImageId.Value,
-                Image = image
-            };
-        }
-
-        if (dto.ContentType == ContentType.Author)
+        if (dto.FaqQuestion.Id is > 0)
         {
-            return new AuthorProgramContent
-            {
-                ContentType = ContentType.Author,
-                Order = dto.Order,
-                GroupIndex = dto.GroupIndex,
-                Name = dto.Author!.Trim()
-            };
-        }
-
-        if (dto.ContentType == ContentType.FaqQuestion)
-        {
-            if (dto.FaqQuestion is null)
-            {
-                return null;
-            }
-
-            var content = new FaqQuestionProgramContent
-            {
-                ContentType = ContentType.FaqQuestion,
-                Order = dto.Order,
-                GroupIndex = dto.GroupIndex,
-            };
-
-            if (dto.FaqQuestion.Id is > 0)
-            {
-                content.FaqQuestionId = dto.FaqQuestion.Id.Value;
-            }
-            else
-            {
-                if (string.IsNullOrWhiteSpace(dto.FaqQuestion.QuestionText) ||
-                    string.IsNullOrWhiteSpace(dto.FaqQuestion.AnswerText))
-                {
-                    return null;
-                }
-
-                content.FaqQuestion = new FaqQuestion
-                {
-                    QuestionText = dto.FaqQuestion.QuestionText.Trim(),
-                    AnswerText = dto.FaqQuestion.AnswerText.Trim(),
-                    Status = Status.Published,
-                    CreatedAt = createdAt
-                };
-            }
-
+            content.FaqQuestionId = dto.FaqQuestion.Id.Value;
             return content;
         }
 
-        return null;
+        if (string.IsNullOrWhiteSpace(dto.FaqQuestion.QuestionText) ||
+            string.IsNullOrWhiteSpace(dto.FaqQuestion.AnswerText))
+        {
+            return null;
+        }
+
+        content.FaqQuestion = new FaqQuestion
+        {
+            QuestionText = dto.FaqQuestion.QuestionText.Trim(),
+            AnswerText = dto.FaqQuestion.AnswerText.Trim(),
+            Status = Status.Published,
+            CreatedAt = createdAt
+        };
+
+        return content;
     }
 
     private static List<ProgramSectionContent> BuildContents(

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/HippotherapyProgramSectionsBuilder.cs
@@ -33,34 +33,7 @@ public static class HippotherapyProgramSectionsBuilder
         return result;
     }
 
-    private static List<ProgramSectionContent> BuildContents(
-        CreateHippotherapyProgramSectionDto sectionDto,
-        IReadOnlyDictionary<long, Image> imagesById,
-        DateTimeOffset createdAt)
-    {
-        var dtoContents = sectionDto.Contents ?? [];
-        if (dtoContents.Count == 0)
-        {
-            return [];
-        }
-
-        var contents = new List<ProgramSectionContent>(dtoContents.Count);
-
-        foreach (var dto in dtoContents.OrderBy(x => x.Order))
-        {
-            var entity = CreateContent(dto, imagesById, createdAt);
-            if (entity is null)
-            {
-                continue;
-            }
-
-            contents.Add(entity);
-        }
-
-        return contents;
-    }
-
-    private static ProgramSectionContent? CreateContent(
+    public static ProgramSectionContent? CreateContent(
         CreateProgramSectionContentDto dto,
         IReadOnlyDictionary<long, Image> imagesById,
         DateTimeOffset createdAt)
@@ -159,5 +132,32 @@ public static class HippotherapyProgramSectionsBuilder
         }
 
         return null;
+    }
+
+    private static List<ProgramSectionContent> BuildContents(
+        CreateHippotherapyProgramSectionDto sectionDto,
+        IReadOnlyDictionary<long, Image> imagesById,
+        DateTimeOffset createdAt)
+    {
+        var dtoContents = sectionDto.Contents ?? [];
+        if (dtoContents.Count == 0)
+        {
+            return [];
+        }
+
+        var contents = new List<ProgramSectionContent>(dtoContents.Count);
+
+        foreach (var dto in dtoContents.OrderBy(x => x.Order))
+        {
+            var entity = CreateContent(dto, imagesById, createdAt);
+            if (entity is null)
+            {
+                continue;
+            }
+
+            contents.Add(entity);
+        }
+
+        return contents;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Interfaces/HippotherapyPrograms/IProgramSectionContentLocalizationTracker.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Interfaces/HippotherapyPrograms/IProgramSectionContentLocalizationTracker.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+
+namespace VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
+
+public interface IProgramSectionContentLocalizationTracker
+{
+    Task TrackAsync(
+        IEnumerable<UpdateHippotherapyProgramSectionContentLocalizationDto> contentDtos,
+        long languageId);
+}

--- a/VictoryCenter/VictoryCenter.BLL/Services/HippotherapyPrograms/ProgramSectionContentLocalizationTracker.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/HippotherapyPrograms/ProgramSectionContentLocalizationTracker.cs
@@ -1,0 +1,80 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Services.HippotherapyPrograms;
+
+public class ProgramSectionContentLocalizationTracker : IProgramSectionContentLocalizationTracker
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> _contentLocalizationService;
+    private readonly TimeProvider _timeProvider;
+
+    public ProgramSectionContentLocalizationTracker(
+        IMapper mapper,
+        IRepositoryWrapper repositoryWrapper,
+        ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization> contentLocalizationService,
+        TimeProvider timeProvider)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+        _contentLocalizationService = contentLocalizationService;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task TrackAsync(
+        IEnumerable<UpdateHippotherapyProgramSectionContentLocalizationDto> contentDtos,
+        long languageId)
+    {
+        var contentDtoList = contentDtos.ToList();
+        var contentLocalizations = _mapper.Map<List<ProgramSectionContentLocalization>>(contentDtoList);
+
+        for (int i = 0; i < contentLocalizations.Count; i++)
+        {
+            contentLocalizations[i].EntityId = contentDtoList[i].EntityId;
+            contentLocalizations[i].LanguageId = languageId;
+            contentLocalizations[i].TranslationStatus = TranslationStatus.Relevant;
+        }
+
+        var contentIds = contentLocalizations.Select(l => l.EntityId).ToList();
+
+        var existingContentLocalizations = (await _repositoryWrapper.ProgramSectionContentLocalizationsRepository
+            .GetAllAsync(new QueryOptions<ProgramSectionContentLocalization>
+            {
+                Filter = l => l.LanguageId == languageId && contentIds.Contains(l.EntityId)
+            })).ToList();
+
+        var existingContentLocalizationsById = existingContentLocalizations.ToDictionary(l => l.EntityId);
+
+        var contentLocalizationsToUpdate = contentLocalizations.Where(l => existingContentLocalizationsById.ContainsKey(l.EntityId)).ToList();
+        var contentLocalizationsToCreate = contentLocalizations.Where(l => !existingContentLocalizationsById.ContainsKey(l.EntityId)).ToList();
+
+        if (contentLocalizationsToUpdate.Count > 0)
+        {
+            foreach (var loc in contentLocalizationsToUpdate)
+            {
+                loc.CreatedAt = existingContentLocalizationsById[loc.EntityId].CreatedAt;
+            }
+
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToUpdate, true);
+        }
+
+        if (contentLocalizationsToCreate.Count > 0)
+        {
+            var utcNow = _timeProvider.GetUtcNow();
+            foreach (var loc in contentLocalizationsToCreate)
+            {
+                loc.CreatedAt = utcNow;
+            }
+
+            await _contentLocalizationService.TrackEntityLocalizationAsync(contentLocalizationsToCreate, false);
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -61,7 +61,7 @@ public class UpdateHippotherapyProgramTests
     [Fact]
     public async Task Handle_ValidRequest_ReplacesSections()
     {
-        var program = Program(sections: [new HippotherapyProgramSection { Template = default, Order = 99, CreatedAt = DateTimeOffset.UtcNow, Contents = [] }]);
+        var program = Program(sections: [new HippotherapyProgramSection { Id = 1, Template = default, Order = 99, CreatedAt = DateTimeOffset.UtcNow, Contents = [] }]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
         await sut.Handle(
@@ -298,6 +298,7 @@ public class UpdateHippotherapyProgramTests
     {
         var content = new TitleProgramContent
         {
+            Id = 1,
             ContentType = ContentType.Title,
             Order = 0,
             Title = "Old title",
@@ -310,6 +311,7 @@ public class UpdateHippotherapyProgramTests
 
         var section = new HippotherapyProgramSection
         {
+            Id = 1,
             Template = default,
             Order = 0,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -319,7 +321,7 @@ public class UpdateHippotherapyProgramTests
         var program = Program(sections: [section]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        var dto = Dto(sections: [CreateSection(0, CreateTitleContent(0, "New title"))]);
+        var dto = Dto(sections: [CreateSection(0, CreateTitleContent(0, "New title", id: 1), id: 1)]);
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
@@ -328,10 +330,11 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
-    public async Task Handle_SameSectionStructureAndUnchangedTitle_MarksContentLocalizationsOutdated()
+    public async Task Handle_SameSectionStructureAndUnchangedTitle_KeepsExistingContentIdentity()
     {
         var content = new TitleProgramContent
         {
+            Id = 1,
             ContentType = ContentType.Title,
             Order = 0,
             Title = "Same title",
@@ -344,6 +347,7 @@ public class UpdateHippotherapyProgramTests
 
         var section = new HippotherapyProgramSection
         {
+            Id = 1,
             Template = default,
             Order = 0,
             CreatedAt = DateTimeOffset.UtcNow,
@@ -353,22 +357,38 @@ public class UpdateHippotherapyProgramTests
         var program = Program(sections: [section]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        var dto = Dto(sections: [CreateSection(0, CreateTitleContent(0, "Same title"))]);
+        var dto = Dto(
+            name: program.Name,
+            description: program.Description,
+            sections: [CreateSection(0, CreateTitleContent(0, "Same title", id: 1), id: 1)]);
+        dto.Location = program.Location;
+        dto.ParticipantsCount = program.ParticipantsCount;
+        dto.MeetingsCount = program.MeetingsCount;
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
+        Assert.Same(content, program.Sections.Single().Contents.Single());
+        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
     }
 
     [Fact]
-    public async Task Handle_DifferentSectionStructure_ClearsProgramLocalizations()
+    public async Task Handle_NewSectionAdded_MarksProgramLocalizationsOutdatedWithoutClearingThem()
     {
+        var content = new TitleProgramContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Same title",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
         var section = new HippotherapyProgramSection
         {
+            Id = 1,
             Template = default,
-            Order = 99,
+            Order = 0,
             CreatedAt = DateTimeOffset.UtcNow,
-            Contents = []
+            Contents = [content]
         };
 
         var program = Program(sections: [section]);
@@ -380,15 +400,73 @@ public class UpdateHippotherapyProgramTests
 
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        await sut.Handle(
-            Command(id: 1, dto: Dto(sections:
+        var dto = Dto(
+            name: program.Name,
+            description: program.Description,
+            sections:
             [
-                CreateSection(0, CreateImageContent(0, 1)),
+                CreateSection(0, CreateTitleContent(0, "Same title", id: 1), id: 1),
                 CreateSection(1, CreateImageContent(0, 2))
-            ])),
-            CancellationToken.None);
+            ]);
+        dto.Location = program.Location;
+        dto.ParticipantsCount = program.ParticipantsCount;
+        dto.MeetingsCount = program.MeetingsCount;
 
-        Assert.Empty(program.Localizations);
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.Equal(2, program.Sections.Count);
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
+        Assert.Same(content, program.Sections.First().Contents.Single());
+        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+    }
+
+    [Fact]
+    public async Task Handle_SectionRemoved_RemovesOnlyThatSectionAndKeepsOtherLocalizations()
+    {
+        var keptContent = new TitleProgramContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Kept title",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var keptSection = new HippotherapyProgramSection
+        {
+            Id = 1,
+            Template = default,
+            Order = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [keptContent]
+        };
+        var removedSection = new HippotherapyProgramSection
+        {
+            Id = 2,
+            Template = default,
+            Order = 1,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = []
+        };
+
+        var program = Program(sections: [keptSection, removedSection]);
+        program.Localizations = [ProgramLocalization(1, TranslationStatus.Relevant)];
+
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        var dto = Dto(
+            name: program.Name,
+            description: program.Description,
+            sections: [CreateSection(0, CreateTitleContent(0, "Kept title", id: 1), id: 1)]);
+        dto.Location = program.Location;
+        dto.ParticipantsCount = program.ParticipantsCount;
+        dto.MeetingsCount = program.MeetingsCount;
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.Equal(1, program.Sections.Count);
+        Assert.Same(keptSection, program.Sections.Single());
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+        Assert.All(keptContent.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
     }
 
     [Fact]
@@ -396,16 +474,17 @@ public class UpdateHippotherapyProgramTests
     {
         var content = new DescriptionProgramContent
         {
+            Id = 1,
             ContentType = ContentType.Description,
             Order = 0,
             Description = "Old description",
             Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
         };
-        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var section = new HippotherapyProgramSection { Id = 1, Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
         var program = Program(sections: [section]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateDescriptionContent(0, "New description"))])), CancellationToken.None);
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateDescriptionContent(0, "New description", id: 1), id: 1)])), CancellationToken.None);
 
         Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
     }
@@ -415,16 +494,17 @@ public class UpdateHippotherapyProgramTests
     {
         var content = new AuthorProgramContent
         {
+            Id = 1,
             ContentType = ContentType.Author,
             Order = 0,
             Name = "Old author",
             Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
         };
-        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var section = new HippotherapyProgramSection { Id = 1, Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
         var program = Program(sections: [section]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateAuthorContent(0, "New author"))])), CancellationToken.None);
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateAuthorContent(0, "New author", id: 1), id: 1)])), CancellationToken.None);
 
         Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
     }
@@ -435,17 +515,18 @@ public class UpdateHippotherapyProgramTests
         var faqQuestion = new FaqQuestion { Id = 10, QuestionText = "Old question", AnswerText = "Old answer" };
         var content = new FaqQuestionProgramContent
         {
+            Id = 1,
             ContentType = ContentType.FaqQuestion,
             Order = 0,
             FaqQuestionId = 10,
             FaqQuestion = faqQuestion,
             Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
         };
-        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var section = new HippotherapyProgramSection { Id = 1, Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
         var program = Program(sections: [section]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        var dto = Dto(sections: [CreateSection(0, CreateFaqQuestionContent(0, 10, "New question", "New answer"))]);
+        var dto = Dto(sections: [CreateSection(0, CreateFaqQuestionContent(0, 10, "New question", "New answer", id: 1), id: 1)]);
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
@@ -459,17 +540,18 @@ public class UpdateHippotherapyProgramTests
     {
         var content = new ImageProgramContent
         {
+            Id = 1,
             ContentType = ContentType.Image,
             Order = 0,
             ImageId = 1,
             Image = Images[0],
             Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
         };
-        var section = new HippotherapyProgramSection { Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var section = new HippotherapyProgramSection { Id = 1, Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
         var program = Program(sections: [section]);
         var sut = CreateSut(program: program, saveChanges: 1);
 
-        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateImageContent(0, 2))])), CancellationToken.None);
+        await sut.Handle(Command(id: 1, dto: Dto(sections: [CreateSection(0, CreateImageContent(0, 2, id: 1), id: 1)])), CancellationToken.None);
 
         Assert.Equal(2, content.ImageId);
         Assert.Equal(TranslationStatus.Outdated, content.Localizations.Single().TranslationStatus);
@@ -689,53 +771,70 @@ public class UpdateHippotherapyProgramTests
         };
     }
 
-    private static CreateProgramSectionContentDto CreateImageContent(int order, long imageId)
+    private static CreateHippotherapyProgramSectionDto CreateSection(int order, CreateProgramSectionContentDto content, long id)
+    {
+        return new CreateHippotherapyProgramSectionDto
+        {
+            Id = id,
+            Template = default,
+            Order = order,
+            Contents = [content]
+        };
+    }
+
+    private static CreateProgramSectionContentDto CreateImageContent(int order, long imageId, long? id = null)
     {
         return new CreateProgramSectionContentDto
         {
+            Id = id,
             ContentType = ContentType.Image,
             Order = order,
             ImageId = imageId
         };
     }
 
-    private static CreateProgramSectionContentDto CreateTitleContent(int order, string title)
+    private static CreateProgramSectionContentDto CreateTitleContent(int order, string title, long? id = null)
     {
         return new CreateProgramSectionContentDto
         {
+            Id = id,
             ContentType = ContentType.Title,
             Order = order,
             Title = title
         };
     }
 
-    private static CreateProgramSectionContentDto CreateDescriptionContent(int order, string description)
+    private static CreateProgramSectionContentDto CreateDescriptionContent(int order, string description, long? id = null)
     {
         return new CreateProgramSectionContentDto
         {
+            Id = id,
             ContentType = ContentType.Description,
             Order = order,
             Description = description
         };
     }
 
-    private static CreateProgramSectionContentDto CreateAuthorContent(int order, string author)
+    private static CreateProgramSectionContentDto CreateAuthorContent(int order, string author, long? id = null)
     {
         return new CreateProgramSectionContentDto
         {
+            Id = id,
             ContentType = ContentType.Author,
             Order = order,
             Author = author
         };
     }
 
-    private static CreateProgramSectionContentDto CreateFaqQuestionContent(int order, long id, string questionText, string answerText)
+    private static CreateProgramSectionContentDto CreateFaqQuestionContent(
+        int order, long faqQuestionId, string questionText, string answerText, long? id = null)
     {
         return new CreateProgramSectionContentDto
         {
+            Id = id,
             ContentType = ContentType.FaqQuestion,
             Order = order,
-            FaqQuestion = new CreateFaqSectionQuestionDto { Id = id, QuestionText = questionText, AnswerText = answerText }
+            FaqQuestion = new CreateFaqSectionQuestionDto { Id = faqQuestionId, QuestionText = questionText, AnswerText = answerText }
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -470,6 +470,35 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
+    public async Task Handle_ExistingContentReordered_UpdatesOrderWithoutMarkingLocalizationsOutdated()
+    {
+        var content = new TitleProgramContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Same title",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection { Id = 1, Template = default, Order = 0, CreatedAt = DateTimeOffset.UtcNow, Contents = [content] };
+        var program = Program(sections: [section]);
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        var dto = Dto(
+            name: program.Name,
+            description: program.Description,
+            sections: [CreateSection(0, CreateTitleContent(3, "Same title", id: 1), id: 1)]);
+        dto.Location = program.Location;
+        dto.ParticipantsCount = program.ParticipantsCount;
+        dto.MeetingsCount = program.MeetingsCount;
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.Equal(3, content.Order);
+        Assert.All(content.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+    }
+
+    [Fact]
     public async Task Handle_SameStructureAndChangedDescription_MarksContentLocalizationsOutdated()
     {
         var content = new DescriptionProgramContent

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -463,7 +463,7 @@ public class UpdateHippotherapyProgramTests
 
         await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
 
-        Assert.Equal(1, program.Sections.Count);
+        Assert.Single(program.Sections);
         Assert.Same(keptSection, program.Sections.Single());
         Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
         Assert.All(keptContent.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
@@ -723,7 +723,7 @@ public class UpdateHippotherapyProgramTests
 
     private static UpdateHippotherapyProgramDto Dto(
         string name = "Name",
-        string description = "Description",
+        string? description = "Description",
         Status status = Status.Published,
         long? backgroundImageId = 1,
         long? previewImageId = 2,

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
@@ -306,6 +306,10 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             });
 
         _mockRepositoryWrapper
+            .Setup(r => r.ProgramSectionContentLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<ProgramSectionContentLocalization>>()))
+            .ReturnsAsync(new List<ProgramSectionContentLocalization>());
+
+        _mockRepositoryWrapper
             .Setup(r => r.SaveChangesAsync())
             .ReturnsAsync(1);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
@@ -26,9 +26,8 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
     private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
     private readonly Mock<IValidator<UpdateHippotherapyProgramLocalizationCommand>> _mockValidator;
     private readonly Mock<ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization>> _mockProgramLocalizationService;
-    private readonly Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>> _mockContentLocalizationService;
+    private readonly Mock<IProgramSectionContentLocalizationTracker> _mockContentLocalizationTracker;
     private readonly Mock<IProgramSectionContentService> _mockProgramSectionContentService;
-    private readonly Mock<TimeProvider> _mockTimeProvider;
     private readonly UpdateHippotherapyProgramLocalizationHandler _handler;
 
     private readonly UpdateHippotherapyProgramLocalizationDto _testUpdateDto = new()
@@ -99,10 +98,8 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
         _mockValidator = new Mock<IValidator<UpdateHippotherapyProgramLocalizationCommand>>();
         _mockProgramLocalizationService = new Mock<ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization>>();
-        _mockContentLocalizationService = new Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>>();
+        _mockContentLocalizationTracker = new Mock<IProgramSectionContentLocalizationTracker>();
         _mockProgramSectionContentService = new Mock<IProgramSectionContentService>();
-        _mockTimeProvider = new Mock<TimeProvider>();
-        _mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(DateTimeOffset.UtcNow);
 
         _handler = new UpdateHippotherapyProgramLocalizationHandler(
             _mockMapper.Object,
@@ -110,8 +107,7 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             _mockValidator.Object,
             _mockProgramSectionContentService.Object,
             _mockProgramLocalizationService.Object,
-            _mockContentLocalizationService.Object,
-            _mockTimeProvider.Object);
+            _mockContentLocalizationTracker.Object);
     }
 
     [Fact]
@@ -310,10 +306,6 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             });
 
         _mockRepositoryWrapper
-            .Setup(r => r.ProgramSectionContentLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<ProgramSectionContentLocalization>>()))
-            .ReturnsAsync([]);
-
-        _mockRepositoryWrapper
             .Setup(r => r.SaveChangesAsync())
             .ReturnsAsync(1);
 
@@ -329,19 +321,12 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             .Setup(m => m.Map<LocalizationInfoDto>(It.IsAny<LocalizationLanguage>()))
             .Returns(new LocalizationInfoDto { Id = 2, Code = "en" });
 
-        _mockMapper
-            .Setup(m => m.Map<List<ProgramSectionContentLocalization>>(It.IsAny<List<UpdateHippotherapyProgramSectionContentLocalizationDto>>()))
-            .Returns(new List<ProgramSectionContentLocalization>
-            {
-                new()
-            });
-
         _mockProgramLocalizationService
             .Setup(s => s.TrackEntityLocalizationForUpdateAsync(It.IsAny<HippotherapyProgramLocalization>()))
             .Returns(Task.CompletedTask);
 
-        _mockContentLocalizationService
-            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), It.IsAny<bool>()))
+        _mockContentLocalizationTracker
+            .Setup(t => t.TrackAsync(It.IsAny<IEnumerable<UpdateHippotherapyProgramSectionContentLocalizationDto>>(), It.IsAny<long>()))
             .Returns(Task.CompletedTask);
 
         _mockProgramSectionContentService

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/UpdateHippotherapyProgramLocalizationHandlerTests.cs
@@ -28,6 +28,7 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
     private readonly Mock<ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization>> _mockProgramLocalizationService;
     private readonly Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>> _mockContentLocalizationService;
     private readonly Mock<IProgramSectionContentService> _mockProgramSectionContentService;
+    private readonly Mock<TimeProvider> _mockTimeProvider;
     private readonly UpdateHippotherapyProgramLocalizationHandler _handler;
 
     private readonly UpdateHippotherapyProgramLocalizationDto _testUpdateDto = new()
@@ -100,6 +101,8 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
         _mockProgramLocalizationService = new Mock<ILocalizationService<HippotherapyProgramEntity, HippotherapyProgramLocalization>>();
         _mockContentLocalizationService = new Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>>();
         _mockProgramSectionContentService = new Mock<IProgramSectionContentService>();
+        _mockTimeProvider = new Mock<TimeProvider>();
+        _mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(DateTimeOffset.UtcNow);
 
         _handler = new UpdateHippotherapyProgramLocalizationHandler(
             _mockMapper.Object,
@@ -107,7 +110,8 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
             _mockValidator.Object,
             _mockProgramSectionContentService.Object,
             _mockProgramLocalizationService.Object,
-            _mockContentLocalizationService.Object);
+            _mockContentLocalizationService.Object,
+            _mockTimeProvider.Object);
     }
 
     [Fact]
@@ -307,7 +311,7 @@ public class UpdateHippotherapyProgramLocalizationHandlerTests
 
         _mockRepositoryWrapper
             .Setup(r => r.ProgramSectionContentLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<ProgramSectionContentLocalization>>()))
-            .ReturnsAsync(new List<ProgramSectionContentLocalization>());
+            .ReturnsAsync([]);
 
         _mockRepositoryWrapper
             .Setup(r => r.SaveChangesAsync())

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentLocalizationTrackerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentLocalizationTrackerTests.cs
@@ -47,7 +47,7 @@ public class ProgramSectionContentLocalizationTrackerTests
         List<ProgramSectionContentLocalization>? capturedCreateBatch = null;
         _mockContentLocalizationService
             .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), false))
-            .Callback<IEnumerable<ProgramSectionContentLocalization>, bool>((locs, _) => capturedCreateBatch = locs.ToList())
+            .Callback<IEnumerable<ProgramSectionContentLocalization>, bool>((locs, _) => capturedCreateBatch = [.. locs])
             .Returns(Task.CompletedTask);
 
         // Act
@@ -83,7 +83,7 @@ public class ProgramSectionContentLocalizationTrackerTests
         List<ProgramSectionContentLocalization>? capturedUpdateBatch = null;
         _mockContentLocalizationService
             .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), true))
-            .Callback<IEnumerable<ProgramSectionContentLocalization>, bool>((locs, _) => capturedUpdateBatch = locs.ToList())
+            .Callback<IEnumerable<ProgramSectionContentLocalization>, bool>((locs, _) => capturedUpdateBatch = [.. locs])
             .Returns(Task.CompletedTask);
 
         // Act
@@ -139,7 +139,7 @@ public class ProgramSectionContentLocalizationTrackerTests
     {
         _mockMapper
             .Setup(m => m.Map<List<ProgramSectionContentLocalization>>(It.IsAny<List<UpdateHippotherapyProgramSectionContentLocalizationDto>>()))
-            .Returns(Enumerable.Range(0, count).Select(_ => new ProgramSectionContentLocalization()).ToList());
+            .Returns([.. Enumerable.Range(0, count).Select(_ => new ProgramSectionContentLocalization())]);
     }
 
     private void SetupExistingLocalizations(List<ProgramSectionContentLocalization> existing)

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentLocalizationTrackerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentLocalizationTrackerTests.cs
@@ -1,0 +1,151 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection.Update;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Services.HippotherapyPrograms;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.ServiceTests;
+
+public class ProgramSectionContentLocalizationTrackerTests
+{
+    private readonly Mock<IMapper> _mockMapper = new();
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper = new();
+    private readonly Mock<ILocalizationService<ProgramSectionContent, ProgramSectionContentLocalization>> _mockContentLocalizationService = new();
+    private readonly Mock<TimeProvider> _mockTimeProvider = new();
+    private readonly ProgramSectionContentLocalizationTracker _tracker;
+
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public ProgramSectionContentLocalizationTrackerTests()
+    {
+        _mockTimeProvider.Setup(t => t.GetUtcNow()).Returns(Now);
+
+        _tracker = new ProgramSectionContentLocalizationTracker(
+            _mockMapper.Object,
+            _mockRepositoryWrapper.Object,
+            _mockContentLocalizationService.Object,
+            _mockTimeProvider.Object);
+    }
+
+    [Fact]
+    public async Task TrackAsync_NewContent_CreatesLocalizationWithCurrentTimestamp()
+    {
+        // Arrange
+        var contentDtos = new List<UpdateHippotherapyProgramSectionContentLocalizationDto>
+        {
+            new() { EntityId = 200, Title = "New title" }
+        };
+
+        SetupMapper(contentDtos.Count);
+        SetupExistingLocalizations([]);
+
+        List<ProgramSectionContentLocalization>? capturedCreateBatch = null;
+        _mockContentLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), false))
+            .Callback<IEnumerable<ProgramSectionContentLocalization>, bool>((locs, _) => capturedCreateBatch = locs.ToList())
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _tracker.TrackAsync(contentDtos, languageId: 2);
+
+        // Assert
+        Assert.NotNull(capturedCreateBatch);
+        var created = Assert.Single(capturedCreateBatch!);
+        Assert.Equal(200, created.EntityId);
+        Assert.Equal(Now, created.CreatedAt);
+        Assert.Equal(TranslationStatus.Relevant, created.TranslationStatus);
+        _mockContentLocalizationService.Verify(
+            s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), true),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TrackAsync_ExistingContent_UpdatesAndPreservesOriginalCreatedAt()
+    {
+        // Arrange
+        var originalCreatedAt = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var contentDtos = new List<UpdateHippotherapyProgramSectionContentLocalizationDto>
+        {
+            new() { EntityId = 200, Title = "Updated title" }
+        };
+
+        SetupMapper(contentDtos.Count);
+        SetupExistingLocalizations(
+        [
+            new() { EntityId = 200, LanguageId = 2, CreatedAt = originalCreatedAt }
+        ]);
+
+        List<ProgramSectionContentLocalization>? capturedUpdateBatch = null;
+        _mockContentLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), true))
+            .Callback<IEnumerable<ProgramSectionContentLocalization>, bool>((locs, _) => capturedUpdateBatch = locs.ToList())
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _tracker.TrackAsync(contentDtos, languageId: 2);
+
+        // Assert
+        Assert.NotNull(capturedUpdateBatch);
+        var updated = Assert.Single(capturedUpdateBatch!);
+        Assert.Equal(originalCreatedAt, updated.CreatedAt);
+        _mockContentLocalizationService.Verify(
+            s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), false),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TrackAsync_MixedBatch_CreatesNewContentAndUpdatesExistingContentSeparately()
+    {
+        // Arrange
+        var originalCreatedAt = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var contentDtos = new List<UpdateHippotherapyProgramSectionContentLocalizationDto>
+        {
+            new() { EntityId = 100, Title = "Existing section title" },
+            new() { EntityId = 200, Title = "New section title" }
+        };
+
+        SetupMapper(contentDtos.Count);
+        SetupExistingLocalizations(
+        [
+            new() { EntityId = 100, LanguageId = 2, CreatedAt = originalCreatedAt }
+        ]);
+
+        _mockContentLocalizationService
+            .Setup(s => s.TrackEntityLocalizationAsync(It.IsAny<IEnumerable<ProgramSectionContentLocalization>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _tracker.TrackAsync(contentDtos, languageId: 2);
+
+        // Assert
+        _mockContentLocalizationService.Verify(
+            s => s.TrackEntityLocalizationAsync(
+                It.Is<IEnumerable<ProgramSectionContentLocalization>>(l => l.Single().EntityId == 100),
+                true),
+            Times.Once);
+        _mockContentLocalizationService.Verify(
+            s => s.TrackEntityLocalizationAsync(
+                It.Is<IEnumerable<ProgramSectionContentLocalization>>(l => l.Single().EntityId == 200),
+                false),
+            Times.Once);
+    }
+
+    private void SetupMapper(int count)
+    {
+        _mockMapper
+            .Setup(m => m.Map<List<ProgramSectionContentLocalization>>(It.IsAny<List<UpdateHippotherapyProgramSectionContentLocalizationDto>>()))
+            .Returns(Enumerable.Range(0, count).Select(_ => new ProgramSectionContentLocalization()).ToList());
+    }
+
+    private void SetupExistingLocalizations(List<ProgramSectionContentLocalization> existing)
+    {
+        _mockRepositoryWrapper
+            .Setup(r => r.ProgramSectionContentLocalizationsRepository.GetAllAsync(It.IsAny<QueryOptions<ProgramSectionContentLocalization>>()))
+            .ReturnsAsync(existing);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -184,6 +184,7 @@ public static class ServicesConfiguration
         services.AddScoped<IMainPageBlocksLocalizationUpdater, MainPageBlocksLocalizationUpdater>();
 
         services.AddScoped<IProgramSectionContentService, ProgramSectionContentService>();
+        services.AddScoped<IProgramSectionContentLocalizationTracker, ProgramSectionContentLocalizationTracker>();
 
         services.AddHttpClient<ICaptchaResponseTokenValidationService, CloudflareTurnstileCaptchaResponseTokenValidationService>();
 


### PR DESCRIPTION
dev
## JIRA

* [#1510](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1510)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Adding a new section to a Ukrainian program page destroyed the entire existing English translation instead of just flagging it for review. `UpdateHippotherapyProgramHandler` matched old and new sections by `Order` + `Template` + `ContentType` only; any change to section count (e.g. inserting a new section) caused `EnsureReplaceSameSections` to fail the match, which triggered `ReplaceSections` (a full `program.Sections.Clear()` + rebuild with brand new Ids) followed by `program.Localizations.Clear()`. Because the rebuilt sections/content got new Ids and the localization row was deleted outright, every previously translated section (and the top-level program name/description translation) was lost, contradicting the requirement that only the new section should need translation and the rest of the page stay untouched. Separately, once the section-diff was fixed, saving a translation for the newly added section's content surfaced a `400 Bad Request` ("Failed to update HippotherapyProgramLocalization in the database"), because `UpdateHippotherapyProgramLocalizationHandler` unconditionally called `TrackEntityLocalizationAsync(contentLocalizations, isUpdate: true)` for the whole batch. EF Core's `UPDATE` against a content Id that never had a localization row before affects 0 rows and throws `DbUpdateConcurrencyException`.

## Summary of change

- **`CreateHippotherapyProgramSectionDto` / `CreateProgramSectionContentDto`:** added nullable `Id` so the update payload can identify which sections/content already exist versus which are brand new.
- **`HippotherapyProgramSectionsBuilder`:** `CreateContent` made `public` so it can be reused to build a single new content item outside of a full section rebuild; split into per-content-type helpers (`CreateTitleContent`, `CreateDescriptionContent`, `CreateImageContent`, `CreateAuthorContent`, `CreateFaqQuestionContent`) to reduce cognitive/cyclomatic complexity.
- **`UpdateHippotherapyProgramHandler`:** replaced the order-based all-or-nothing `EnsureReplaceSameSections` / `ReplaceSections` with `MergeSections` / `MergeSectionContents`, a diff by stable `Id`. Sections/content present in both old and new payload are updated in place (Id and `Localizations` preserved); sections with no matching Id are created without touching the rest of the tree; sections missing from the new payload are removed individually. `program.Localizations.Clear()` was removed; when a new section is added, only the top-level `HippotherapyProgramLocalization` rows are marked `Outdated` via a new narrow `MarkProgramLocalizationsOutdated` helper, leaving already-translated sections/content untouched. `TryApplyContentFieldUpdates` now also copies `Order` for matched content (previously only `GroupIndex` was copied, so reordering existing content within a section silently didn't persist).
- **`UpdateHippotherapyProgramLocalizationHandler` / new `IProgramSectionContentLocalizationTracker`:** content localizations are split into an "update" batch (existing `(EntityId, LanguageId)` row found) and a "create" batch (no existing row), each sent to `TrackEntityLocalizationAsync` with the correct `isUpdate` flag, mirroring the pattern already used by `UpdateHistorySectionLocalizationHandler`. This logic was extracted from the handler into a new dedicated `ProgramSectionContentLocalizationTracker` service to reduce the handler's own type coupling. The tracker also preserves the original `CreatedAt` on updated rows (previously `UpdateRange`'s blanket property-modified tracking silently zeroed it out, since the update DTO never carries a `CreatedAt`) and uses an injected `TimeProvider` instead of `DateTimeOffset.UtcNow` for newly-created rows, for testability. Fixes the `DbUpdateConcurrencyException` for content in a section that was just added.
- **Unit Test Coverage:** updated `UpdateHippotherapyProgramTests.cs` to set matching `Id` values where "unchanged section" is being tested, replaced the test asserting the old `Localizations.Clear()` behavior with tests asserting the new preserve-and-mark-outdated behavior, and added coverage for "new section added", "section removed", and "existing content reordered" scenarios. Added `ProgramSectionContentLocalizationTrackerTests.cs` covering the create/update split in isolation, including a mixed create+update batch in one call (the real #1510 scenario: one untouched translated section alongside one newly added, untranslated section) and `CreatedAt` preservation on update.

## Testing approach

- Full backend unit test suite: `2121/2121` passed (`dotnet vstest VictoryCenter.UnitTests`).
- Manual end-to-end verification: ran the backend (`VictoryCenter.WebAPI`, `Local` profile) and the frontend (`npm start`) locally against each other. Reproduced the target scenario: added a new section to a UA program that already had a full EN translation, saved, confirmed the EN indicator turned orange without resetting existing translated fields, opened "Редагувати переклад" and confirmed the new section appeared with the UA-mirrored structure and empty fields while previously translated sections kept their EN text, then saved the new section's translation and confirmed the indicator turned green again (this last step surfaced and led to fixing the content-localization create/update-split bug described above).

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hippotherapy program sections and content updates now use identifiers to add, reorder, and remove items while matching existing sections/contents.

* **Improvements**
  * Localization review/outdated status updates more precisely: only triggers when section fields or content changes occur, and unchanged content is preserved when possible.

* **Tests**
  * Updated and expanded tests to cover identifier-aware section/content updates, localization status behavior, and mixed batches of existing and newly created content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->