### PR TITLE
Reconcile PDF report language migration history

### DIFF
--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260525100310_AddLanguageIdToPdfReports.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260525100310_AddLanguageIdToPdfReports.cs
@@ -10,36 +10,66 @@ namespace VictoryCenter.DAL.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // CreatedAt is required and has no database default, so the fallback language must provide it explicitly.
+            migrationBuilder.Sql("""
+                INSERT INTO dbo.LocalizationLanguages (Code, Name, CreatedAt)
+                SELECT 'uk', N'Українська', TODATETIMEOFFSET(SYSUTCDATETIME(), '+00:00')
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM dbo.LocalizationLanguages
+                    WHERE Code = 'uk'
+                );
+                """);
+
+            // Clean databases do not have this column, while some environments
+            // already received it from the removed migration.
+            migrationBuilder.Sql("""
+                IF COL_LENGTH(N'media.PdfReports', N'LanguageId') IS NULL
+                BEGIN
+                    ALTER TABLE media.PdfReports ADD LanguageId bigint NULL;
+                END;
+                """);
+
+            // Remove artifacts created by the removed migration before applying the current model constraints.
+            migrationBuilder.Sql("""
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.foreign_keys
+                    WHERE name = N'FK_PdfReports_LocalizationLanguages_LanguageId'
+                      AND parent_object_id = OBJECT_ID(N'media.PdfReports')
+                )
+                BEGIN
+                    ALTER TABLE media.PdfReports
+                    DROP CONSTRAINT FK_PdfReports_LocalizationLanguages_LanguageId;
+                END;
+
+                IF EXISTS (
+                    SELECT 1
+                    FROM sys.indexes
+                    WHERE name = N'IX_PdfReports_LanguageId'
+                      AND object_id = OBJECT_ID(N'media.PdfReports')
+                )
+                BEGIN
+                    DROP INDEX IX_PdfReports_LanguageId ON media.PdfReports;
+                END;
+                """);
+
+            // The current model defines priority as unique within a language, rather than globally across all reports.
             migrationBuilder.DropIndex(
                 name: "IX_PdfReports_Priority",
                 schema: "media",
                 table: "PdfReports");
 
-            migrationBuilder.Sql("""
-                INSERT INTO LocalizationLanguages (Code, Name)
-                SELECT 'uk', N'Українська'
-                WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM LocalizationLanguages
-                    WHERE Code = 'uk'
-                );
-                """);
-
-            migrationBuilder.AddColumn<long>(
-                name: "LanguageId",
-                schema: "media",
-                table: "PdfReports",
-                type: "bigint",
-                nullable: true);
-
+            // Existing rows must be backfilled before the initially nullable column can be made required.
+            // Code has a unique index, so the cross join resolves to exactly one fallback language.
             migrationBuilder.Sql("""
                 UPDATE pr
                 SET LanguageId = ll.Id
                 FROM media.PdfReports pr
-                CROSS JOIN LocalizationLanguages ll
+                CROSS JOIN dbo.LocalizationLanguages ll
                 WHERE ll.Code = 'uk'
                   AND pr.LanguageId IS NULL;
-             """);
+                """);
 
             migrationBuilder.AlterColumn<long>(
                 name: "LanguageId",
@@ -51,6 +81,7 @@ namespace VictoryCenter.DAL.Migrations
                 oldType: "bigint",
                 oldNullable: true);
 
+            // Allow the same priority in different languages while preventing duplicates within one language.
             migrationBuilder.CreateIndex(
                 name: "IX_PdfReports_LanguageId_Priority",
                 schema: "media",
@@ -58,6 +89,7 @@ namespace VictoryCenter.DAL.Migrations
                 columns: new[] { "LanguageId", "Priority" },
                 unique: true);
 
+            // Prevent deletion of a language while PDF reports still reference it.
             migrationBuilder.AddForeignKey(
                 name: "FK_PdfReports_LocalizationLanguages_LanguageId",
                 schema: "media",

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260525100310_AddLanguageIdToPdfReports.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260525100310_AddLanguageIdToPdfReports.cs
@@ -113,10 +113,32 @@ namespace VictoryCenter.DAL.Migrations
                 schema: "media",
                 table: "PdfReports");
 
-            migrationBuilder.DropColumn(
-                name: "LanguageId",
-                schema: "media",
-                table: "PdfReports");
+            // Restore the schema owned by the removed migration when its history row remains.
+            // Otherwise, remove the column introduced by this migration on a clean database.
+            migrationBuilder.Sql("""
+                IF EXISTS (
+                    SELECT 1
+                    FROM entity_framework.__EFMigrationsHistory
+                    WHERE MigrationId = N'20260609211541_AddLanguageIdToPdfReport'
+                )
+                BEGIN
+                    ALTER TABLE media.PdfReports
+                    ALTER COLUMN LanguageId bigint NULL;
+
+                    CREATE INDEX IX_PdfReports_LanguageId
+                    ON media.PdfReports (LanguageId);
+
+                    ALTER TABLE media.PdfReports
+                    ADD CONSTRAINT FK_PdfReports_LocalizationLanguages_LanguageId
+                    FOREIGN KEY (LanguageId)
+                    REFERENCES dbo.LocalizationLanguages (Id)
+                    ON DELETE NO ACTION;
+                END;
+                ELSE
+                BEGIN
+                    ALTER TABLE media.PdfReports DROP COLUMN LanguageId;
+                END;
+                """);
 
             migrationBuilder.CreateIndex(
                 name: "IX_PdfReports_Priority",

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/VictoryCenterWebApplicationFactory.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/VictoryCenterWebApplicationFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using VictoryCenter.DAL.Data;
@@ -88,10 +89,13 @@ public class VictoryCenterWebApplicationFactory<TStartup> : WebApplicationFactor
 
     private static void RemoveExistingContext(IServiceCollection services)
     {
+        // EF Core registers provider configuration separately; remove it to avoid
+        // mixing SQL Server and InMemory providers.
         var descriptors = services
             .Where(d =>
                 d.ServiceType == typeof(DbContextOptions<VictoryCenterDbContext>) ||
-                d.ServiceType == typeof(VictoryCenterDbContext))
+                d.ServiceType == typeof(VictoryCenterDbContext) ||
+                d.ServiceType == typeof(IDbContextOptionsConfiguration<VictoryCenterDbContext>))
             .ToList();
 
         foreach (var descriptor in descriptors)

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -208,6 +208,16 @@ public static class ServicesConfiguration
         {
             using IServiceScope localScope = app.Services.CreateScope();
             var victoryCenterDbContext = localScope.ServiceProvider.GetRequiredService<VictoryCenterDbContext>();
+
+            // Integration tests use EF Core InMemory, which does not support relational migration operations.
+            if (!victoryCenterDbContext.Database.IsRelational())
+            {
+                logger.LogInformation(
+                    "Skipping startup migrations for non-relational database provider {DatabaseProvider}",
+                    victoryCenterDbContext.Database.ProviderName);
+                return;
+            }
+
             var pendingMigrations = await victoryCenterDbContext.Database.GetPendingMigrationsAsync();
             var migrations = pendingMigrations.ToList();
 
@@ -240,6 +250,9 @@ public static class ServicesConfiguration
         catch (Exception ex)
         {
             logger.LogError(ex, "An error occurred during startup migration");
+
+            // Do not serve traffic when the application model is newer than the database schema.
+            throw;
         }
     }
 


### PR DESCRIPTION
## Root Cause Analysis

The dev database migration history was inconsistent with the migrations currently present in the repository.

The diagnostics confirmed that:

- the removed migration `20260609211541_AddLanguageIdToPdfReport` was present in `entity_framework.__EFMigrationsHistory`;
- the current migration `20260525100310_AddLanguageIdToPdfReports` was not applied;
- `media.PdfReports.LanguageId` already existed but was nullable;
- the legacy `IX_PdfReports_LanguageId` and `IX_PdfReports_Priority` indexes existed;
- the foreign key to `LocalizationLanguages` existed;
- all 3 existing PDF reports had a valid `LanguageId`;
- `dbo.Metrics.RowVersion` was missing because subsequent migrations had not been applied.

As a result, EF Core attempted to execute a migration that expected a different database state.

## Implemented Fix

The PDF report language migration now supports both valid starting states:

- a clean database where `LanguageId` does not exist;
- an existing environment where the removed migration has already created `LanguageId`.

The migration now:

- inserts the fallback `uk` language with the required `CreatedAt`;
- creates `LanguageId` only when it is missing;
- removes legacy foreign-key and index artifacts when they exist;
- backfills missing `LanguageId` values with the `uk` language;
- changes `LanguageId` to `NOT NULL`;
- creates the unique `(LanguageId, Priority)` index;
- restores the restrictive language foreign key.

Startup migration handling was also changed to fail fast. Migration exceptions are logged and rethrown, preventing the application from accepting traffic with an outdated database schema.

Non-relational providers are skipped so that integration tests can continue using EF Core InMemory.

## Local Verification

The fix was verified from scratch using three disposable SQL Server databases.

### Clean database

- all 76 current migrations were applied successfully;
- the resulting schema matched the EF Core model;
- the fallback language was created with a valid `CreatedAt`.

### Reproduced dev state

- the confirmed dev schema and migration history were reproduced locally;
- the fix was applied successfully;
- all 3 PDF report records were preserved;
- names, blob names, file sizes and priorities remained unchanged;
- the final migration history contained 77 records, including the removed migration ID.

### Nullable backfill scenario

- one PDF report was created with `LanguageId = NULL`;
- the migration assigned the `uk` language;
- `LanguageId` became `NOT NULL`;
- no data was lost.

### Idempotency

A second migration run on all three databases returned:

`No migrations were applied. The database is already up to date.`

## Attachments

- [dev database diagnostics report](https://github.com/user-attachments/files/30703217/2026-08-04-migration-diagnostics.txt)
- [migration diagnostics SQL script](https://github.com/user-attachments/files/30703220/2026-08-04-migration-diagnostics.sql)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test database configuration to prevent conflicts when using in-memory storage.
  * Prevented migration attempts for non-relational database providers.
  * Improved migration error handling so failures are logged and surfaced appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->