### PR TITLE
Implement admin update event/news api

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Create/CreateEventNewsHandler.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using FluentResults;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.EventNews;
 using VictoryCenter.BLL.Helpers;
@@ -9,15 +8,12 @@ using VictoryCenter.BLL.Interfaces.SlugService;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.DAL.Entities.Localization;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
-using VictoryCenter.DAL.Repositories.Options;
 using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
 
 namespace VictoryCenter.BLL.Commands.Admin.EventNews.Create;
 
 public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Result<EventNewsDto>>
 {
-    private const int MaxSlugSaveAttempts = 3;
-
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly ISlugService _slugService;
@@ -70,7 +66,9 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
             .Where(localization => localization is not null && !string.IsNullOrWhiteSpace(localization.Title))
             .ToList();
 
-        var languagesResult = await ValidateAndGetLanguagesAsync(localizationsToCreate);
+        var languagesResult = await EventNewsAggregateHelper.ValidateAndGetLanguagesAsync(
+            _repositoryWrapper,
+            localizationsToCreate);
 
         if (languagesResult.IsFailed)
         {
@@ -109,42 +107,17 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
 
         await _repositoryWrapper.EventNewsRepository.CreateAsync(eventNews);
 
-        if (await SaveEventNewsAsync(eventNews, titleForSlug, cancellationToken) > 0)
+        if (await EventNewsAggregateHelper.SaveWithSlugRetryAsync(
+                _repositoryWrapper,
+                _slugService,
+                eventNews,
+                titleForSlug,
+                cancellationToken) > 0)
         {
             return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
         }
 
         return Result.Fail<EventNewsDto>(ErrorMessagesConstants.FailedToCreateEntity(typeof(EventNewsEntity)));
-    }
-
-    private async Task<Result<IReadOnlyDictionary<long, LocalizationLanguage>>> ValidateAndGetLanguagesAsync(
-        IEnumerable<CreateEventNewsLocalizationDto> localizations)
-    {
-        var languageIds = localizations
-            .Select(localization => localization.LanguageId)
-            .Distinct()
-            .ToList();
-
-        if (languageIds.Count == 0)
-        {
-            return Result.Ok<IReadOnlyDictionary<long, LocalizationLanguage>>(
-                new Dictionary<long, LocalizationLanguage>());
-        }
-
-        var languages = (await _repositoryWrapper.LocalizationLanguagesRepository.GetAllAsync(
-            new QueryOptions<LocalizationLanguage>
-            {
-                Filter = language => languageIds.Contains(language.Id),
-                AsNoTracking = false
-            })).ToList();
-
-        var languagesById = languages.ToDictionary(language => language.Id);
-        var missingIds = languageIds.Where(id => !languagesById.ContainsKey(id)).ToList();
-
-        return missingIds.Count == 0
-            ? Result.Ok<IReadOnlyDictionary<long, LocalizationLanguage>>(languagesById)
-            : Result.Fail<IReadOnlyDictionary<long, LocalizationLanguage>>(
-                ErrorMessagesConstants.NotFound(missingIds, typeof(LocalizationLanguage)));
     }
 
     private static void AddCategories(EventNewsEntity eventNews, ICollection<EventNewsCategory> categories)
@@ -182,40 +155,5 @@ public class CreateEventNewsHandler : IRequestHandler<CreateEventNewsCommand, Re
         }
 
         return Result.Ok();
-    }
-
-    private async Task<int> SaveEventNewsAsync(
-        EventNewsEntity eventNews,
-        string? titleForSlug,
-        CancellationToken cancellationToken)
-    {
-        for (var attempt = 1; attempt <= MaxSlugSaveAttempts; attempt++)
-        {
-            try
-            {
-                return await _repositoryWrapper.SaveChangesAsync();
-            }
-            catch (DbUpdateException exception) when (
-                attempt < MaxSlugSaveAttempts
-                && !string.IsNullOrWhiteSpace(titleForSlug)
-                && exception.IsUniqueConstraintException())
-            {
-                var slugAlreadyExists = !string.IsNullOrWhiteSpace(eventNews.Slug)
-                    && await _repositoryWrapper.EventNewsRepository.ExistsAsync(
-                        existingEventNews => existingEventNews.Slug == eventNews.Slug);
-
-                if (!slugAlreadyExists)
-                {
-                    throw;
-                }
-
-                eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
-                    eventNews.Id,
-                    titleForSlug,
-                    cancellationToken);
-            }
-        }
-
-        return 0;
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Update/UpdateEventNewsCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Update/UpdateEventNewsCommand.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using VictoryCenter.BLL.Behaviors.Abstractions;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNews.Update;
+
+public record UpdateEventNewsCommand(long Id, UpdateEventNewsDto EventNews)
+    : IValidatableRequest<Result<EventNewsDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Update/UpdateEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Update/UpdateEventNewsHandler.cs
@@ -20,15 +20,18 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly ISlugService _slugService;
+    private readonly TimeProvider _timeProvider;
 
     public UpdateEventNewsHandler(
         IMapper mapper,
         IRepositoryWrapper repositoryWrapper,
-        ISlugService slugService)
+        ISlugService slugService,
+        TimeProvider timeProvider)
     {
         _mapper = mapper;
         _repositoryWrapper = repositoryWrapper;
         _slugService = slugService;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Result<EventNewsDto>> Handle(
@@ -77,68 +80,34 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
             return Result.Fail<EventNewsDto>(languagesResult.Errors);
         }
 
-        var categoriesChanged = !HaveSameCategoryIds(eventNews.Categories, categoryIds);
-        var localizationsChanged = HaveLocalizationChanges(eventNews.Localizations, localizationDtos);
-        var titlesChanged = HaveLocalizationTitlesChanged(eventNews.Localizations, localizationDtos);
-        var slugStateChanged = string.IsNullOrWhiteSpace(eventNews.Slug) != (localizationDtos.Count == 0);
-        var hasChanges = HasScalarOrImageChanges(eventNews, dto)
-                         || categoriesChanged
-                         || localizationsChanged
-                         || slugStateChanged;
+        var (categoriesChanged, localizationsChanged, titlesChanged, hasChanges) = GetChanges(
+            eventNews,
+            dto,
+            categoryIds,
+            localizationDtos);
 
         if (!hasChanges)
         {
             return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
         }
 
-        ApplyScalarAndImageChanges(eventNews, dto, imagesResult.Value);
-
-        if (categoriesChanged)
-        {
-            ReplaceCategories(eventNews, categoriesResult.Value);
-        }
-
-        if (localizationsChanged)
-        {
-            MergeLocalizations(eventNews, localizationDtos, languagesResult.Value);
-        }
+        ApplyChanges(
+            eventNews,
+            dto,
+            imagesResult.Value,
+            categoriesResult.Value,
+            localizationDtos,
+            languagesResult.Value,
+            categoriesChanged,
+            localizationsChanged);
 
         var titleForSlug = localizationDtos
             .Select(localization => localization.Title?.Trim())
             .FirstOrDefault(title => !string.IsNullOrWhiteSpace(title));
 
-        if (string.IsNullOrWhiteSpace(titleForSlug))
-        {
-            eventNews.Slug = null;
-        }
-        else if (titlesChanged || string.IsNullOrWhiteSpace(eventNews.Slug))
-        {
-            eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
-                eventNews.Id,
-                titleForSlug,
-                cancellationToken);
-        }
+        await UpdateSlugAsync(eventNews, titleForSlug, titlesChanged, cancellationToken);
 
-        try
-        {
-            if (await EventNewsAggregateHelper.SaveWithSlugRetryAsync(
-                    _repositoryWrapper,
-                    _slugService,
-                    eventNews,
-                    titleForSlug,
-                    cancellationToken) > 0)
-            {
-                return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
-            }
-        }
-        catch (DbUpdateConcurrencyException)
-        {
-            return Result.Fail<EventNewsDto>(
-                ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
-        }
-
-        return Result.Fail<EventNewsDto>(
-            ErrorMessagesConstants.FailedToUpdateEntity(typeof(EventNewsEntity)));
+        return await SaveAsync(eventNews, titleForSlug, cancellationToken);
     }
 
     private async Task<EventNewsEntity?> GetEventNewsAsync(long id)
@@ -177,11 +146,13 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
         EventNewsEntity eventNews,
         UpdateEventNewsDto dto)
     {
-        return !string.Equals(eventNews.Resource, dto.Resource, StringComparison.Ordinal)
-               || eventNews.PublishedAt != dto.PublishedAt
-               || eventNews.Status != dto.Status
-               || eventNews.PreviewImageId != dto.PreviewImageId
-               || eventNews.BackgroundImageId != dto.BackgroundImageId;
+        var scalarFieldsChanged = !string.Equals(eventNews.Resource, dto.Resource, StringComparison.Ordinal)
+                                  || eventNews.PublishedAt != dto.PublishedAt
+                                  || eventNews.Status != dto.Status;
+        var imagesChanged = eventNews.PreviewImageId != dto.PreviewImageId
+                            || eventNews.BackgroundImageId != dto.BackgroundImageId;
+
+        return scalarFieldsChanged || imagesChanged;
     }
 
     private static bool HaveSameCategoryIds(
@@ -192,38 +163,33 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
             .SetEquals(requestedCategoryIds);
     }
 
-    private static bool HaveLocalizationChanges(
+    private static (bool LocalizationsChanged, bool TitlesChanged) GetLocalizationChanges(
         IEnumerable<EventNewsLocalization> currentLocalizations,
         IReadOnlyCollection<CreateEventNewsLocalizationDto> requestedLocalizations)
     {
         var currentByLanguageId = currentLocalizations.ToDictionary(localization => localization.LanguageId);
-        if (currentByLanguageId.Count != requestedLocalizations.Count)
+        var localizationsChanged = currentByLanguageId.Count != requestedLocalizations.Count;
+        var titlesChanged = localizationsChanged;
+
+        foreach (var dto in requestedLocalizations)
         {
-            return true;
+            if (!currentByLanguageId.TryGetValue(dto.LanguageId, out var current))
+            {
+                localizationsChanged = true;
+                titlesChanged = true;
+                continue;
+            }
+
+            var titleChanged = !string.Equals(current.Title, dto.Title?.Trim(), StringComparison.Ordinal);
+            titlesChanged |= titleChanged;
+            localizationsChanged |= titleChanged
+                                    || !string.Equals(
+                                        current.Description,
+                                        NormalizeOptional(dto.Description),
+                                        StringComparison.Ordinal);
         }
 
-        return requestedLocalizations.Any(dto =>
-            !currentByLanguageId.TryGetValue(dto.LanguageId, out var current)
-            || !string.Equals(current.Title, dto.Title?.Trim(), StringComparison.Ordinal)
-            || !string.Equals(current.Description, NormalizeOptional(dto.Description), StringComparison.Ordinal)
-            || current.TranslationStatus != TranslationStatus.Relevant);
-    }
-
-    private static bool HaveLocalizationTitlesChanged(
-        IEnumerable<EventNewsLocalization> currentLocalizations,
-        IReadOnlyCollection<CreateEventNewsLocalizationDto> requestedLocalizations)
-    {
-        var currentTitles = currentLocalizations.ToDictionary(
-            localization => localization.LanguageId,
-            localization => localization.Title);
-        var requestedTitles = requestedLocalizations.ToDictionary(
-            localization => localization.LanguageId,
-            localization => localization.Title!.Trim());
-
-        return currentTitles.Count != requestedTitles.Count
-               || requestedTitles.Any(pair =>
-                   !currentTitles.TryGetValue(pair.Key, out var title)
-                   || !string.Equals(title, pair.Value, StringComparison.Ordinal));
+        return (localizationsChanged, titlesChanged);
     }
 
     private static void ApplyScalarAndImageChanges(
@@ -255,7 +221,7 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
         }
     }
 
-    private static void MergeLocalizations(
+    private void MergeLocalizations(
         EventNewsEntity eventNews,
         IReadOnlyCollection<CreateEventNewsLocalizationDto> localizationDtos,
         IReadOnlyDictionary<long, LocalizationLanguage> languagesById)
@@ -271,14 +237,22 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
         }
 
         var currentByLanguageId = eventNews.Localizations.ToDictionary(localization => localization.LanguageId);
-        var now = DateTimeOffset.UtcNow;
+        var now = _timeProvider.GetUtcNow();
 
         foreach (var localizationDto in localizationDtos)
         {
             if (currentByLanguageId.TryGetValue(localizationDto.LanguageId, out var localization))
             {
-                localization.Title = localizationDto.Title!.Trim();
-                localization.Description = NormalizeOptional(localizationDto.Description);
+                var title = localizationDto.Title!.Trim();
+                var description = NormalizeOptional(localizationDto.Description);
+                if (string.Equals(localization.Title, title, StringComparison.Ordinal)
+                    && string.Equals(localization.Description, description, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                localization.Title = title;
+                localization.Description = description;
                 localization.TranslationStatus = TranslationStatus.Relevant;
                 continue;
             }
@@ -298,5 +272,103 @@ public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Re
     private static string? NormalizeOptional(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static (bool CategoriesChanged, bool LocalizationsChanged, bool TitlesChanged, bool HasChanges) GetChanges(
+        EventNewsEntity eventNews,
+        UpdateEventNewsDto dto,
+        IReadOnlyCollection<long> categoryIds,
+        IReadOnlyCollection<CreateEventNewsLocalizationDto> localizationDtos)
+    {
+        var categoriesChanged = !HaveSameCategoryIds(eventNews.Categories, categoryIds);
+        var (localizationsChanged, titlesChanged) = GetLocalizationChanges(
+            eventNews.Localizations,
+            localizationDtos);
+        var slugStateChanged = string.IsNullOrWhiteSpace(eventNews.Slug) != (localizationDtos.Count == 0);
+        var hasChanges = HasScalarOrImageChanges(eventNews, dto)
+                         || categoriesChanged
+                         || localizationsChanged
+                         || slugStateChanged;
+
+        return (categoriesChanged, localizationsChanged, titlesChanged, hasChanges);
+    }
+
+    private void ApplyChanges(
+        EventNewsEntity eventNews,
+        UpdateEventNewsDto dto,
+        IReadOnlyDictionary<long, Image> imagesById,
+        IEnumerable<EventNewsCategory> categories,
+        IReadOnlyCollection<CreateEventNewsLocalizationDto> localizationDtos,
+        IReadOnlyDictionary<long, LocalizationLanguage> languagesById,
+        bool categoriesChanged,
+        bool localizationsChanged)
+    {
+        ApplyScalarAndImageChanges(eventNews, dto, imagesById);
+
+        if (categoriesChanged)
+        {
+            ReplaceCategories(eventNews, categories);
+        }
+
+        if (localizationsChanged)
+        {
+            MergeLocalizations(eventNews, localizationDtos, languagesById);
+        }
+    }
+
+    private async Task UpdateSlugAsync(
+        EventNewsEntity eventNews,
+        string? titleForSlug,
+        bool titlesChanged,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(titleForSlug))
+        {
+            eventNews.Slug = null;
+            return;
+        }
+
+        if (!titlesChanged && !string.IsNullOrWhiteSpace(eventNews.Slug))
+        {
+            return;
+        }
+
+        eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
+            eventNews.Id,
+            titleForSlug,
+            cancellationToken);
+    }
+
+    private async Task<Result<EventNewsDto>> SaveAsync(
+        EventNewsEntity eventNews,
+        string? titleForSlug,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (await EventNewsAggregateHelper.SaveWithSlugRetryAsync(
+                    _repositoryWrapper,
+                    _slugService,
+                    eventNews,
+                    titleForSlug,
+                    cancellationToken) > 0)
+            {
+                return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
+            }
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            if (!await _repositoryWrapper.EventNewsRepository.ExistsAsync(
+                    entity => entity.Id == eventNews.Id))
+            {
+                return Result.Fail<EventNewsDto>(
+                    ErrorMessagesConstants.NotFound(eventNews.Id, typeof(EventNewsEntity)));
+            }
+
+            throw;
+        }
+
+        return Result.Fail<EventNewsDto>(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(EventNewsEntity)));
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Update/UpdateEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Update/UpdateEventNewsHandler.cs
@@ -1,0 +1,302 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Helpers;
+using VictoryCenter.BLL.Interfaces.SlugService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNews.Update;
+
+public class UpdateEventNewsHandler : IRequestHandler<UpdateEventNewsCommand, Result<EventNewsDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly ISlugService _slugService;
+
+    public UpdateEventNewsHandler(
+        IMapper mapper,
+        IRepositoryWrapper repositoryWrapper,
+        ISlugService slugService)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+        _slugService = slugService;
+    }
+
+    public async Task<Result<EventNewsDto>> Handle(
+        UpdateEventNewsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var eventNews = await GetEventNewsAsync(request.Id);
+        if (eventNews is null)
+        {
+            return Result.Fail<EventNewsDto>(
+                ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
+        }
+
+        var dto = request.EventNews;
+        var categoryIds = dto.CategoryIds ?? [];
+        var localizationDtos = (dto.Localizations ?? [])
+            .Where(localization => localization is not null && !string.IsNullOrWhiteSpace(localization.Title))
+            .ToList();
+
+        var categoriesResult = await CategoryValidationHelper.ValidateAndGetCategoriesAsync(
+            _repositoryWrapper.EventNewsCategoryRepository,
+            categoryIds,
+            query => query
+                .Include(category => category.Localizations)
+                .ThenInclude(localization => localization.Language));
+
+        if (categoriesResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(categoriesResult.Errors);
+        }
+
+        var imagesResult = await ImageValidationHelper.ValidateAndGetImagesByIdsAsync(
+            _repositoryWrapper,
+            GetRequestedImageIds(dto));
+
+        if (imagesResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(imagesResult.Errors);
+        }
+
+        var languagesResult = await EventNewsAggregateHelper.ValidateAndGetLanguagesAsync(
+            _repositoryWrapper,
+            localizationDtos);
+        if (languagesResult.IsFailed)
+        {
+            return Result.Fail<EventNewsDto>(languagesResult.Errors);
+        }
+
+        var categoriesChanged = !HaveSameCategoryIds(eventNews.Categories, categoryIds);
+        var localizationsChanged = HaveLocalizationChanges(eventNews.Localizations, localizationDtos);
+        var titlesChanged = HaveLocalizationTitlesChanged(eventNews.Localizations, localizationDtos);
+        var slugStateChanged = string.IsNullOrWhiteSpace(eventNews.Slug) != (localizationDtos.Count == 0);
+        var hasChanges = HasScalarOrImageChanges(eventNews, dto)
+                         || categoriesChanged
+                         || localizationsChanged
+                         || slugStateChanged;
+
+        if (!hasChanges)
+        {
+            return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
+        }
+
+        ApplyScalarAndImageChanges(eventNews, dto, imagesResult.Value);
+
+        if (categoriesChanged)
+        {
+            ReplaceCategories(eventNews, categoriesResult.Value);
+        }
+
+        if (localizationsChanged)
+        {
+            MergeLocalizations(eventNews, localizationDtos, languagesResult.Value);
+        }
+
+        var titleForSlug = localizationDtos
+            .Select(localization => localization.Title?.Trim())
+            .FirstOrDefault(title => !string.IsNullOrWhiteSpace(title));
+
+        if (string.IsNullOrWhiteSpace(titleForSlug))
+        {
+            eventNews.Slug = null;
+        }
+        else if (titlesChanged || string.IsNullOrWhiteSpace(eventNews.Slug))
+        {
+            eventNews.Slug = await _slugService.GenerateUniqueEventNewsSlugAsync(
+                eventNews.Id,
+                titleForSlug,
+                cancellationToken);
+        }
+
+        try
+        {
+            if (await EventNewsAggregateHelper.SaveWithSlugRetryAsync(
+                    _repositoryWrapper,
+                    _slugService,
+                    eventNews,
+                    titleForSlug,
+                    cancellationToken) > 0)
+            {
+                return Result.Ok(_mapper.Map<EventNewsDto>(eventNews));
+            }
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return Result.Fail<EventNewsDto>(
+                ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
+        }
+
+        return Result.Fail<EventNewsDto>(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(EventNewsEntity)));
+    }
+
+    private async Task<EventNewsEntity?> GetEventNewsAsync(long id)
+    {
+        return await _repositoryWrapper.EventNewsRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<EventNewsEntity>
+            {
+                Filter = eventNews => eventNews.Id == id,
+                Include = query => query
+                    .Include(eventNews => eventNews.PreviewImage)
+                    .Include(eventNews => eventNews.BackgroundImage)
+                    .Include(eventNews => eventNews.Categories)
+                    .ThenInclude(category => category.Localizations)
+                    .ThenInclude(localization => localization.Language)
+                    .Include(eventNews => eventNews.Localizations)
+                    .ThenInclude(localization => localization.Language),
+                AsNoTracking = false,
+                AsSplitQuery = true
+            });
+    }
+
+    private static IEnumerable<long> GetRequestedImageIds(UpdateEventNewsDto dto)
+    {
+        if (dto.PreviewImageId.HasValue)
+        {
+            yield return dto.PreviewImageId.Value;
+        }
+
+        if (dto.BackgroundImageId.HasValue)
+        {
+            yield return dto.BackgroundImageId.Value;
+        }
+    }
+
+    private static bool HasScalarOrImageChanges(
+        EventNewsEntity eventNews,
+        UpdateEventNewsDto dto)
+    {
+        return !string.Equals(eventNews.Resource, dto.Resource, StringComparison.Ordinal)
+               || eventNews.PublishedAt != dto.PublishedAt
+               || eventNews.Status != dto.Status
+               || eventNews.PreviewImageId != dto.PreviewImageId
+               || eventNews.BackgroundImageId != dto.BackgroundImageId;
+    }
+
+    private static bool HaveSameCategoryIds(
+        IEnumerable<EventNewsCategory> currentCategories,
+        IEnumerable<long> requestedCategoryIds)
+    {
+        return currentCategories.Select(category => category.Id).ToHashSet()
+            .SetEquals(requestedCategoryIds);
+    }
+
+    private static bool HaveLocalizationChanges(
+        IEnumerable<EventNewsLocalization> currentLocalizations,
+        IReadOnlyCollection<CreateEventNewsLocalizationDto> requestedLocalizations)
+    {
+        var currentByLanguageId = currentLocalizations.ToDictionary(localization => localization.LanguageId);
+        if (currentByLanguageId.Count != requestedLocalizations.Count)
+        {
+            return true;
+        }
+
+        return requestedLocalizations.Any(dto =>
+            !currentByLanguageId.TryGetValue(dto.LanguageId, out var current)
+            || !string.Equals(current.Title, dto.Title?.Trim(), StringComparison.Ordinal)
+            || !string.Equals(current.Description, NormalizeOptional(dto.Description), StringComparison.Ordinal)
+            || current.TranslationStatus != TranslationStatus.Relevant);
+    }
+
+    private static bool HaveLocalizationTitlesChanged(
+        IEnumerable<EventNewsLocalization> currentLocalizations,
+        IReadOnlyCollection<CreateEventNewsLocalizationDto> requestedLocalizations)
+    {
+        var currentTitles = currentLocalizations.ToDictionary(
+            localization => localization.LanguageId,
+            localization => localization.Title);
+        var requestedTitles = requestedLocalizations.ToDictionary(
+            localization => localization.LanguageId,
+            localization => localization.Title!.Trim());
+
+        return currentTitles.Count != requestedTitles.Count
+               || requestedTitles.Any(pair =>
+                   !currentTitles.TryGetValue(pair.Key, out var title)
+                   || !string.Equals(title, pair.Value, StringComparison.Ordinal));
+    }
+
+    private static void ApplyScalarAndImageChanges(
+        EventNewsEntity eventNews,
+        UpdateEventNewsDto dto,
+        IReadOnlyDictionary<long, Image> imagesById)
+    {
+        eventNews.Resource = dto.Resource;
+        eventNews.PublishedAt = dto.PublishedAt;
+        eventNews.Status = dto.Status;
+        eventNews.PreviewImageId = dto.PreviewImageId;
+        eventNews.PreviewImage = dto.PreviewImageId.HasValue
+            ? imagesById[dto.PreviewImageId.Value]
+            : null;
+        eventNews.BackgroundImageId = dto.BackgroundImageId;
+        eventNews.BackgroundImage = dto.BackgroundImageId.HasValue
+            ? imagesById[dto.BackgroundImageId.Value]
+            : null;
+    }
+
+    private static void ReplaceCategories(
+        EventNewsEntity eventNews,
+        IEnumerable<EventNewsCategory> categories)
+    {
+        eventNews.Categories.Clear();
+        foreach (var category in categories)
+        {
+            eventNews.Categories.Add(category);
+        }
+    }
+
+    private static void MergeLocalizations(
+        EventNewsEntity eventNews,
+        IReadOnlyCollection<CreateEventNewsLocalizationDto> localizationDtos,
+        IReadOnlyDictionary<long, LocalizationLanguage> languagesById)
+    {
+        var requestedByLanguageId = localizationDtos.ToDictionary(localization => localization.LanguageId);
+        var localizationsToRemove = eventNews.Localizations
+            .Where(localization => !requestedByLanguageId.ContainsKey(localization.LanguageId))
+            .ToList();
+
+        foreach (var localization in localizationsToRemove)
+        {
+            eventNews.Localizations.Remove(localization);
+        }
+
+        var currentByLanguageId = eventNews.Localizations.ToDictionary(localization => localization.LanguageId);
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var localizationDto in localizationDtos)
+        {
+            if (currentByLanguageId.TryGetValue(localizationDto.LanguageId, out var localization))
+            {
+                localization.Title = localizationDto.Title!.Trim();
+                localization.Description = NormalizeOptional(localizationDto.Description);
+                localization.TranslationStatus = TranslationStatus.Relevant;
+                continue;
+            }
+
+            eventNews.Localizations.Add(new EventNewsLocalization
+            {
+                LanguageId = localizationDto.LanguageId,
+                Language = languagesById[localizationDto.LanguageId],
+                Title = localizationDto.Title!.Trim(),
+                Description = NormalizeOptional(localizationDto.Description),
+                TranslationStatus = TranslationStatus.Relevant,
+                CreatedAt = now
+            });
+        }
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/UpdateEventNewsDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/EventNews/UpdateEventNewsDto.cs
@@ -1,0 +1,3 @@
+namespace VictoryCenter.BLL.DTOs.Admin.EventNews;
+
+public record UpdateEventNewsDto : CreateEventNewsDto;

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/CategoryValidationHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/CategoryValidationHelper.cs
@@ -1,4 +1,5 @@
 using FluentResults;
+using Microsoft.EntityFrameworkCore.Query;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.DAL.Data.BaseEntity;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -10,7 +11,8 @@ public static class CategoryValidationHelper
 {
     public static async Task<Result<ICollection<TCategory>>> ValidateAndGetCategoriesAsync<TCategory>(
         IRepositoryBase<TCategory> categoryRepository,
-        IEnumerable<long> requestedCategoryIds)
+        IEnumerable<long> requestedCategoryIds,
+        Func<IQueryable<TCategory>, IIncludableQueryable<TCategory, object>>? include = null)
         where TCategory : BaseEntity
     {
         var requestedIdsList = requestedCategoryIds.ToList();
@@ -23,6 +25,7 @@ public static class CategoryValidationHelper
         var retrievedCategoriesList = (await categoryRepository.GetAllAsync(new QueryOptions<TCategory>
         {
             Filter = category => requestedIdsList.Contains(category.Id),
+            Include = include,
             AsNoTracking = false
         })).ToList();
 

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/EventNewsAggregateHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/EventNewsAggregateHelper.cs
@@ -52,15 +52,14 @@ public static class EventNewsAggregateHelper
         string? titleForSlug,
         CancellationToken cancellationToken)
     {
-        for (var attempt = 1; attempt <= MaxSlugSaveAttempts; attempt++)
+        for (var attempt = 1; attempt < MaxSlugSaveAttempts; attempt++)
         {
             try
             {
                 return await repositoryWrapper.SaveChangesAsync();
             }
             catch (DbUpdateException exception) when (
-                attempt < MaxSlugSaveAttempts
-                && !string.IsNullOrWhiteSpace(titleForSlug)
+                !string.IsNullOrWhiteSpace(titleForSlug)
                 && exception.IsUniqueConstraintException())
             {
                 var slugAlreadyExists = !string.IsNullOrWhiteSpace(eventNews.Slug)
@@ -80,6 +79,6 @@ public static class EventNewsAggregateHelper
             }
         }
 
-        return 0;
+        return await repositoryWrapper.SaveChangesAsync();
     }
 }

--- a/VictoryCenter/VictoryCenter.BLL/Helpers/EventNewsAggregateHelper.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Helpers/EventNewsAggregateHelper.cs
@@ -1,0 +1,85 @@
+using FluentResults;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Interfaces.SlugService;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.BLL.Helpers;
+
+public static class EventNewsAggregateHelper
+{
+    private const int MaxSlugSaveAttempts = 3;
+
+    public static async Task<Result<IReadOnlyDictionary<long, LocalizationLanguage>>> ValidateAndGetLanguagesAsync(
+        IRepositoryWrapper repositoryWrapper,
+        IEnumerable<CreateEventNewsLocalizationDto> localizations)
+    {
+        var languageIds = localizations
+            .Select(localization => localization.LanguageId)
+            .Distinct()
+            .ToList();
+
+        if (languageIds.Count == 0)
+        {
+            return Result.Ok<IReadOnlyDictionary<long, LocalizationLanguage>>(
+                new Dictionary<long, LocalizationLanguage>());
+        }
+
+        var languages = (await repositoryWrapper.LocalizationLanguagesRepository.GetAllAsync(
+            new QueryOptions<LocalizationLanguage>
+            {
+                Filter = language => languageIds.Contains(language.Id),
+                AsNoTracking = false
+            })).ToList();
+
+        var languagesById = languages.ToDictionary(language => language.Id);
+        var missingIds = languageIds.Where(id => !languagesById.ContainsKey(id)).ToList();
+
+        return missingIds.Count == 0
+            ? Result.Ok<IReadOnlyDictionary<long, LocalizationLanguage>>(languagesById)
+            : Result.Fail<IReadOnlyDictionary<long, LocalizationLanguage>>(
+                ErrorMessagesConstants.NotFound(missingIds, typeof(LocalizationLanguage)));
+    }
+
+    public static async Task<int> SaveWithSlugRetryAsync(
+        IRepositoryWrapper repositoryWrapper,
+        ISlugService slugService,
+        EventNewsEntity eventNews,
+        string? titleForSlug,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 1; attempt <= MaxSlugSaveAttempts; attempt++)
+        {
+            try
+            {
+                return await repositoryWrapper.SaveChangesAsync();
+            }
+            catch (DbUpdateException exception) when (
+                attempt < MaxSlugSaveAttempts
+                && !string.IsNullOrWhiteSpace(titleForSlug)
+                && exception.IsUniqueConstraintException())
+            {
+                var slugAlreadyExists = !string.IsNullOrWhiteSpace(eventNews.Slug)
+                    && await repositoryWrapper.EventNewsRepository.ExistsAsync(
+                        existingEventNews => existingEventNews.Id != eventNews.Id
+                            && existingEventNews.Slug == eventNews.Slug);
+
+                if (!slugAlreadyExists)
+                {
+                    throw;
+                }
+
+                eventNews.Slug = await slugService.GenerateUniqueEventNewsSlugAsync(
+                    eventNews.Id,
+                    titleForSlug,
+                    cancellationToken);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/UpdateEventNewsValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/EventNews/UpdateEventNewsValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Update;
+using VictoryCenter.BLL.Constants;
+
+namespace VictoryCenter.BLL.Validators.EventNews;
+
+public class UpdateEventNewsValidator : AbstractValidator<UpdateEventNewsCommand>
+{
+    public UpdateEventNewsValidator(BaseEventNewsValidator baseEventNewsValidator)
+    {
+        RuleFor(command => command.Id)
+            .GreaterThan(0)
+            .WithMessage(ErrorMessagesConstants.PropertyMustBePositive(nameof(UpdateEventNewsCommand.Id)));
+
+        RuleFor(command => command.EventNews)
+            .NotNull()
+            .SetValidator(baseEventNewsValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Update/UpdateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Update/UpdateEventNewsTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.DTOs.Public.EventNews;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.EventNews.Update;
+
+public class UpdateEventNewsTests : BaseTestClass
+{
+    private const string EndpointUri = "/api/EventNews";
+
+    public UpdateEventNewsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_ShouldSynchronizeAggregateAndBeIdempotent()
+    {
+        var originalCreatedAt = await Fixture.DbContext.EventNews
+            .Where(eventNews => eventNews.Id == 1)
+            .Select(eventNews => eventNews.CreatedAt)
+            .SingleAsync();
+
+        var firstDto = PublishedDto(
+            categoryIds: [4, 5],
+            localizations:
+            [
+                Localization(1, "Updated Integration Event", "Updated integration description"),
+                Localization(2, "Updated Community Workshop", "Updated community workshop description"),
+            ]);
+
+        var firstResponse = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/1", firstDto);
+        var firstContent = await firstResponse.Content.ReadFromJsonAsync<EventNewsDto>(JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.NotNull(firstContent);
+        Assert.Equal("updated-integration-event", firstContent.Slug);
+        Assert.Equal(Status.Published, firstContent.Status);
+        Assert.Equal([4, 5], firstContent.Categories.Select(category => category.Id).OrderBy(id => id));
+        Assert.Equal([1, 2], firstContent.Localizations.Select(item => item.Language.Id).OrderBy(id => id));
+        Assert.NotNull(firstContent.PreviewImage);
+        Assert.NotNull(firstContent.BackgroundImage);
+
+        var secondDto = PublishedDto(
+            categoryIds: [5],
+            localizations:
+            [
+                Localization(2, "Community Charity Day", "Final details for the community charity day"),
+            ]);
+
+        var secondResponse = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/1", secondDto);
+        var repeatResponse = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/1", secondDto);
+        var secondContent = await secondResponse.Content.ReadFromJsonAsync<EventNewsDto>(JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, repeatResponse.StatusCode);
+        Assert.NotNull(secondContent);
+        Assert.Equal("community-charity-day", secondContent.Slug);
+        Assert.Equal(5, Assert.Single(secondContent.Categories).Id);
+        Assert.Equal(2, Assert.Single(secondContent.Localizations).Language.Id);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        var persisted = await Fixture.DbContext.EventNews
+            .Include(eventNews => eventNews.Categories)
+            .Include(eventNews => eventNews.Localizations)
+            .SingleAsync(eventNews => eventNews.Id == 1);
+
+        Assert.Equal(originalCreatedAt, persisted.CreatedAt);
+        Assert.Equal(5, Assert.Single(persisted.Categories).Id);
+        var persistedLocalization = Assert.Single(persisted.Localizations);
+        Assert.Equal(2, persistedLocalization.LanguageId);
+        Assert.Equal(TranslationStatus.Relevant, persistedLocalization.TranslationStatus);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_ToEmptyDraft_ShouldRemoveContentAndHidePublicItem()
+    {
+        var dto = new UpdateEventNewsDto
+        {
+            Status = Status.Draft,
+            Localizations = [new CreateEventNewsLocalizationDto { LanguageId = 1 }]
+        };
+
+        var response = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/2", dto);
+        var content = await response.Content.ReadFromJsonAsync<EventNewsDto>(JsonOptions);
+        var publicItems = await Fixture.HttpClient.GetFromJsonAsync<List<PublishedEventNewsDto>>(
+            "/api/EventNews/published",
+            JsonOptions);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(content);
+        Assert.Equal(Status.Draft, content.Status);
+        Assert.Null(content.Slug);
+        Assert.Empty(content.Categories);
+        Assert.Empty(content.Localizations);
+        Assert.NotNull(publicItems);
+        Assert.DoesNotContain(publicItems, eventNews => eventNews.Id == 2);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_WhenEntityDoesNotExist_ShouldReturnNotFound()
+    {
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"{EndpointUri}/{long.MaxValue}",
+            new UpdateEventNewsDto { Status = Status.Draft });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_WhenIdIsInvalid_ShouldReturnBadRequest()
+    {
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"{EndpointUri}/0",
+            new UpdateEventNewsDto { Status = Status.Draft });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdatePublishedEventNews_WhenRequiredFieldsAreMissing_ShouldReturnBadRequest()
+    {
+        var response = await Fixture.HttpClient.PutAsJsonAsync(
+            $"{EndpointUri}/1",
+            new UpdateEventNewsDto { Status = Status.Published });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_WhenCategoryDoesNotExist_ShouldReturnNotFound()
+    {
+        var dto = PublishedDto(categoryIds: [long.MaxValue]);
+
+        var response = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/1", dto);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_WhenImageDoesNotExist_ShouldReturnNotFound()
+    {
+        var dto = PublishedDto() with { PreviewImageId = long.MaxValue };
+
+        var response = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/1", dto);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_WhenLanguageDoesNotExist_ShouldReturnNotFound()
+    {
+        var dto = PublishedDto(localizations:
+        [
+            Localization(long.MaxValue, "Missing Language Event", "Missing language description"),
+        ]);
+
+        var response = await Fixture.HttpClient.PutAsJsonAsync($"{EndpointUri}/1", dto);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateEventNews_WithoutAuthorization_ShouldReturnUnauthorized()
+    {
+        using var anonymousClient = Fixture.Factory.CreateClient();
+
+        var response = await anonymousClient.PutAsJsonAsync(
+            $"{EndpointUri}/1",
+            new UpdateEventNewsDto { Status = Status.Draft });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static UpdateEventNewsDto PublishedDto(
+        List<long>? categoryIds = null,
+        List<CreateEventNewsLocalizationDto>? localizations = null)
+    {
+        return new UpdateEventNewsDto
+        {
+            Resource = "https://example.com/integration-update",
+            PublishedAt = DateTimeOffset.UtcNow,
+            Status = Status.Published,
+            PreviewImageId = 1,
+            BackgroundImageId = 2,
+            CategoryIds = categoryIds ?? [1],
+            Localizations = localizations ??
+            [
+                Localization(1, "Default Integration Event", "Default integration description"),
+            ]
+        };
+    }
+
+    private static CreateEventNewsLocalizationDto Localization(
+        long languageId,
+        string title,
+        string description)
+    {
+        return new CreateEventNewsLocalizationDto
+        {
+            LanguageId = languageId,
+            Title = title,
+            Description = description
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/HelperTests/CategoryValidationHelperTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/HelperTests/CategoryValidationHelperTests.cs
@@ -1,4 +1,5 @@
 using FluentResults;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.Helpers;
@@ -123,6 +124,25 @@ public class CategoryValidationHelperTests
         _categoryRepoMock.Verify(
             repository => repository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task ValidateAndGetCategoriesAsync_WithInclude_ForwardsIncludeToRepository()
+    {
+        var categories = new List<HippotherapyProgramCategory> { MakeCategory(1, "Category 1") };
+        QueryOptions<HippotherapyProgramCategory>? capturedOptions = null;
+        _categoryRepoMock
+            .Setup(repository => repository.GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategory>>()))
+            .Callback<QueryOptions<HippotherapyProgramCategory>>(options => capturedOptions = options)
+            .ReturnsAsync(categories);
+
+        var result = await CategoryValidationHelper.ValidateAndGetCategoriesAsync(
+            _categoryRepoMock.Object,
+            [1],
+            query => query.Include(category => category.Programs));
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(capturedOptions?.Include);
     }
 
     private static HippotherapyProgramCategory MakeCategory(long id, string name)

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/UpdateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/UpdateEventNewsTests.cs
@@ -78,11 +78,6 @@ public class UpdateEventNewsTests
     public async Task Handle_UnchangedRequest_ReturnsSuccessWithoutSaving()
     {
         var eventNews = ExistingEventNews();
-        foreach (var localization in eventNews.Localizations)
-        {
-            localization.TranslationStatus = TranslationStatus.Relevant;
-        }
-
         var handler = CreateHandler(eventNews);
 
         var result = await handler.Handle(
@@ -97,6 +92,23 @@ public class UpdateEventNewsTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLocalizationContentIsUnchanged_PreservesTranslationStatus()
+    {
+        var eventNews = ExistingEventNews();
+        var outdatedLocalization = eventNews.Localizations.Single(item => item.LanguageId == 1);
+        var dto = MatchingDto(eventNews) with { Resource = "https://example.com/updated" };
+        var handler = CreateHandler(eventNews);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, dto),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(TranslationStatus.Outdated, outdatedLocalization.TranslationStatus);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
     }
 
     [Fact]
@@ -186,6 +198,9 @@ public class UpdateEventNewsTests
         var handler = CreateHandler(
             ExistingEventNews(),
             saveException: new DbUpdateConcurrencyException());
+        _repositoryWrapper.Setup(wrapper => wrapper.EventNewsRepository.ExistsAsync(
+                It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(false);
 
         var result = await handler.Handle(
             new UpdateEventNewsCommand(10, PublishedDto()),
@@ -193,6 +208,22 @@ public class UpdateEventNewsTests
 
         Assert.True(result.IsFailed);
         Assert.Contains(typeof(EventNewsEntity).Name, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_WhenConcurrencyFailureIsNotCausedByEntityDeletion_PropagatesException()
+    {
+        var exception = new DbUpdateConcurrencyException();
+        var handler = CreateHandler(ExistingEventNews(), saveException: exception);
+        _repositoryWrapper.Setup(wrapper => wrapper.EventNewsRepository.ExistsAsync(
+                It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(true);
+
+        var actualException = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None));
+
+        Assert.Same(exception, actualException);
     }
 
     [Fact]
@@ -224,7 +255,7 @@ public class UpdateEventNewsTests
     }
 
     [Fact]
-    public async Task Handle_NonSlugDatabaseException_PropagatesException()
+    public async Task Handle_UniqueConstraintOnNonSlugColumn_PropagatesException()
     {
         var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");
         var handler = CreateHandler(ExistingEventNews(), saveException: exception);
@@ -300,7 +331,8 @@ public class UpdateEventNewsTests
         return new UpdateEventNewsHandler(
             _mapper.Object,
             _repositoryWrapper.Object,
-            _slugService.Object);
+            _slugService.Object,
+            TimeProvider.System);
     }
 
     private static IEnumerable<TEntity> ApplyFilter<TEntity>(
@@ -398,13 +430,13 @@ public class UpdateEventNewsTests
             Status = eventNews.Status,
             PreviewImageId = eventNews.PreviewImageId,
             BackgroundImageId = eventNews.BackgroundImageId,
-            CategoryIds = eventNews.Categories.Select(category => category.Id).ToList(),
-            Localizations = eventNews.Localizations.Select(localization => new CreateEventNewsLocalizationDto
+            CategoryIds = [.. eventNews.Categories.Select(category => category.Id)],
+            Localizations = [.. eventNews.Localizations.Select(localization => new CreateEventNewsLocalizationDto
             {
                 LanguageId = localization.LanguageId,
                 Title = localization.Title,
                 Description = localization.Description
-            }).ToList()
+            })]
         };
     }
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/UpdateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/UpdateEventNewsTests.cs
@@ -1,0 +1,425 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Interfaces.SlugService;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using VictoryCenter.UnitTests.Utils;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+using EventNewsPredicate = System.Linq.Expressions.Expression<System.Func<VictoryCenter.DAL.Entities.EventNews, bool>>;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNews;
+
+public class UpdateEventNewsTests
+{
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapper = new();
+    private readonly Mock<ISlugService> _slugService = new();
+
+    [Fact]
+    public async Task Handle_WhenEntityDoesNotExist_ReturnsNotFound()
+    {
+        var handler = CreateHandler(eventNews: null);
+
+        var result = await handler.Handle(new UpdateEventNewsCommand(10, DraftDto()), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(typeof(EventNewsEntity).Name, result.Errors[0].Message);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesCompleteAggregate()
+    {
+        var eventNews = ExistingEventNews();
+        var originalCreatedAt = eventNews.CreatedAt;
+        var originalLocalizationCreatedAt = eventNews.Localizations.Single(item => item.LanguageId == 1).CreatedAt;
+        var handler = CreateHandler(eventNews);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("https://example.com/updated", eventNews.Resource);
+        Assert.Equal(Status.Published, eventNews.Status);
+        Assert.Equal(3, eventNews.PreviewImageId);
+        Assert.Equal(2, eventNews.BackgroundImageId);
+        Assert.Equal(originalCreatedAt, eventNews.CreatedAt);
+        Assert.Equal("updated-event-title", eventNews.Slug);
+        Assert.Equal([2], eventNews.Categories.Select(category => category.Id));
+        Assert.Equal([1, 3], eventNews.Localizations.Select(item => item.LanguageId).OrderBy(id => id));
+
+        var updatedLocalization = eventNews.Localizations.Single(item => item.LanguageId == 1);
+        Assert.Equal("Updated Event Title", updatedLocalization.Title);
+        Assert.Equal("Updated event description", updatedLocalization.Description);
+        Assert.Equal(TranslationStatus.Relevant, updatedLocalization.TranslationStatus);
+        Assert.Equal(originalLocalizationCreatedAt, updatedLocalization.CreatedAt);
+
+        var newLocalization = eventNews.Localizations.Single(item => item.LanguageId == 3);
+        Assert.Equal("German Event Title", newLocalization.Title);
+        Assert.NotEqual(default, newLocalization.CreatedAt);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
+        _slugService.Verify(
+            service => service.GenerateUniqueEventNewsSlugAsync(
+                10,
+                "Updated Event Title",
+                CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UnchangedRequest_ReturnsSuccessWithoutSaving()
+    {
+        var eventNews = ExistingEventNews();
+        foreach (var localization in eventNews.Localizations)
+        {
+            localization.TranslationStatus = TranslationStatus.Relevant;
+        }
+
+        var handler = CreateHandler(eventNews);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, MatchingDto(eventNews)),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+        _slugService.Verify(
+            service => service.GenerateUniqueEventNewsSlugAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_DraftWithoutContent_RemovesAssociationsAndSlug()
+    {
+        var eventNews = ExistingEventNews();
+        var handler = CreateHandler(eventNews);
+        var dto = DraftDto() with
+        {
+            Localizations = [new CreateEventNewsLocalizationDto { LanguageId = 1 }]
+        };
+
+        var result = await handler.Handle(new UpdateEventNewsCommand(10, dto), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(eventNews.Slug);
+        Assert.Empty(eventNews.Categories);
+        Assert.Empty(eventNews.Localizations);
+        _repositoryWrapper.Verify(
+            wrapper => wrapper.LocalizationLanguagesRepository.GetAllAsync(
+                It.IsAny<QueryOptions<LocalizationLanguage>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCategoryDoesNotExist_ReturnsNotFoundWithoutSaving()
+    {
+        var handler = CreateHandler(ExistingEventNews(), categories: [Category(1)]);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(nameof(EventNewsCategory), string.Join(" | ", result.Errors.Select(error => error.Message)));
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenImageDoesNotExist_ReturnsNotFoundWithoutSaving()
+    {
+        var handler = CreateHandler(ExistingEventNews(), images: [Image(1), Image(2)]);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(nameof(Image), string.Join(" | ", result.Errors.Select(error => error.Message)));
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLanguageDoesNotExist_ReturnsNotFoundWithoutSaving()
+    {
+        var handler = CreateHandler(ExistingEventNews(), languages: [Language(1), Language(2)]);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(
+            nameof(LocalizationLanguage),
+            string.Join(" | ", result.Errors.Select(error => error.Message)));
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSaveReturnsZero_ReturnsFailedToUpdate()
+    {
+        var handler = CreateHandler(ExistingEventNews(), saveChanges: 0);
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(EventNewsEntity)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEntityIsDeletedConcurrently_ReturnsNotFound()
+    {
+        var handler = CreateHandler(
+            ExistingEventNews(),
+            saveException: new DbUpdateConcurrencyException());
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Contains(typeof(EventNewsEntity).Name, result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_SlugCollision_RegeneratesSlugAndRetriesSave()
+    {
+        var eventNews = ExistingEventNews();
+        var handler = CreateHandler(eventNews);
+        var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");
+        _repositoryWrapper.SetupSequence(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(exception)
+            .ReturnsAsync(1);
+        _repositoryWrapper.Setup(wrapper => wrapper.EventNewsRepository.ExistsAsync(
+                It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(true);
+        _slugService.SetupSequence(service => service.GenerateUniqueEventNewsSlugAsync(
+                10,
+                "Updated Event Title",
+                CancellationToken.None))
+            .ReturnsAsync("updated-event-title")
+            .ReturnsAsync("updated-event-title-1");
+
+        var result = await handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("updated-event-title-1", eventNews.Slug);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_NonSlugDatabaseException_PropagatesException()
+    {
+        var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");
+        var handler = CreateHandler(ExistingEventNews(), saveException: exception);
+        _repositoryWrapper.Setup(wrapper => wrapper.EventNewsRepository.ExistsAsync(
+                It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(false);
+
+        var actualException = await Assert.ThrowsAsync<DbUpdateException>(() => handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None));
+
+        Assert.Same(exception, actualException);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
+    }
+
+    private UpdateEventNewsHandler CreateHandler(
+        EventNewsEntity? eventNews,
+        IReadOnlyCollection<EventNewsCategory>? categories = null,
+        IReadOnlyCollection<Image>? images = null,
+        IReadOnlyCollection<LocalizationLanguage>? languages = null,
+        int saveChanges = 1,
+        DbUpdateException? saveException = null)
+    {
+        categories ??= [Category(1), Category(2)];
+        images ??= [Image(1), Image(2), Image(3)];
+        languages ??= [Language(1), Language(2), Language(3)];
+
+        _repositoryWrapper.Reset();
+        _mapper.Reset();
+        _slugService.Reset();
+
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .ReturnsAsync(eventNews);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.EventNewsCategoryRepository.GetAllAsync(
+                It.IsAny<QueryOptions<EventNewsCategory>>()))
+            .ReturnsAsync((QueryOptions<EventNewsCategory> options) => ApplyFilter(categories, options));
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.ImageRepository.GetAllAsync(It.IsAny<QueryOptions<Image>>()))
+            .ReturnsAsync((QueryOptions<Image> options) => ApplyFilter(images, options));
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.LocalizationLanguagesRepository.GetAllAsync(
+                It.IsAny<QueryOptions<LocalizationLanguage>>()))
+            .ReturnsAsync((QueryOptions<LocalizationLanguage> options) => ApplyFilter(languages, options));
+
+        if (saveException is not null)
+        {
+            _repositoryWrapper.Setup(wrapper => wrapper.SaveChangesAsync()).ThrowsAsync(saveException);
+        }
+        else
+        {
+            _repositoryWrapper.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(saveChanges);
+        }
+
+        _slugService.Setup(service => service.GenerateUniqueEventNewsSlugAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("updated-event-title");
+
+        _mapper.Setup(mapper => mapper.Map<EventNewsDto>(It.IsAny<EventNewsEntity>()))
+            .Returns((EventNewsEntity entity) => new EventNewsDto
+            {
+                Id = entity.Id,
+                Slug = entity.Slug,
+                Resource = entity.Resource,
+                PublishedAt = entity.PublishedAt,
+                Status = entity.Status
+            });
+
+        return new UpdateEventNewsHandler(
+            _mapper.Object,
+            _repositoryWrapper.Object,
+            _slugService.Object);
+    }
+
+    private static IEnumerable<TEntity> ApplyFilter<TEntity>(
+        IEnumerable<TEntity> entities,
+        QueryOptions<TEntity> options)
+        where TEntity : class
+    {
+        var predicate = options.Filter?.Compile();
+        return predicate is null ? entities : entities.Where(predicate);
+    }
+
+    private static EventNewsEntity ExistingEventNews()
+    {
+        var firstLanguage = Language(1);
+        var secondLanguage = Language(2);
+
+        return new EventNewsEntity
+        {
+            Id = 10,
+            Slug = "old-event-title",
+            Resource = "https://example.com/original",
+            PublishedAt = null,
+            Status = Status.Draft,
+            PreviewImageId = 1,
+            PreviewImage = Image(1),
+            BackgroundImageId = 2,
+            BackgroundImage = Image(2),
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-10),
+            Categories = [Category(1)],
+            Localizations =
+            [
+                new EventNewsLocalization
+                {
+                    EntityId = 10,
+                    LanguageId = 1,
+                    Language = firstLanguage,
+                    Title = "Old Event Title",
+                    Description = "Old event description",
+                    TranslationStatus = TranslationStatus.Outdated,
+                    CreatedAt = DateTimeOffset.UtcNow.AddDays(-5)
+                },
+                new EventNewsLocalization
+                {
+                    EntityId = 10,
+                    LanguageId = 2,
+                    Language = secondLanguage,
+                    Title = "Community Workshop",
+                    Description = "Community workshop description",
+                    TranslationStatus = TranslationStatus.Relevant,
+                    CreatedAt = DateTimeOffset.UtcNow.AddDays(-5)
+                },
+            ]
+        };
+    }
+
+    private static UpdateEventNewsDto PublishedDto()
+    {
+        return new UpdateEventNewsDto
+        {
+            Resource = "https://example.com/updated",
+            PublishedAt = DateTimeOffset.UtcNow,
+            Status = Status.Published,
+            PreviewImageId = 3,
+            BackgroundImageId = 2,
+            CategoryIds = [2],
+            Localizations =
+            [
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 1,
+                    Title = "  Updated Event Title  ",
+                    Description = "  Updated event description  "
+                },
+                new CreateEventNewsLocalizationDto
+                {
+                    LanguageId = 3,
+                    Title = "German Event Title",
+                    Description = "German event description"
+                },
+            ]
+        };
+    }
+
+    private static UpdateEventNewsDto DraftDto()
+    {
+        return new UpdateEventNewsDto { Status = Status.Draft };
+    }
+
+    private static UpdateEventNewsDto MatchingDto(EventNewsEntity eventNews)
+    {
+        return new UpdateEventNewsDto
+        {
+            Resource = eventNews.Resource,
+            PublishedAt = eventNews.PublishedAt,
+            Status = eventNews.Status,
+            PreviewImageId = eventNews.PreviewImageId,
+            BackgroundImageId = eventNews.BackgroundImageId,
+            CategoryIds = eventNews.Categories.Select(category => category.Id).ToList(),
+            Localizations = eventNews.Localizations.Select(localization => new CreateEventNewsLocalizationDto
+            {
+                LanguageId = localization.LanguageId,
+                Title = localization.Title,
+                Description = localization.Description
+            }).ToList()
+        };
+    }
+
+    private static EventNewsCategory Category(long id)
+    {
+        return new EventNewsCategory { Id = id, Name = $"Category {id}" };
+    }
+
+    private static Image Image(long id)
+    {
+        return new Image { Id = id, BlobName = $"image-{id}", MimeType = "image/png" };
+    }
+
+    private static LocalizationLanguage Language(long id)
+    {
+        return new LocalizationLanguage { Id = id, Code = $"l{id}", Name = $"Language {id}" };
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/UpdateEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/UpdateEventNewsTests.cs
@@ -255,6 +255,36 @@ public class UpdateEventNewsTests
     }
 
     [Fact]
+    public async Task Handle_WhenSlugCollisionsExhaustRetryLimit_PropagatesFinalException()
+    {
+        var eventNews = ExistingEventNews();
+        var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");
+        var handler = CreateHandler(eventNews);
+        _repositoryWrapper.SetupSequence(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(exception)
+            .ThrowsAsync(exception)
+            .ThrowsAsync(exception);
+        _repositoryWrapper.Setup(wrapper => wrapper.EventNewsRepository.ExistsAsync(
+                It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(true);
+        _slugService.SetupSequence(service => service.GenerateUniqueEventNewsSlugAsync(
+                10,
+                "Updated Event Title",
+                CancellationToken.None))
+            .ReturnsAsync("updated-event-title")
+            .ReturnsAsync("updated-event-title-1")
+            .ReturnsAsync("updated-event-title-2");
+
+        var actualException = await Assert.ThrowsAsync<DbUpdateException>(() => handler.Handle(
+            new UpdateEventNewsCommand(10, PublishedDto()),
+            CancellationToken.None));
+
+        Assert.Same(exception, actualException);
+        Assert.Equal("updated-event-title-2", eventNews.Slug);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Exactly(3));
+    }
+
+    [Fact]
     public async Task Handle_UniqueConstraintOnNonSlugColumn_PropagatesException()
     {
         var exception = SqlExceptionFactory.CreateDbUpdateException(2601, "Unique constraint violation");

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/UpdateEventNewsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/UpdateEventNewsValidatorTests.cs
@@ -1,0 +1,47 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Update;
+using VictoryCenter.BLL.DTOs.Admin.EventNews;
+using VictoryCenter.BLL.Validators.EventNews;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.EventNews;
+
+public class UpdateEventNewsValidatorTests
+{
+    private readonly UpdateEventNewsValidator _validator = new(new BaseEventNewsValidator());
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_ShouldHaveError_WhenIdIsNotPositive(long id)
+    {
+        var command = new UpdateEventNewsCommand(id, new UpdateEventNewsDto { Status = Status.Draft });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(item => item.Id);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveErrors_WhenPublishedFieldsAreMissing()
+    {
+        var command = new UpdateEventNewsCommand(1, new UpdateEventNewsDto { Status = Status.Published });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(item => item.EventNews.PublishedAt);
+        result.ShouldHaveValidationErrorFor(item => item.EventNews.PreviewImageId);
+        result.ShouldHaveValidationErrorFor(item => item.EventNews.CategoryIds);
+        result.ShouldHaveValidationErrorFor(item => item.EventNews.Localizations);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveErrors_WhenDraftIsEmpty()
+    {
+        var command = new UpdateEventNewsCommand(1, new UpdateEventNewsDto { Status = Status.Draft });
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/UpdateEventNewsValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/EventNews/UpdateEventNewsValidatorTests.cs
@@ -36,6 +36,16 @@ public class UpdateEventNewsValidatorTests
     }
 
     [Fact]
+    public void Validate_ShouldHaveError_WhenEventNewsIsNull()
+    {
+        var command = new UpdateEventNewsCommand(1, null!);
+
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(item => item.EventNews);
+    }
+
+    [Fact]
     public void Validate_ShouldNotHaveErrors_WhenDraftIsEmpty()
     {
         var command = new UpdateEventNewsCommand(1, new UpdateEventNewsDto { Status = Status.Draft });

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Update;
 using VictoryCenter.BLL.DTOs.Admin.EventNews;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -11,5 +12,15 @@ public class EventNewsController : AuthorizedApiController
     public async Task<IActionResult> CreateEventNews([FromBody] CreateEventNewsDto createEventNewsDto)
     {
         return HandleResult(await Mediator.Send(new CreateEventNewsCommand(createEventNewsDto)));
+    }
+
+    [HttpPut("{id:long}")]
+    [ProducesResponseType(typeof(EventNewsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateEventNews(long id, [FromBody] UpdateEventNewsDto updateEventNewsDto)
+    {
+        return HandleResult(await Mediator.Send(new UpdateEventNewsCommand(id, updateEventNewsDto)));
     }
 }


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to update event news, including content, images, categories, localizations, publication status, and slugs.
  * Added validation for update requests, including IDs, required published content, categories, images, and languages.
  * Added automatic slug conflict handling during updates.

* **Bug Fixes**
  * Empty drafts now clear associated content and are hidden from public view.

* **Tests**
  * Added comprehensive coverage for successful updates, validation, authorization, missing data, idempotency, drafts, and slug conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->