### PR TITLE
Implement admin delete event/news api

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Delete/DeleteEventNewsCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Delete/DeleteEventNewsCommand.cs
@@ -1,0 +1,6 @@
+using FluentResults;
+using MediatR;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNews.Delete;
+
+public record DeleteEventNewsCommand(long Id) : IRequest<Result<long>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Delete/DeleteEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Delete/DeleteEventNewsHandler.cs
@@ -1,0 +1,53 @@
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.BLL.Commands.Admin.EventNews.Delete;
+
+public class DeleteEventNewsHandler : IRequestHandler<DeleteEventNewsCommand, Result<long>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public DeleteEventNewsHandler(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<long>> Handle(
+        DeleteEventNewsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var eventNews = await _repositoryWrapper.EventNewsRepository.GetFirstOrDefaultAsync(
+            new QueryOptions<EventNewsEntity>
+            {
+                Filter = entity => entity.Id == request.Id,
+                Include = query => query
+                    .Include(entity => entity.Categories)
+                    .Include(entity => entity.Localizations),
+                AsNoTracking = false,
+                AsSplitQuery = true
+            });
+
+        if (eventNews is null)
+        {
+            return Result.Fail<long>(ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
+        }
+
+        _repositoryWrapper.EventNewsRepository.Delete(eventNews);
+
+        try
+        {
+            return await _repositoryWrapper.SaveChangesAsync() > 0
+                ? Result.Ok(eventNews.Id)
+                : Result.Fail<long>(ErrorMessagesConstants.FailedToDeleteEntity(typeof(EventNewsEntity)));
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return Result.Fail<long>(ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Delete/DeleteEventNewsHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/EventNews/Delete/DeleteEventNewsHandler.cs
@@ -47,7 +47,13 @@ public class DeleteEventNewsHandler : IRequestHandler<DeleteEventNewsCommand, Re
         }
         catch (DbUpdateConcurrencyException)
         {
-            return Result.Fail<long>(ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
+            if (!await _repositoryWrapper.EventNewsRepository.ExistsAsync(
+                    entity => entity.Id == request.Id))
+            {
+                return Result.Fail<long>(ErrorMessagesConstants.NotFound(request.Id, typeof(EventNewsEntity)));
+            }
+
+            throw;
         }
     }
 }

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Delete/DeleteEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Delete/DeleteEventNewsTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.EventNews.Delete;
+
+public class DeleteEventNewsTests : BaseTestClass
+{
+    private const string EndpointUri = "/api/EventNews";
+
+    public DeleteEventNewsTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task DeleteEventNews_ShouldDeleteAggregateAndPreserveSharedEntities()
+    {
+        const long eventNewsId = 1;
+        const long imageId = 1;
+        const long languageId = 1;
+        var eventNews = await Fixture.DbContext.EventNews
+            .Include(entity => entity.Categories)
+            .SingleAsync(entity => entity.Id == eventNewsId);
+        var categoryIds = eventNews.Categories.Select(category => category.Id).ToList();
+
+        eventNews.PreviewImageId = imageId;
+        eventNews.Localizations.Add(new EventNewsLocalization
+        {
+            EntityId = eventNewsId,
+            LanguageId = languageId,
+            Title = "Community Support Event",
+            Description = "Details about the community support event",
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+        await Fixture.DbContext.SaveChangesAsync();
+        Fixture.DbContext.ChangeTracker.Clear();
+
+        var response = await Fixture.HttpClient.DeleteAsync($"{EndpointUri}/{eventNewsId}");
+        var deletedId = await response.Content.ReadFromJsonAsync<long>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(eventNewsId, deletedId);
+
+        Fixture.DbContext.ChangeTracker.Clear();
+        Assert.False(await Fixture.DbContext.EventNews
+            .AsNoTracking()
+            .AnyAsync(entity => entity.Id == eventNewsId));
+        Assert.False(await Fixture.DbContext.EventNewsLocalizations
+            .AsNoTracking()
+            .AnyAsync(localization => localization.EntityId == eventNewsId));
+        Assert.False(await Fixture.DbContext
+            .Set<Dictionary<string, object>>("EventNewsEventNewsCategory")
+            .AsNoTracking()
+            .AnyAsync(join => EF.Property<long>(join, "EventsNewsId") == eventNewsId));
+        Assert.True(await Fixture.DbContext.Images
+            .AsNoTracking()
+            .AnyAsync(image => image.Id == imageId));
+        Assert.True(await Fixture.DbContext.LocalizationLanguages
+            .AsNoTracking()
+            .AnyAsync(language => language.Id == languageId));
+        Assert.Equal(
+            categoryIds.Count,
+            await Fixture.DbContext.EventNewsCategories
+                .AsNoTracking()
+                .CountAsync(category => categoryIds.Contains(category.Id)));
+    }
+
+    [Fact]
+    public async Task DeleteEventNews_ShouldDeletePublishedEventNews()
+    {
+        const long publishedEventNewsId = 2;
+
+        var response = await Fixture.HttpClient.DeleteAsync($"{EndpointUri}/{publishedEventNewsId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(publishedEventNewsId, await response.Content.ReadFromJsonAsync<long>());
+        Fixture.DbContext.ChangeTracker.Clear();
+        Assert.False(await Fixture.DbContext.EventNews
+            .AsNoTracking()
+            .AnyAsync(entity => entity.Id == publishedEventNewsId));
+    }
+
+    [Fact]
+    public async Task DeleteEventNews_ShouldReturnNotFound_WhenEventNewsDoesNotExist()
+    {
+        const long missingId = long.MaxValue;
+
+        var response = await Fixture.HttpClient.DeleteAsync($"{EndpointUri}/{missingId}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteEventNews_ShouldReturnNotFound_WhenRequestIsRepeated()
+    {
+        const long eventNewsId = 1;
+
+        var firstResponse = await Fixture.HttpClient.DeleteAsync($"{EndpointUri}/{eventNewsId}");
+        var secondResponse = await Fixture.HttpClient.DeleteAsync($"{EndpointUri}/{eventNewsId}");
+
+        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, secondResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteEventNews_ShouldRequireAuthorization()
+    {
+        using var anonymousClient = Fixture.Factory.CreateClient();
+
+        var response = await anonymousClient.DeleteAsync($"{EndpointUri}/1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.True(await Fixture.DbContext.EventNews
+            .AsNoTracking()
+            .AnyAsync(entity => entity.Id == 1));
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Delete/DeleteEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/EventNews/Delete/DeleteEventNewsTests.cs
@@ -52,10 +52,9 @@ public class DeleteEventNewsTests : BaseTestClass
         Assert.False(await Fixture.DbContext.EventNewsLocalizations
             .AsNoTracking()
             .AnyAsync(localization => localization.EntityId == eventNewsId));
-        Assert.False(await Fixture.DbContext
-            .Set<Dictionary<string, object>>("EventNewsEventNewsCategory")
+        Assert.False(await Fixture.DbContext.EventNewsCategories
             .AsNoTracking()
-            .AnyAsync(join => EF.Property<long>(join, "EventsNewsId") == eventNewsId));
+            .AnyAsync(category => category.EventsNews.Any(entity => entity.Id == eventNewsId)));
         Assert.True(await Fixture.DbContext.Images
             .AsNoTracking()
             .AnyAsync(image => image.Id == imageId));

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/DeleteEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/DeleteEventNewsTests.cs
@@ -6,6 +6,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
 using VictoryCenter.DAL.Repositories.Options;
 using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+using EventNewsPredicate = System.Linq.Expressions.Expression<System.Func<VictoryCenter.DAL.Entities.EventNews, bool>>;
 
 namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNews;
 
@@ -100,6 +101,9 @@ public class DeleteEventNewsTests
         _repositoryWrapper
             .Setup(wrapper => wrapper.SaveChangesAsync())
             .ThrowsAsync(new DbUpdateConcurrencyException());
+        _eventNewsRepository
+            .Setup(repository => repository.ExistsAsync(It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(false);
         var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
 
         var result = await handler.Handle(new DeleteEventNewsCommand(eventNews.Id), CancellationToken.None);
@@ -111,7 +115,27 @@ public class DeleteEventNewsTests
     }
 
     [Fact]
-    public async Task Handle_ShouldPropagateUnexpectedDatabaseException()
+    public async Task Handle_ShouldPropagateConcurrencyException_WhenEventNewsStillExists()
+    {
+        var eventNews = EventNews(10);
+        var exception = new DbUpdateConcurrencyException();
+        SetupEventNews(eventNews);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(exception);
+        _eventNewsRepository
+            .Setup(repository => repository.ExistsAsync(It.IsAny<EventNewsPredicate>()))
+            .ReturnsAsync(true);
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        var actualException = await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() =>
+            handler.Handle(new DeleteEventNewsCommand(eventNews.Id), CancellationToken.None));
+
+        Assert.Same(exception, actualException);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldPropagateNonConcurrencyDatabaseException()
     {
         var eventNews = EventNews(10);
         SetupEventNews(eventNews);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/DeleteEventNewsTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/EventNews/DeleteEventNewsTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Delete;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Interfaces.EventNews;
+using VictoryCenter.DAL.Repositories.Options;
+using EventNewsEntity = VictoryCenter.DAL.Entities.EventNews;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.EventNews;
+
+public class DeleteEventNewsTests
+{
+    private readonly Mock<IEventNewsRepository> _eventNewsRepository = new();
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapper = new();
+
+    public DeleteEventNewsTests()
+    {
+        _repositoryWrapper
+            .SetupGet(wrapper => wrapper.EventNewsRepository)
+            .Returns(_eventNewsRepository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDeleteEventNewsAndReturnId()
+    {
+        var eventNews = EventNews(10);
+        SetupEventNews(eventNews);
+        _repositoryWrapper.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(1);
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCommand(eventNews.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(eventNews.Id, result.Value);
+        _eventNewsRepository.Verify(repository => repository.Delete(eventNews), Times.Once);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUseTrackedAggregateLookupForRequestedId()
+    {
+        const long eventNewsId = 10;
+        var eventNews = EventNews(eventNewsId);
+        SetupEventNews(eventNews);
+        _repositoryWrapper.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(1);
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        await handler.Handle(new DeleteEventNewsCommand(eventNewsId), CancellationToken.None);
+
+        _eventNewsRepository.Verify(
+            repository => repository.GetFirstOrDefaultAsync(
+                It.Is<QueryOptions<EventNewsEntity>>(options =>
+                    !options.AsNoTracking
+                    && options.AsSplitQuery
+                    && options.Include != null
+                    && options.Filter != null
+                    && options.Filter.Compile()(eventNews))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnNotFound_WhenEventNewsDoesNotExist()
+    {
+        const long eventNewsId = 10;
+        SetupEventNews(null);
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCommand(eventNewsId), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(eventNewsId, typeof(EventNewsEntity)),
+            result.Errors[0].Message);
+        _eventNewsRepository.Verify(repository => repository.Delete(It.IsAny<EventNewsEntity>()), Times.Never);
+        _repositoryWrapper.Verify(wrapper => wrapper.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailure_WhenSaveDoesNotDeleteRow()
+    {
+        var eventNews = EventNews(10);
+        SetupEventNews(eventNews);
+        _repositoryWrapper.Setup(wrapper => wrapper.SaveChangesAsync()).ReturnsAsync(0);
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCommand(eventNews.Id), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToDeleteEntity(typeof(EventNewsEntity)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnNotFound_WhenEventNewsIsDeletedConcurrently()
+    {
+        var eventNews = EventNews(10);
+        SetupEventNews(eventNews);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        var result = await handler.Handle(new DeleteEventNewsCommand(eventNews.Id), CancellationToken.None);
+
+        Assert.True(result.IsFailed);
+        Assert.Equal(
+            ErrorMessagesConstants.NotFound(eventNews.Id, typeof(EventNewsEntity)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldPropagateUnexpectedDatabaseException()
+    {
+        var eventNews = EventNews(10);
+        SetupEventNews(eventNews);
+        _repositoryWrapper
+            .Setup(wrapper => wrapper.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException("Unexpected database failure"));
+        var handler = new DeleteEventNewsHandler(_repositoryWrapper.Object);
+
+        await Assert.ThrowsAsync<DbUpdateException>(() =>
+            handler.Handle(new DeleteEventNewsCommand(eventNews.Id), CancellationToken.None));
+    }
+
+    private void SetupEventNews(EventNewsEntity? eventNews)
+    {
+        _eventNewsRepository
+            .Setup(repository => repository.GetFirstOrDefaultAsync(
+                It.IsAny<QueryOptions<EventNewsEntity>>()))
+            .ReturnsAsync(eventNews);
+    }
+
+    private static EventNewsEntity EventNews(long id)
+    {
+        return new EventNewsEntity
+        {
+            Id = id,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/EventNewsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using VictoryCenter.BLL.Commands.Admin.EventNews.Create;
+using VictoryCenter.BLL.Commands.Admin.EventNews.Delete;
 using VictoryCenter.BLL.DTOs.Admin.EventNews;
 using VictoryCenter.WebAPI.Controllers.Common;
 
@@ -11,5 +12,15 @@ public class EventNewsController : AuthorizedApiController
     public async Task<IActionResult> CreateEventNews([FromBody] CreateEventNewsDto createEventNewsDto)
     {
         return HandleResult(await Mediator.Send(new CreateEventNewsCommand(createEventNewsDto)));
+    }
+
+    [HttpDelete("{id:long}")]
+    [ProducesResponseType(typeof(long), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteEventNews(long id)
+    {
+        return HandleResult(await Mediator.Send(new DeleteEventNewsCommand(id)));
     }
 }


### PR DESCRIPTION
dev
## JIRA

* [Main JIRA ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)


## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

ToDo

## Summary of change

ToDo

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorized administrators can delete event news items.
  * Deletion removes associated content and localizations while preserving shared resources.
  * Published event news can also be deleted.
  * Clear not-found and failure responses are returned for invalid or repeated deletion attempts.

* **Tests**
  * Added coverage for successful deletion, authorization, missing items, concurrency conflicts, shared resources, and database failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->