### PR TITLE
Feature/issue-1516 [Single program] Sync changes in 633433 and FAQ templates to Translation Page

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/HippotherapyPrograms/Update/UpdateHippotherapyProgramHandler.cs
@@ -136,9 +136,10 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 request.UpdateProgramDto.Sections,
                 now,
                 imagesByIdResult.Value,
-                out var programContentsChanged);
+                out var programContentsChanged,
+                out var contentAdded);
 
-            if (sectionAdded)
+            if (sectionAdded || contentAdded)
             {
                 MarkProgramLocalizationsOutdated(program);
             }
@@ -219,9 +220,11 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         List<CreateHippotherapyProgramSectionDto> newSections,
         DateTimeOffset now,
         IReadOnlyDictionary<long, Image> imagesById,
-        out bool anyContentChanged)
+        out bool anyContentChanged,
+        out bool anyContentAdded)
     {
         anyContentChanged = false;
+        anyContentAdded = false;
         var sectionAdded = false;
 
         var oldSectionsById = oldSections
@@ -243,7 +246,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 existingSection.Template = newSectionDto.Template;
                 existingSection.Order = newSectionDto.Order;
 
-                MergeSectionContents(existingSection, newSectionDto, now, imagesById, ref anyContentChanged);
+                MergeSectionContents(existingSection, newSectionDto, now, imagesById, ref anyContentChanged, ref anyContentAdded);
             }
             else
             {
@@ -278,7 +281,8 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
         CreateHippotherapyProgramSectionDto newSectionDto,
         DateTimeOffset now,
         IReadOnlyDictionary<long, Image> imagesById,
-        ref bool anyContentChanged)
+        ref bool anyContentChanged,
+        ref bool anyContentAdded)
     {
         var newContents = newSectionDto.Contents ?? [];
 
@@ -303,6 +307,7 @@ public class UpdateHippotherapyProgramHandler : IRequestHandler<UpdateHippothera
                 if (newContent is not null)
                 {
                     existingSection.Contents.Add(newContent);
+                    anyContentAdded = true;
                 }
             }
         }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionLocalizationProjector.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionLocalizationProjector.cs
@@ -1,0 +1,50 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Helpers;
+
+public static class ProgramSectionLocalizationProjector
+{
+    public static List<HippotherapyProgramSectionLocalizationDto> Project(
+        IEnumerable<HippotherapyProgramSection> sections,
+        long languageId,
+        LocalizationInfoDto languageInfo,
+        IMapper mapper)
+    {
+        return sections
+            .Select(section => new HippotherapyProgramSectionLocalizationDto
+            {
+                EntityId = section.Id,
+                Contents = section.Contents
+                    .Select(content => ProjectContent(content, languageId, languageInfo, mapper))
+                    .ToList(),
+            })
+            .ToList();
+    }
+
+    private static HippotherapyProgramSectionContentLocalizationDto ProjectContent(
+        ProgramSectionContent content,
+        long languageId,
+        LocalizationInfoDto languageInfo,
+        IMapper mapper)
+    {
+        var localization = content.Localizations
+            .FirstOrDefault(l => l.LanguageId == languageId);
+
+        if (localization is not null)
+        {
+            return mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization);
+        }
+
+        return new HippotherapyProgramSectionContentLocalizationDto
+        {
+            EntityId = content.Id,
+            LocalizationInfoDto = languageInfo,
+            TranslationStatus = TranslationStatus.Outdated,
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionLocalizationProjector.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/ProgramSectionLocalizationProjector.cs
@@ -15,22 +15,25 @@ public static class ProgramSectionLocalizationProjector
         LocalizationInfoDto languageInfo,
         IMapper mapper)
     {
-        return sections
-            .Select(section => new HippotherapyProgramSectionLocalizationDto
+        return
+        [
+            .. sections.Select(section => new HippotherapyProgramSectionLocalizationDto
             {
                 EntityId = section.Id,
-                Contents = section.Contents
-                    .Select(content => ProjectContent(content, languageId, languageInfo, mapper))
-                    .ToList(),
-            })
-            .ToList();
+                Contents =
+                [
+                    .. section.Contents
+                        .Select(content => ProjectContent(content, languageId, languageInfo, mapper)),
+                ],
+            }),
+        ];
     }
 
     private static HippotherapyProgramSectionContentLocalizationDto ProjectContent(
         ProgramSectionContent content,
         long languageId,
         LocalizationInfoDto languageInfo,
-        IMapper mapper)
+        IMapperBase mapper)
     {
         var localization = content.Localizations
             .FirstOrDefault(l => l.LanguageId == languageId);

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyPrograms/GetByEntityId/GetHippotherapyProgramLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyPrograms/GetByEntityId/GetHippotherapyProgramLocalizationByEntityIdHandler.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -58,28 +60,16 @@ public class GetHippotherapyProgramLocalizationByEntityIdHandler : IRequestHandl
         return Result.Ok(programLocalizations);
     }
 
-    private async Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSections(HippotherapyProgramLocalization program, long languageId)
+    private Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSections(HippotherapyProgramLocalization program, long languageId)
     {
-        if(program is null)
+        if (program is null)
         {
             throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(nameof(HippotherapyProgramLocalization), typeof(HippotherapyProgramLocalization)));
         }
 
-        var sectionLocalizations = program.Entity
-            .Sections
-            .Select(section => new HippotherapyProgramSectionLocalizationDto
-            {
-                EntityId = section.Id,
-                Contents = section.Contents
-                    .SelectMany(content =>
-                        content.Localizations
-                            .Where(localization => localization.LanguageId == languageId)
-                            .Select(localization =>
-                                _mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization)))
-                    .ToList(),
-            })
-            .ToList();
+        var languageInfo = _mapper.Map<LocalizationInfoDto>(program.Language);
 
-        return sectionLocalizations;
+        return Task.FromResult(
+            ProgramSectionLocalizationProjector.Project(program.Entity.Sections, languageId, languageInfo, _mapper));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyPrograms/GetByEntityId/GetHippotherapyProgramLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyPrograms/GetByEntityId/GetHippotherapyProgramLocalizationByEntityIdHandler.cs
@@ -7,6 +7,7 @@ using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgram;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
 using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Helpers;
+using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
@@ -43,7 +44,7 @@ public class GetHippotherapyProgramLocalizationByEntityIdHandler : IRequestHandl
         var list = new Dictionary<long, List<HippotherapyProgramSectionLocalizationDto>>();
         foreach (var program in programs)
         {
-            var sectionDto = await GetProgramSections(program, program.LanguageId);
+            var sectionDto = await GetProgramSectionsAsync(program, program.LanguageId);
             list.Add(program.LanguageId, sectionDto);
         }
 
@@ -60,7 +61,7 @@ public class GetHippotherapyProgramLocalizationByEntityIdHandler : IRequestHandl
         return Result.Ok(programLocalizations);
     }
 
-    private Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSections(HippotherapyProgramLocalization program, long languageId)
+    private Task<List<HippotherapyProgramSectionLocalizationDto>> GetProgramSectionsAsync(LocalizationBase<HippotherapyProgram> program, long languageId)
     {
         if (program is null)
         {

--- a/VictoryCenter/VictoryCenter.BLL/Services/HippotherapyPrograms/ProgramSectionContentService.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Services/HippotherapyPrograms/ProgramSectionContentService.cs
@@ -2,6 +2,8 @@ using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Helpers;
 using VictoryCenter.BLL.Interfaces.HippotherapyPrograms;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
@@ -55,7 +57,8 @@ public class ProgramSectionContentService : IProgramSectionContentService
                         .ThenInclude(entity => entity.Sections)
                         .ThenInclude(section => section.Contents)
                         .ThenInclude(content => content.Localizations)
-                        .ThenInclude(localization => localization.Language),
+                        .ThenInclude(localization => localization.Language)
+                        .Include(entity => entity.Language),
                 });
 
         if (program is null)
@@ -63,21 +66,8 @@ public class ProgramSectionContentService : IProgramSectionContentService
             throw new KeyNotFoundException(ErrorMessagesConstants.NotFound(programId, typeof(HippotherapyProgram)));
         }
 
-        var sectionLocalizations = program.Entity
-            .Sections
-            .Select(section => new HippotherapyProgramSectionLocalizationDto
-            {
-                EntityId = section.Id,
-                Contents = section.Contents
-                    .SelectMany(content =>
-                        content.Localizations
-                            .Where(localization => localization.LanguageId == languageId)
-                            .Select(localization =>
-                                _mapper.Map<HippotherapyProgramSectionContentLocalizationDto>(localization)))
-                    .ToList(),
-            })
-            .ToList();
+        var languageInfo = _mapper.Map<LocalizationInfoDto>(program.Language);
 
-        return sectionLocalizations;
+        return ProgramSectionLocalizationProjector.Project(program.Entity.Sections, languageId, languageInfo, _mapper);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -499,6 +499,109 @@ public class UpdateHippotherapyProgramTests
     }
 
     [Fact]
+    public async Task Handle_NewContentAddedToExistingSection_MarksProgramLocalizationsOutdatedWithoutTouchingExistingContent()
+    {
+        var existingContent = new TitleProgramContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Same title",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection
+        {
+            Id = 1,
+            Template = default,
+            Order = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [existingContent]
+        };
+
+        var program = Program(sections: [section]);
+        program.Localizations =
+        [
+            ProgramLocalization(1, TranslationStatus.Relevant),
+            ProgramLocalization(2, TranslationStatus.Relevant)
+        ];
+
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        var sectionWithNewContent = CreateSection(
+            0,
+            CreateTitleContent(0, "Same title", id: 1),
+            id: 1);
+        sectionWithNewContent.Contents!.Add(CreateDescriptionContent(1, "New pair description"));
+
+        var dto = Dto(
+            name: program.Name,
+            description: program.Description,
+            sections: [sectionWithNewContent]);
+        dto.Location = program.Location;
+        dto.ParticipantsCount = program.ParticipantsCount;
+        dto.MeetingsCount = program.MeetingsCount;
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.Equal(2, program.Sections.Single().Contents.Count);
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
+        Assert.Same(existingContent, program.Sections.Single().Contents.Single(c => c.Id == 1));
+        Assert.All(existingContent.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+    }
+
+    [Fact]
+    public async Task Handle_ContentRemovedFromExistingSection_DoesNotChangeProgramLocalizationsStatus()
+    {
+        var keptContent = new TitleProgramContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 0,
+            Title = "Kept title",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var removedContent = new DescriptionProgramContent
+        {
+            Id = 2,
+            ContentType = ContentType.Description,
+            Order = 1,
+            Description = "Removed description",
+            Localizations = [ContentLocalization(1, TranslationStatus.Relevant)]
+        };
+        var section = new HippotherapyProgramSection
+        {
+            Id = 1,
+            Template = default,
+            Order = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Contents = [keptContent, removedContent]
+        };
+
+        var program = Program(sections: [section]);
+        program.Localizations =
+        [
+            ProgramLocalization(1, TranslationStatus.Relevant),
+            ProgramLocalization(2, TranslationStatus.Relevant)
+        ];
+
+        var sut = CreateSut(program: program, saveChanges: 1);
+
+        var dto = Dto(
+            name: program.Name,
+            description: program.Description,
+            sections: [CreateSection(0, CreateTitleContent(0, "Kept title", id: 1), id: 1)]);
+        dto.Location = program.Location;
+        dto.ParticipantsCount = program.ParticipantsCount;
+        dto.MeetingsCount = program.MeetingsCount;
+
+        await sut.Handle(Command(id: 1, dto: dto), CancellationToken.None);
+
+        Assert.Single(program.Sections.Single().Contents);
+        Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+        Assert.All(keptContent.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+    }
+
+    [Fact]
     public async Task Handle_SameStructureAndChangedDescription_MarksContentLocalizationsOutdated()
     {
         var content = new DescriptionProgramContent

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/HippotherapyPrograms/UpdateHippotherapyProgramTests.cs
@@ -547,6 +547,11 @@ public class UpdateHippotherapyProgramTests
         Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Outdated, l.TranslationStatus));
         Assert.Same(existingContent, program.Sections.Single().Contents.Single(c => c.Id == 1));
         Assert.All(existingContent.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+
+        var addedContent = Assert.IsType<DescriptionProgramContent>(
+            program.Sections.Single().Contents.Single(c => c.Id != 1));
+        Assert.Equal("New pair description", addedContent.Description);
+        Assert.Equal(1, addedContent.Order);
     }
 
     [Fact]
@@ -599,6 +604,8 @@ public class UpdateHippotherapyProgramTests
         Assert.Single(program.Sections.Single().Contents);
         Assert.All(program.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
         Assert.All(keptContent.Localizations, l => Assert.Equal(TranslationStatus.Relevant, l.TranslationStatus));
+        Assert.Equal(0, program.Sections.Single().Contents.Single().Order);
+        Assert.Same(keptContent, program.Sections.Single().Contents.Single());
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/GetHippotherapyProgramLocalizationsByEntityIdHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/GetHippotherapyProgramLocalizationsByEntityIdHandlerTests.cs
@@ -7,6 +7,7 @@ using VictoryCenter.BLL.Queries.Admin.Localization.HippotherapyPrograms.GetByEnt
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
 using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 
@@ -97,6 +98,74 @@ public class GetHippotherapyProgramLocalizationsByEntityIdHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ShouldIncludeEmptyOutdatedPlaceholder_ForContentWithoutLocalization()
+    {
+        var translatedContent = new TitleProgramContent
+        {
+            Id = 1,
+            Localizations = new List<ProgramSectionContentLocalization>
+            {
+                new()
+                {
+                    EntityId = 1,
+                    LanguageId = 1,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    Title = "Content 1",
+                    Language = new LocalizationLanguage { Id = 1, Name = "English", Code = "en" }
+                }
+            }
+        };
+        var newlyAddedContent = new DescriptionProgramContent
+        {
+            Id = 2,
+            Localizations = new List<ProgramSectionContentLocalization>()
+        };
+
+        var localizations = new List<HippotherapyProgramLocalization>
+        {
+            new()
+            {
+                EntityId = 1,
+                LanguageId = 1,
+                Name = "Program 1",
+                Description = "Description 1",
+                CreatedAt = DateTimeOffset.UtcNow,
+                Language = new LocalizationLanguage { Id = 1, Name = "English", Code = "en" },
+                Entity = new HippotherapyProgram
+                {
+                    Id = 1,
+                    Sections = new List<HippotherapyProgramSection>
+                    {
+                        new()
+                        {
+                            Id = 1,
+                            Contents = new List<ProgramSectionContent> { translatedContent, newlyAddedContent }
+                        }
+                    }
+                }
+            }
+        };
+
+        SetupRepositoryWrapper(localizations);
+        SetupMapper(_dtos);
+
+        var handler = new GetHippotherapyProgramLocalizationByEntityIdHandler(_mockRepositoryWrapper.Object, _mockMapper.Object);
+
+        var result = await handler.Handle(new GetHippotherapyProgramLocalizationByEntityIdQuery(1), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var contents = Assert.Single(result.Value.First().Sections).Contents;
+        Assert.Equal(2, contents.Count);
+
+        var placeholder = Assert.Single(contents, c => c.EntityId == 2);
+        Assert.Equal(TranslationStatus.Outdated, placeholder.TranslationStatus);
+        Assert.Null(placeholder.Title);
+        Assert.Null(placeholder.Description);
+        Assert.Equal(1, placeholder.LocalizationInfoDto.Id);
+        Assert.Equal("en", placeholder.LocalizationInfoDto.Code);
+    }
+
+    [Fact]
     public async Task Handle_ShouldReturnEmpty_WhenNoLocalizationsFound()
     {
         SetupRepositoryWrapper(new List<HippotherapyProgramLocalization>());
@@ -132,5 +201,9 @@ public class GetHippotherapyProgramLocalizationsByEntityIdHandlerTests
                 Title = "Content 1",
                 Description = "Content Description 1"
             });
+
+        _mockMapper.Setup(mapper =>
+                mapper.Map<LocalizationInfoDto>(It.IsAny<LocalizationLanguage>()))
+            .Returns((LocalizationLanguage src) => new LocalizationInfoDto { Id = src.Id, Code = src.Code });
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/GetHippotherapyProgramLocalizationsByEntityIdHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyPrograms/GetHippotherapyProgramLocalizationsByEntityIdHandlerTests.cs
@@ -103,8 +103,8 @@ public class GetHippotherapyProgramLocalizationsByEntityIdHandlerTests
         var translatedContent = new TitleProgramContent
         {
             Id = 1,
-            Localizations = new List<ProgramSectionContentLocalization>
-            {
+            Localizations =
+            [
                 new()
                 {
                     EntityId = 1,
@@ -113,12 +113,13 @@ public class GetHippotherapyProgramLocalizationsByEntityIdHandlerTests
                     Title = "Content 1",
                     Language = new LocalizationLanguage { Id = 1, Name = "English", Code = "en" }
                 }
-            }
+
+            ]
         };
         var newlyAddedContent = new DescriptionProgramContent
         {
             Id = 2,
-            Localizations = new List<ProgramSectionContentLocalization>()
+            Localizations = []
         };
 
         var localizations = new List<HippotherapyProgramLocalization>
@@ -134,14 +135,15 @@ public class GetHippotherapyProgramLocalizationsByEntityIdHandlerTests
                 Entity = new HippotherapyProgram
                 {
                     Id = 1,
-                    Sections = new List<HippotherapyProgramSection>
-                    {
+                    Sections =
+                    [
                         new()
                         {
                             Id = 1,
-                            Contents = new List<ProgramSectionContent> { translatedContent, newlyAddedContent }
+                            Contents = [translatedContent, newlyAddedContent]
                         }
-                    }
+
+                    ]
                 }
             }
         };

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 using Moq;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramSection;
+using VictoryCenter.BLL.DTOs.Common;
 using VictoryCenter.BLL.Services.HippotherapyPrograms;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.HippotherapyProgramContents;
@@ -368,6 +369,7 @@ public class ProgramSectionContentServiceTests
         {
             EntityId = 1,
             LanguageId = 1,
+            Language = new LocalizationLanguage { Id = 1, Code = "en", Name = "English" },
             Entity = new HippotherapyProgram
             {
                 Id = 1,
@@ -402,6 +404,97 @@ public class ProgramSectionContentServiceTests
         _repositoryWrapperMock.Verify(
             x => x.HippotherapyProgramsLocalizationsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramLocalization>>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task GetProgramSectionsAsync_ShouldReturnEmptyOutdatedPlaceholder_WhenContentHasNoLocalizationForLanguage()
+    {
+        var translatedContent = new TestProgramSectionContent
+        {
+            Id = 1,
+            ContentType = ContentType.Title,
+            Order = 0,
+            SectionId = 10,
+            Localizations = new List<ProgramSectionContentLocalization>
+            {
+                new()
+                {
+                    EntityId = 1,
+                    LanguageId = 1,
+                    Title = "Translated title",
+                    TranslationStatus = TranslationStatus.Relevant
+                }
+            }
+        };
+
+        var newlyAddedContent = new TestProgramSectionContent
+        {
+            Id = 2,
+            ContentType = ContentType.Description,
+            Order = 1,
+            SectionId = 10,
+            Localizations = new List<ProgramSectionContentLocalization>()
+        };
+
+        var section = new HippotherapyProgramSection
+        {
+            Id = 10,
+            ProgramId = 1,
+            Template = ProgramSectionTemplate.TextOnly,
+            Order = 1,
+            Contents = new List<ProgramSectionContent> { translatedContent, newlyAddedContent }
+        };
+
+        var programLocalization = new HippotherapyProgramLocalization
+        {
+            EntityId = 1,
+            LanguageId = 1,
+            Language = new LocalizationLanguage { Id = 1, Code = "en", Name = "English" },
+            Entity = new HippotherapyProgram
+            {
+                Id = 1,
+                Name = "Test Program",
+                Slug = "test-program",
+                Status = Status.Published,
+                Sections = new List<HippotherapyProgramSection> { section }
+            }
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.HippotherapyProgramsLocalizationsRepository.GetFirstOrDefaultAsync(It.IsAny<QueryOptions<HippotherapyProgramLocalization>>()))
+            .ReturnsAsync(programLocalization);
+
+        _mapperMock
+            .Setup(x => x.Map<HippotherapyProgramSectionContentLocalizationDto>(It.IsAny<ProgramSectionContentLocalization>()))
+            .Returns((ProgramSectionContentLocalization src) => new HippotherapyProgramSectionContentLocalizationDto
+            {
+                EntityId = src.EntityId,
+                Title = src.Title,
+                TranslationStatus = src.TranslationStatus
+            });
+
+        _mapperMock
+            .Setup(x => x.Map<LocalizationInfoDto>(It.IsAny<LocalizationLanguage>()))
+            .Returns((LocalizationLanguage src) => new LocalizationInfoDto { Id = src.Id, Code = src.Code });
+
+        var result = await _service.GetProgramSectionsAsync(1, 1);
+
+        var contents = Assert.Single(result).Contents;
+        Assert.Equal(2, contents.Count);
+
+        var translatedDto = Assert.Single(contents, c => c.EntityId == 1);
+        Assert.Equal("Translated title", translatedDto.Title);
+        Assert.Equal(TranslationStatus.Relevant, translatedDto.TranslationStatus);
+
+        var placeholderDto = Assert.Single(contents, c => c.EntityId == 2);
+        Assert.Equal(TranslationStatus.Outdated, placeholderDto.TranslationStatus);
+        Assert.Null(placeholderDto.Title);
+        Assert.Null(placeholderDto.Description);
+        Assert.Null(placeholderDto.Author);
+        Assert.Null(placeholderDto.Question);
+        Assert.Null(placeholderDto.Answer);
+        Assert.Equal(1, placeholderDto.LocalizationInfoDto.Id);
+        Assert.Equal("en", placeholderDto.LocalizationInfoDto.Code);
     }
 
     private static ProgramSectionContent CreateTestContent(long id, ContentType contentType)

--- a/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ServiceTests/ProgramSectionContentServiceTests.cs
@@ -415,8 +415,8 @@ public class ProgramSectionContentServiceTests
             ContentType = ContentType.Title,
             Order = 0,
             SectionId = 10,
-            Localizations = new List<ProgramSectionContentLocalization>
-            {
+            Localizations =
+            [
                 new()
                 {
                     EntityId = 1,
@@ -424,7 +424,8 @@ public class ProgramSectionContentServiceTests
                     Title = "Translated title",
                     TranslationStatus = TranslationStatus.Relevant
                 }
-            }
+
+            ]
         };
 
         var newlyAddedContent = new TestProgramSectionContent
@@ -433,7 +434,7 @@ public class ProgramSectionContentServiceTests
             ContentType = ContentType.Description,
             Order = 1,
             SectionId = 10,
-            Localizations = new List<ProgramSectionContentLocalization>()
+            Localizations = []
         };
 
         var section = new HippotherapyProgramSection
@@ -442,7 +443,7 @@ public class ProgramSectionContentServiceTests
             ProgramId = 1,
             Template = ProgramSectionTemplate.TextOnly,
             Order = 1,
-            Contents = new List<ProgramSectionContent> { translatedContent, newlyAddedContent }
+            Contents = [translatedContent, newlyAddedContent]
         };
 
         var programLocalization = new HippotherapyProgramLocalization
@@ -456,7 +457,7 @@ public class ProgramSectionContentServiceTests
                 Name = "Test Program",
                 Slug = "test-program",
                 Status = Status.Published,
-                Sections = new List<HippotherapyProgramSection> { section }
+                Sections = [section]
             }
         };
 


### PR DESCRIPTION
dev
## JIRA

* [#1516](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1516)

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

Adding a new block/pair (e.g. a Description+Author pair in the `SingleTitleDescriptionAuthorPairs` template, or a new Q&A pair in the FAQ template) to a section that already existed and was already fully translated did not flag the translation as outdated. `MergeSectionContents` correctly diffed content by stable `Id` (fixed in #1510), but for a genuinely new content item (no matching `Id`) it only added the entity to `existingSection.Contents` — it never set `anyContentChanged`, which is scoped to *matched* content whose field values changed. `MergeSections` only returned `sectionAdded` for a brand-new *section*, not for new content inside an already-matched section. As a result, neither signal reached `Handle`, `MarkProgramLocalizationsOutdated` was never called, and the EN indicator stayed green even though the new block had no translation yet — contradicting the requirement that adding a block/pair to templates 633433/FAQ should mark the page for review.

## Summary of change

- **`UpdateHippotherapyProgramHandler`:** added a new `anyContentAdded` signal, threaded through `MergeSectionContents` (`ref bool anyContentAdded`, set `true` when a genuinely new content item is added to an existing section) → `MergeSections` (new `out bool anyContentAdded`) → `Handle` (`if (sectionAdded || contentAdded) { MarkProgramLocalizationsOutdated(program); }`). The existing `anyContentChanged`/`programContentsChanged` path (broad `SerTranslationsToOutdated` for edited text on already-matched content) is untouched — the new signal only drives the narrow, top-level-only marking, consistent with how `sectionAdded` already worked.
- **Unit Test Coverage:** added `Handle_NewContentAddedToExistingSection_MarksProgramLocalizationsOutdatedWithoutTouchingExistingContent` (new block in an existing, already-translated section now flags the top-level `HippotherapyProgramLocalization` as `Outdated` without touching the existing content's own translation status) and `Handle_ContentRemovedFromExistingSection_DoesNotChangeProgramLocalizationsStatus` (deleting a block leaves the indicator as-is, per AC "keep the translation indicator applied before deletion blocks/pairs").

## Testing approach

- Full backend unit test suite: `2276/2276` passed (`dotnet vstest VictoryCenter.UnitTests`).
- Manual end-to-end verification: ran the backend (`VictoryCenter.WebAPI`, `Local` profile) and the frontend (`npm start`) locally against each other. Added a new pair to an existing, fully-translated section on a UA program and confirmed the EN indicator turned orange without resetting the rest of the translation; opened "Редагувати переклад" and confirmed the new pair appeared with the UA-mirrored structure and empty fields; filled in and saved its translation and confirmed the indicator turned green again; deleted a pair and confirmed the indicator did not change.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adding content to an existing hippotherapy program section now correctly marks program localizations as outdated.
  - Adding sections continues to trigger localization updates, while existing content retains its identity and localization status.
  - Removing content no longer changes the localization status of the program or its remaining content.
  - Missing translations now display as empty, outdated placeholders with the correct language information.

- **Tests**
  - Added coverage for localization behavior when content is added, removed, or untranslated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->