### PR TITLE
Implement admin get event/news api

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsCategoryShortDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsCategoryShortDto.cs
@@ -1,7 +1,10 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.EventNewsCategories;
+
 namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
 
 public record EventNewsCategoryShortDto
 {
     public long Id { get; init; }
     public string Name { get; init; } = null!;
+    public List<AdminEventNewsCategoryLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsFilterDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/EventNewsFilterDto.cs
@@ -1,0 +1,8 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record EventNewsFilterDto
+{
+    public int? Offset { get; init; }
+    public int? Limit { get; init; }
+    public long? CategoryId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetByFilters/GetEventNewsByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetByFilters/GetEventNewsByFiltersHandler.cs
@@ -14,6 +14,8 @@ namespace VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
 public class GetEventNewsByFiltersHandler
     : IRequestHandler<GetEventNewsByFiltersQuery, Result<PaginationResult<EventNewsDto>>>
 {
+    private const int DefaultLimit = 20;
+
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
 
@@ -44,7 +46,7 @@ public class GetEventNewsByFiltersHandler
                 .Include(entity => entity.Localizations)
                     .ThenInclude(localization => localization.Language),
             Offset = request.Filter.Offset ?? 0,
-            Limit = request.Filter.Limit ?? 0,
+            Limit = request.Filter.Limit ?? DefaultLimit,
             OrderByDESC = eventNews => eventNews.Id,
             AsNoTracking = true
         };

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetByFilters/GetEventNewsByFiltersHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetByFilters/GetEventNewsByFiltersHandler.cs
@@ -1,0 +1,64 @@
+using System.Linq.Expressions;
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
+
+public class GetEventNewsByFiltersHandler
+    : IRequestHandler<GetEventNewsByFiltersQuery, Result<PaginationResult<EventNewsDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetEventNewsByFiltersHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<PaginationResult<EventNewsDto>>> Handle(
+        GetEventNewsByFiltersQuery request,
+        CancellationToken cancellationToken)
+    {
+        var categoryId = request.Filter.CategoryId;
+        Expression<Func<EventNewsEntity, bool>> filter = eventNews =>
+            !categoryId.HasValue || eventNews.Categories.Any(category => category.Id == categoryId.Value);
+
+        var queryOptions = new QueryOptions<EventNewsEntity>
+        {
+            Filter = filter,
+            Include = eventNews => eventNews
+                .AsSplitQuery()
+                .Include(entity => entity.PreviewImage)
+                .Include(entity => entity.BackgroundImage)
+                .Include(entity => entity.Categories)
+                    .ThenInclude(category => category.Localizations)
+                        .ThenInclude(localization => localization.Language)
+                .Include(entity => entity.Localizations)
+                    .ThenInclude(localization => localization.Language),
+            Offset = request.Filter.Offset ?? 0,
+            Limit = request.Filter.Limit ?? 0,
+            OrderByDESC = eventNews => eventNews.Id,
+            AsNoTracking = true
+        };
+
+        var eventNews = await _repositoryWrapper.EventNewsRepository.GetAllAsync(queryOptions);
+        var totalCount = await _repositoryWrapper.EventNewsRepository.CountAsync(
+            new QueryOptions<EventNewsEntity>
+            {
+                Filter = filter,
+                AsNoTracking = true
+            });
+
+        var items = _mapper.Map<EventNewsDto[]>(eventNews);
+
+        return Result.Ok(new PaginationResult<EventNewsDto>(items, totalCount));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetByFilters/GetEventNewsByFiltersQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetByFilters/GetEventNewsByFiltersQuery.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using VictoryCenter.BLL.Behaviors.Abstractions;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.DTOs.Common;
+
+namespace VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
+
+public record GetEventNewsByFiltersQuery(EventNewsFilterDto Filter)
+    : IValidatableRequest<Result<PaginationResult<EventNewsDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetById/GetEventNewsByIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetById/GetEventNewsByIdHandler.cs
@@ -1,0 +1,48 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.BLL.Queries.Admin.EventNews.GetById;
+
+public class GetEventNewsByIdHandler : IRequestHandler<GetEventNewsByIdQuery, Result<EventNewsDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetEventNewsByIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<EventNewsDto>> Handle(
+        GetEventNewsByIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var eventNews = await _repositoryWrapper.EventNewsRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<EventNewsEntity>
+            {
+                Filter = entity => entity.Id == request.Id,
+                Include = entity => entity
+                    .AsSplitQuery()
+                    .Include(item => item.PreviewImage)
+                    .Include(item => item.BackgroundImage)
+                    .Include(item => item.Categories)
+                        .ThenInclude(category => category.Localizations)
+                            .ThenInclude(localization => localization.Language)
+                    .Include(item => item.Localizations)
+                        .ThenInclude(localization => localization.Language),
+                AsNoTracking = true
+            });
+
+        return eventNews is null
+            ? Result.Fail<EventNewsDto>(ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)))
+            : Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetById/GetEventNewsByIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/EventNews/GetById/GetEventNewsByIdQuery.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+namespace VictoryCenter.BLL.Queries.Admin.EventNews.GetById;
+
+public record GetEventNewsByIdQuery(long Id) : IRequest<Result<EventNewsDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/GetEventNewsByFiltersQueryValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/GetEventNewsByFiltersQueryValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
+
+namespace VictoryCenter.BLL.Validators.EventNews;
+
+public class GetEventNewsByFiltersQueryValidator : AbstractValidator<GetEventNewsByFiltersQuery>
+{
+    public GetEventNewsByFiltersQueryValidator()
+    {
+        RuleFor(query => query.Filter.Offset)
+            .GreaterThanOrEqualTo(0)
+            .When(query => query.Filter.Offset.HasValue)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN("Offset", 0));
+
+        RuleFor(query => query.Filter.Limit)
+            .GreaterThan(0)
+            .When(query => query.Filter.Limit.HasValue)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan("Limit", 0));
+
+        RuleFor(query => query.Filter.CategoryId)
+            .GreaterThan(0)
+            .When(query => query.Filter.CategoryId.HasValue)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive("CategoryId"));
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/GetAdmin/GetAdminEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/GetAdmin/GetAdminEventNewsTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Http.Json;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.DTOs.Admin.Localization.EventNewsCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.EventNews.GetAdmin;
+
+public class GetAdminEventNewsTests : BaseTestClass
+{
+    private const string EndpointUri = "/api/EventNews";
+
+    public GetAdminEventNewsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetByFilters_ShouldReturnItemsAndTotalCountInDeterministicOrder()
+    {
+        var response = await Fixture.HttpClient.GetAsync(EndpointUri);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PaginationResult<EventNewsDto>>();
+        Assert.NotNull(page);
+        Assert.NotEmpty(page.Items);
+        Assert.True(page.TotalItemsCount >= page.Items.Length);
+        Assert.Equal(
+            page.Items.Select(item => item.Id).OrderByDescending(id => id),
+            page.Items.Select(item => item.Id));
+    }
+
+    [Fact]
+    public async Task GetByFilters_ShouldApplyOffsetAndLimit()
+    {
+        var allItems = await Fixture.HttpClient.GetFromJsonAsync<PaginationResult<EventNewsDto>>(EndpointUri);
+
+        var response = await Fixture.HttpClient.GetAsync($"{EndpointUri}?offset=1&limit=2");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PaginationResult<EventNewsDto>>();
+        Assert.NotNull(allItems);
+        Assert.NotNull(page);
+        Assert.Equal(2, page.Items.Length);
+        Assert.Equal(allItems.TotalItemsCount, page.TotalItemsCount);
+        Assert.Equal(allItems.Items.Skip(1).Take(2).Select(item => item.Id), page.Items.Select(item => item.Id));
+    }
+
+    [Fact]
+    public async Task GetByFilters_ShouldFilterByAssignedCategory()
+    {
+        var allItems = await Fixture.HttpClient.GetFromJsonAsync<PaginationResult<EventNewsDto>>(EndpointUri);
+        var categoryId = allItems!.Items.SelectMany(item => item.Categories).First().Id;
+
+        var response = await Fixture.HttpClient.GetAsync($"{EndpointUri}?categoryId={categoryId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PaginationResult<EventNewsDto>>();
+        Assert.NotNull(page);
+        Assert.NotEmpty(page.Items);
+        Assert.Equal(page.Items.Length, page.TotalItemsCount);
+        Assert.All(page.Items, item => Assert.Contains(item.Categories, category => category.Id == categoryId));
+    }
+
+    [Fact]
+    public async Task GetByFilters_WhenNoItemsMatch_ShouldReturnEmptyPage()
+    {
+        var response = await Fixture.HttpClient.GetAsync($"{EndpointUri}?categoryId={long.MaxValue}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PaginationResult<EventNewsDto>>();
+        Assert.NotNull(page);
+        Assert.Empty(page.Items);
+        Assert.Equal(0, page.TotalItemsCount);
+    }
+
+    [Theory]
+    [InlineData("offset=-1")]
+    [InlineData("limit=0")]
+    [InlineData("categoryId=0")]
+    public async Task GetByFilters_WhenFilterIsInvalid_ShouldReturnBadRequest(string query)
+    {
+        var response = await Fixture.HttpClient.GetAsync($"{EndpointUri}?{query}");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnCompleteEventNewsData()
+    {
+        const long categoryId = 1;
+        const long languageId = 1;
+        var categoryLocalizationResponse = await Fixture.HttpClient.PostAsJsonAsync(
+            "/api/EventNewsCategoryLocalizations",
+            new CreateEventNewsCategoryLocalizationDto
+            {
+                EntityId = categoryId,
+                LanguageId = languageId,
+                Name = "Localized category"
+            });
+        categoryLocalizationResponse.EnsureSuccessStatusCode();
+
+        var createResponse = await Fixture.HttpClient.PostAsJsonAsync(
+            EndpointUri,
+            new CreateEventNewsDto
+            {
+                Resource = "https://example.com/admin-event",
+                PublishedAt = DateTimeOffset.UtcNow,
+                Status = Status.Published,
+                PreviewImageId = 1,
+                BackgroundImageId = 2,
+                CategoryIds = [categoryId],
+                Localizations =
+                [
+                    new CreateEventNewsLocalizationDto
+                    {
+                        LanguageId = languageId,
+                        Title = "Admin event title",
+                        Description = "Admin event description"
+                    },
+                ]
+            });
+        createResponse.EnsureSuccessStatusCode();
+        var created = await createResponse.Content.ReadFromJsonAsync<EventNewsDto>();
+
+        var response = await Fixture.HttpClient.GetAsync($"{EndpointUri}/{created!.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var eventNews = await response.Content.ReadFromJsonAsync<EventNewsDto>();
+        Assert.NotNull(eventNews);
+        Assert.Equal(created.Id, eventNews.Id);
+        Assert.NotNull(eventNews.Slug);
+        Assert.Equal("https://example.com/admin-event", eventNews.Resource);
+        Assert.Equal(Status.Published, eventNews.Status);
+        Assert.NotNull(eventNews.PreviewImage);
+        Assert.Equal(1, eventNews.PreviewImage.Id);
+        Assert.NotNull(eventNews.BackgroundImage);
+        Assert.Equal(2, eventNews.BackgroundImage.Id);
+
+        var category = Assert.Single(eventNews.Categories);
+        Assert.Equal(categoryId, category.Id);
+        var categoryLocalization = Assert.Single(category.Localizations);
+        Assert.Equal(languageId, categoryLocalization.Language.Id);
+        Assert.Equal("Localized category", categoryLocalization.Name);
+
+        var localization = Assert.Single(eventNews.Localizations);
+        Assert.Equal(languageId, localization.Language.Id);
+        Assert.Equal("Admin event title", localization.Title);
+        Assert.Equal("Admin event description", localization.Description);
+        Assert.Equal(TranslationStatus.Relevant, localization.TranslationStatus);
+    }
+
+    [Fact]
+    public async Task GetById_WhenItemDoesNotExist_ShouldReturnNotFound()
+    {
+        var response = await Fixture.HttpClient.GetAsync($"{EndpointUri}/{long.MaxValue}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/api/EventNews")]
+    [InlineData("/api/EventNews/1")]
+    public async Task GetEndpoints_ShouldRequireAuthorization(string endpoint)
+    {
+        using var anonymousClient = Fixture.Factory.CreateClient();
+
+        var response = await anonymousClient.GetAsync(endpoint);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/GetAdmin/GetAdminEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/GetAdmin/GetAdminEventNewsTests.cs
@@ -78,7 +78,7 @@ public class GetAdminEventNewsTests : BaseTestClass
         var page = await response.Content.ReadFromJsonAsync<PaginationResult<EventNewsDto>>();
         Assert.NotNull(page);
         Assert.NotEmpty(page.Items);
-        Assert.Equal(page.Items.Length, page.TotalItemsCount);
+        Assert.True(page.TotalItemsCount >= page.Items.Length);
         Assert.All(page.Items, item => Assert.Contains(item.Categories, category => category.Id == categoryId));
     }
 

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/GetAdmin/GetAdminEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/GetAdmin/GetAdminEventNewsTests.cs
@@ -50,6 +50,23 @@ public class GetAdminEventNewsTests : BaseTestClass
     }
 
     [Fact]
+    public async Task GetByFilters_WhenOffsetExceedsTotalCount_ShouldReturnEmptyPage()
+    {
+        var allItems = await Fixture.HttpClient.GetFromJsonAsync<PaginationResult<EventNewsDto>>(EndpointUri);
+        Assert.NotNull(allItems);
+        var offsetBeyondLastItem = allItems.TotalItemsCount + 1;
+
+        var response = await Fixture.HttpClient.GetAsync(
+            $"{EndpointUri}?offset={offsetBeyondLastItem}&limit=1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var page = await response.Content.ReadFromJsonAsync<PaginationResult<EventNewsDto>>();
+        Assert.NotNull(page);
+        Assert.Empty(page.Items);
+        Assert.Equal(allItems.TotalItemsCount, page.TotalItemsCount);
+    }
+
+    [Fact]
     public async Task GetByFilters_ShouldFilterByAssignedCategory()
     {
         var allItems = await Fixture.HttpClient.GetFromJsonAsync<PaginationResult<EventNewsDto>>(EndpointUri);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/GetAdminEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/GetAdminEventNewsTests.cs
@@ -122,6 +122,33 @@ public class GetAdminEventNewsTests
     }
 
     [Fact]
+    public async Task GetByFilters_WhenPaginationIsNotSpecified_AppliesDefaults()
+    {
+        QueryOptions<EventNewsEntity>? listOptions = null;
+
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetAllAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .Callback<QueryOptions<EventNewsEntity>>(options => listOptions = options)
+            .ReturnsAsync([]);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.CountAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .ReturnsAsync(0);
+        _mapper.Setup(mapper => mapper.Map<EventNewsDto[]>(It.IsAny<IEnumerable<EventNewsEntity>>()))
+            .Returns([]);
+
+        var handler = new GetEventNewsByFiltersHandler(_mapper.Object, _repositoryWrapper.Object);
+
+        var result = await handler.Handle(
+            new GetEventNewsByFiltersQuery(new EventNewsFilterDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(listOptions);
+        Assert.Equal(0, listOptions.Offset);
+        Assert.Equal(20, listOptions.Limit);
+    }
+
+    [Fact]
     public async Task GetByFilters_AppliesCategoryFilterToListAndCountQueries()
     {
         var matchingCategory = new EventNewsCategory { Id = 5, Name = "Events" };

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/GetAdminEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/GetAdminEventNewsTests.cs
@@ -1,0 +1,228 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Mapping.EventNews;
+using VictoryCenter.BLL.Mapping.EventNewsCategories;
+using VictoryCenter.BLL.Mapping.Localization.Languages;
+using VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
+using VictoryCenter.BLL.Queries.Admin.EventNews.GetById;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNews;
+
+public class GetAdminEventNewsTests
+{
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapper = new();
+
+    [Fact]
+    public void Mapping_MapsEventAndCategoryLocalizationsWithLanguages()
+    {
+        var language = new LocalizationLanguage { Id = 1, Code = "uk", Name = "Ukrainian" };
+        var entity = new EventNewsEntity
+        {
+            Id = 10,
+            Categories =
+            [
+                new EventNewsCategory
+                {
+                    Id = 2,
+                    Name = "Events",
+                    Localizations =
+                    [
+                        new EventNewsCategoryLocalization
+                        {
+                            EntityId = 2,
+                            LanguageId = language.Id,
+                            Language = language,
+                            Name = "Localized events",
+                            TranslationStatus = TranslationStatus.Relevant
+                        },
+                    ]
+                },
+            ],
+            Localizations =
+            [
+                new EventNewsLocalization
+                {
+                    EntityId = 10,
+                    LanguageId = language.Id,
+                    Language = language,
+                    Title = "Event title",
+                    Description = "Event description",
+                    TranslationStatus = TranslationStatus.Outdated
+                },
+            ]
+        };
+        var configuration = new MapperConfiguration(config =>
+        {
+            config.AddProfile<EventNewsProfile>();
+            config.AddProfile<EventNewsCategoryProfile>();
+            config.AddProfile<LocalizationsLanguageProfile>();
+        });
+        var mapper = configuration.CreateMapper();
+
+        var result = mapper.Map<EventNewsDto>(entity);
+
+        var category = Assert.Single(result.Categories);
+        var categoryLocalization = Assert.Single(category.Localizations);
+        Assert.Equal("Localized events", categoryLocalization.Name);
+        Assert.Equal("uk", categoryLocalization.Language.Code);
+        var eventLocalization = Assert.Single(result.Localizations);
+        Assert.Equal("Event title", eventLocalization.Title);
+        Assert.Equal("uk", eventLocalization.Language.Code);
+        Assert.Equal(TranslationStatus.Outdated, eventLocalization.TranslationStatus);
+    }
+
+    [Fact]
+    public async Task GetByFilters_ReturnsMappedPageAndMatchingTotalCount()
+    {
+        var entities = new[] { new EventNewsEntity { Id = 3 }, new EventNewsEntity { Id = 2 } };
+        var mappedItems = new[] { new EventNewsDto { Id = 3 }, new EventNewsDto { Id = 2 } };
+        QueryOptions<EventNewsEntity>? listOptions = null;
+        QueryOptions<EventNewsEntity>? countOptions = null;
+
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetAllAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .Callback<QueryOptions<EventNewsEntity>>(options => listOptions = options)
+            .ReturnsAsync(entities);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.CountAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .Callback<QueryOptions<EventNewsEntity>>(options => countOptions = options)
+            .ReturnsAsync(7);
+        _mapper.Setup(mapper => mapper.Map<EventNewsDto[]>(entities)).Returns(mappedItems);
+
+        var handler = new GetEventNewsByFiltersHandler(_mapper.Object, _repositoryWrapper.Object);
+        var result = await handler.Handle(
+            new GetEventNewsByFiltersQuery(new EventNewsFilterDto { Offset = 1, Limit = 2 }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(mappedItems, result.Value.Items);
+        Assert.Equal(7, result.Value.TotalItemsCount);
+        Assert.NotNull(listOptions);
+        Assert.Equal(1, listOptions.Offset);
+        Assert.Equal(2, listOptions.Limit);
+        Assert.True(listOptions.AsNoTracking);
+        Assert.NotNull(listOptions.Include);
+        Assert.NotNull(listOptions.OrderByDESC);
+        Assert.Equal(3L, Assert.IsType<long>(listOptions.OrderByDESC.Compile()(entities[0])));
+        Assert.NotNull(countOptions);
+        Assert.True(countOptions.AsNoTracking);
+        Assert.Equal(0, countOptions.Offset);
+        Assert.Equal(0, countOptions.Limit);
+        Assert.Null(countOptions.Include);
+        Assert.Null(countOptions.OrderByDESC);
+    }
+
+    [Fact]
+    public async Task GetByFilters_AppliesCategoryFilterToListAndCountQueries()
+    {
+        var matchingCategory = new EventNewsCategory { Id = 5, Name = "Events" };
+        var matchingItem = new EventNewsEntity { Id = 1, Categories = [matchingCategory] };
+        var otherItem = new EventNewsEntity
+        {
+            Id = 2,
+            Categories = [new EventNewsCategory { Id = 6, Name = "News" }]
+        };
+        QueryOptions<EventNewsEntity>? listOptions = null;
+        QueryOptions<EventNewsEntity>? countOptions = null;
+
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetAllAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .Callback<QueryOptions<EventNewsEntity>>(options => listOptions = options)
+            .ReturnsAsync([matchingItem]);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.CountAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .Callback<QueryOptions<EventNewsEntity>>(options => countOptions = options)
+            .ReturnsAsync(1);
+        _mapper.Setup(mapper => mapper.Map<EventNewsDto[]>(It.IsAny<IEnumerable<EventNewsEntity>>()))
+            .Returns([new EventNewsDto { Id = 1 }]);
+
+        var handler = new GetEventNewsByFiltersHandler(_mapper.Object, _repositoryWrapper.Object);
+        var result = await handler.Handle(
+            new GetEventNewsByFiltersQuery(new EventNewsFilterDto { CategoryId = 5 }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(listOptions?.Filter);
+        Assert.NotNull(countOptions?.Filter);
+        Assert.True(listOptions.Filter.Compile()(matchingItem));
+        Assert.False(listOptions.Filter.Compile()(otherItem));
+        Assert.True(countOptions.Filter.Compile()(matchingItem));
+        Assert.False(countOptions.Filter.Compile()(otherItem));
+    }
+
+    [Fact]
+    public async Task GetByFilters_WhenNoItemsMatch_ReturnsEmptyPage()
+    {
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetAllAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .ReturnsAsync([]);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.CountAsync(It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .ReturnsAsync(0);
+        _mapper.Setup(mapper => mapper.Map<EventNewsDto[]>(It.IsAny<IEnumerable<EventNewsEntity>>()))
+            .Returns([]);
+
+        var handler = new GetEventNewsByFiltersHandler(_mapper.Object, _repositoryWrapper.Object);
+        var result = await handler.Handle(
+            new GetEventNewsByFiltersQuery(new EventNewsFilterDto { CategoryId = 99 }),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value.Items);
+        Assert.Equal(0, result.Value.TotalItemsCount);
+    }
+
+    [Fact]
+    public async Task GetById_WhenItemExists_ReturnsMappedItemUsingReadOnlyQuery()
+    {
+        var entity = new EventNewsEntity { Id = 10 };
+        var dto = new EventNewsDto { Id = 10 };
+        QueryOptions<EventNewsEntity>? queryOptions = null;
+
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .Callback<QueryOptions<EventNewsEntity>>(options => queryOptions = options)
+            .ReturnsAsync(entity);
+        _mapper.Setup(mapper => mapper.Map<EventNewsDto>(entity)).Returns(dto);
+
+        var handler = new GetEventNewsByIdHandler(_mapper.Object, _repositoryWrapper.Object);
+        var result = await handler.Handle(new GetEventNewsByIdQuery(10), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(dto, result.Value);
+        Assert.NotNull(queryOptions);
+        Assert.True(queryOptions.AsNoTracking);
+        Assert.NotNull(queryOptions.Include);
+        Assert.NotNull(queryOptions.Filter);
+        Assert.True(queryOptions.Filter.Compile()(entity));
+        Assert.False(queryOptions.Filter.Compile()(new EventNewsEntity { Id = 11 }));
+    }
+
+    [Fact]
+    public async Task GetById_WhenItemDoesNotExist_ReturnsNotFound()
+    {
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .ReturnsAsync((EventNewsEntity?)null);
+
+        var handler = new GetEventNewsByIdHandler(_mapper.Object, _repositoryWrapper.Object);
+        var result = await handler.Handle(new GetEventNewsByIdQuery(404), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(404, typeof(EventNewsEntity)),
+            result.Errors.Single().Message);
+        _mapper.Verify(mapper => mapper.Map<EventNewsDto>(It.IsAny<EventNewsEntity>()), Times.Never);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/GetEventNewsByFiltersQueryValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/GetEventNewsByFiltersQueryValidatorTests.cs
@@ -1,0 +1,75 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
+using VictoryCenter.BLL.Validators.EventNews;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.EventNews;
+
+public class GetEventNewsByFiltersQueryValidatorTests
+{
+    private readonly GetEventNewsByFiltersQueryValidator _validator = new();
+
+    [Fact]
+    public void Validate_WhenFilterValuesAreValid_HasNoErrors()
+    {
+        var query = Query(offset: 0, limit: 20, categoryId: 1);
+
+        var result = _validator.TestValidate(query);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WhenFilterValuesAreNull_HasNoErrors()
+    {
+        var result = _validator.TestValidate(Query());
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WhenOffsetIsNegative_HasExpectedError()
+    {
+        var result = _validator.TestValidate(Query(offset: -1));
+
+        result.ShouldHaveValidationErrorFor(query => query.Filter.Offset)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeGreaterThanOrEqualToN("Offset", 0));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WhenLimitIsNotPositive_HasExpectedError(int limit)
+    {
+        var result = _validator.TestValidate(Query(limit: limit));
+
+        result.ShouldHaveValidationErrorFor(query => query.Filter.Limit)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBeGreaterThan("Limit", 0));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WhenCategoryIdIsNotPositive_HasExpectedError(long categoryId)
+    {
+        var result = _validator.TestValidate(Query(categoryId: categoryId));
+
+        result.ShouldHaveValidationErrorFor(query => query.Filter.CategoryId)
+            .WithErrorMessage(ErrorMessagesConstants.PropertyMustBePositive("CategoryId"));
+    }
+
+    private static GetEventNewsByFiltersQuery Query(
+        int? offset = null,
+        int? limit = null,
+        long? categoryId = null)
+    {
+        return new GetEventNewsByFiltersQuery(
+            new EventNewsFilterDto
+            {
+                Offset = offset,
+                Limit = limit,
+                CategoryId = categoryId
+            });
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
@@ -1,12 +1,33 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
 using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.EventNews.GetByFilters;
+using VictoryCenter.BLL.Queries.Admin.EventNews.GetById;
 using VictoryCenter.WebAPI.Controllers.Common;
 
 namespace VictoryCenter.WebAPI.Controllers.Admin;
 
 public class EventNewsController : AuthorizedApiController
 {
+    [HttpGet]
+    [ProducesResponseType(typeof(PaginationResult<EventNewsDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetByFilters([FromQuery] EventNewsFilterDto filter)
+    {
+        return HandleResult(await Mediator.Send(new GetEventNewsByFiltersQuery(filter)));
+    }
+
+    [HttpGet("{id:long}")]
+    [ProducesResponseType(typeof(EventNewsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(long id)
+    {
+        return HandleResult(await Mediator.Send(new GetEventNewsByIdQuery(id)));
+    }
+
     [HttpPost]
     public async Task<IActionResult> CreateEventNews([FromBody] CreateEventNewsDto createEventNewsDto)
     {


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin Event News endpoints for paginated listing, category filtering, and retrieving individual items.
  * Event News responses now include related images, categories, and localization data.
  * Added pagination metadata, deterministic ordering, and clear not-found responses.
  * Added validation for pagination and category filter values.

* **Tests**
  * Added comprehensive integration and unit coverage for filtering, localization, pagination, authorization, validation, and missing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->