### PR TITLE
Feature/issue-1855 [Programs] Open Modal Window to translate a program category

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Create/CreateHippotherapyProgramCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Create/CreateHippotherapyProgramCategoryLocalizationCommand.cs
@@ -1,0 +1,9 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Create;
+
+public record CreateHippotherapyProgramCategoryLocalizationCommand(
+    CreateHippotherapyProgramCategoryLocalizationDto CreateHippotherapyProgramCategoryLocalizationDto)
+    : IRequest<Result<HippotherapyProgramCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Create/CreateHippotherapyProgramCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Create/CreateHippotherapyProgramCategoryLocalizationHandler.cs
@@ -1,0 +1,62 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Create;
+
+public class CreateHippotherapyProgramCategoryLocalizationHandler
+    : IRequestHandler<CreateHippotherapyProgramCategoryLocalizationCommand, Result<HippotherapyProgramCategoryLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization> _localizationService;
+    private readonly IValidator<CreateHippotherapyProgramCategoryLocalizationCommand> _validator;
+
+    public CreateHippotherapyProgramCategoryLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization> localizationService,
+        IValidator<CreateHippotherapyProgramCategoryLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<HippotherapyProgramCategoryLocalizationDto>> Handle(
+        CreateHippotherapyProgramCategoryLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var entity = _mapper.Map<HippotherapyProgramCategoryLocalization>(request.CreateHippotherapyProgramCategoryLocalizationDto);
+            var result = await _localizationService.CreateEntityLocalizationAsync(entity);
+            var responseDto = _mapper.Map<HippotherapyProgramCategoryLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToCreateEntity(typeof(HippotherapyProgramCategoryLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(HippotherapyProgramCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Update/UpdateHippotherapyProgramCategoryLocalizationCommand.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Update/UpdateHippotherapyProgramCategoryLocalizationCommand.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Update;
+
+public record UpdateHippotherapyProgramCategoryLocalizationCommand(
+    UpdateHippotherapyProgramCategoryLocalizationDto UpdateHippotherapyProgramCategoryLocalizationDto,
+    long EntityId,
+    long LanguageId)
+    : IRequest<Result<HippotherapyProgramCategoryLocalizationDto>>;

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Update/UpdateHippotherapyProgramCategoryLocalizationHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/Localization/HippotherapyProgramCategories/Update/UpdateHippotherapyProgramCategoryLocalizationHandler.cs
@@ -1,0 +1,64 @@
+using AutoMapper;
+using FluentResults;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Update;
+
+public class UpdateHippotherapyProgramCategoryLocalizationHandler
+    : IRequestHandler<UpdateHippotherapyProgramCategoryLocalizationCommand, Result<HippotherapyProgramCategoryLocalizationDto>>
+{
+    private readonly IMapper _mapper;
+    private readonly ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization> _localizationService;
+    private readonly IValidator<UpdateHippotherapyProgramCategoryLocalizationCommand> _validator;
+
+    public UpdateHippotherapyProgramCategoryLocalizationHandler(
+        IMapper mapper,
+        ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization> localizationService,
+        IValidator<UpdateHippotherapyProgramCategoryLocalizationCommand> validator)
+    {
+        _mapper = mapper;
+        _localizationService = localizationService;
+        _validator = validator;
+    }
+
+    public async Task<Result<HippotherapyProgramCategoryLocalizationDto>> Handle(
+        UpdateHippotherapyProgramCategoryLocalizationCommand request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _validator.ValidateAndThrowAsync(request, cancellationToken);
+            var entity = _mapper.Map<HippotherapyProgramCategoryLocalization>(request.UpdateHippotherapyProgramCategoryLocalizationDto);
+            entity.EntityId = request.EntityId;
+            entity.LanguageId = request.LanguageId;
+            var result = await _localizationService.UpdateEntityLocalizationAsync(entity);
+            var responseDto = _mapper.Map<HippotherapyProgramCategoryLocalizationDto>(result);
+            return Result.Ok(responseDto);
+        }
+        catch (KeyNotFoundException knfex)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(knfex.Message);
+        }
+        catch (InvalidOperationException)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntity(typeof(HippotherapyProgramCategoryLocalization)));
+        }
+        catch (ValidationException vex)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(vex.Errors.Select(e => e.ErrorMessage));
+        }
+        catch (DbUpdateException)
+        {
+            return Result.Fail<HippotherapyProgramCategoryLocalizationDto>(
+                ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramCategoryLocalization)));
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Constants/Localization/HippotherapyProgramCategoryLocalizationConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/Localization/HippotherapyProgramCategoryLocalizationConstants.cs
@@ -1,0 +1,7 @@
+namespace VictoryCenter.BLL.Constants.Localization;
+
+public static class HippotherapyProgramCategoryLocalizationConstants
+{
+    public static readonly int NameMinLength = HippotherapyProgramCategoryConstants.MinNameLength;
+    public static readonly int NameMaxLength = HippotherapyProgramCategoryConstants.MaxNameLength;
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramCategories/HippotherapyProgramCategoryDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/HippotherapyProgramCategories/HippotherapyProgramCategoryDto.cs
@@ -1,4 +1,5 @@
 using VictoryCenter.BLL.DTOs.Admin.HippotherapyPrograms;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
 
 namespace VictoryCenter.BLL.DTOs.Admin.HippotherapyProgramCategories;
 
@@ -8,4 +9,5 @@ public record HippotherapyProgramCategoryDto
     public string Name { get; set; } = null!;
     public DateTimeOffset CreatedAt { get; init; }
     public List<HippotherapyProgramDto> Programs { get; init; } = [];
+    public List<HippotherapyProgramCategoryLocalizationDto> Localizations { get; init; } = [];
 }

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryLocalizationDto.cs
@@ -1,0 +1,10 @@
+using VictoryCenter.BLL.DTOs.Admin.Localization.Base;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+public class CreateHippotherapyProgramCategoryLocalizationDto
+    : UpdateHippotherapyProgramCategoryLocalizationDto, ILocalizationIdentity
+{
+    public long EntityId { get; init; }
+    public long LanguageId { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramCategories/HippotherapyProgramCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramCategories/HippotherapyProgramCategoryLocalizationDto.cs
@@ -1,0 +1,12 @@
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+public class HippotherapyProgramCategoryLocalizationDto
+{
+    public long EntityId { get; init; }
+    public LocalizationInfoDto LocalizationInfoDto { get; init; } = null!;
+    public string Name { get; set; } = null!;
+    public TranslationStatus TranslationStatus { get; init; }
+}

--- a/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryLocalizationDto.cs
+++ b/VictoryCenter/VictoryCenter.BLL/DTOs/Admin/Localization/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryLocalizationDto.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+public class UpdateHippotherapyProgramCategoryLocalizationDto
+{
+    public string Name { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/HippotherapyProgramCategories/HippotherapyProgramCategoryLocalizationProfile.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Mapping/Localization/HippotherapyProgramCategories/HippotherapyProgramCategoryLocalizationProfile.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Enums;
+
+namespace VictoryCenter.BLL.Mapping.Localization.HippotherapyProgramCategories;
+
+public class HippotherapyProgramCategoryLocalizationProfile : Profile
+{
+    public HippotherapyProgramCategoryLocalizationProfile()
+    {
+        CreateMap<CreateHippotherapyProgramCategoryLocalizationDto, HippotherapyProgramCategoryLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.MapFrom(_ => TranslationStatus.Relevant));
+
+        CreateMap<UpdateHippotherapyProgramCategoryLocalizationDto, HippotherapyProgramCategoryLocalization>()
+            .ForMember(dest => dest.TranslationStatus, opt => opt.Ignore());
+
+        CreateMap<HippotherapyProgramCategoryLocalization, HippotherapyProgramCategoryLocalizationDto>()
+            .ForMember(dest => dest.LocalizationInfoDto, opt => opt.MapFrom(src => src.Language));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyProgramCategories/GetHippotherapyProgramCategoriesHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/HippotherapyProgramCategories/GetHippotherapyProgramCategoriesHandler.cs
@@ -26,6 +26,7 @@ public class GetHippotherapyProgramCategoriesHandler : IRequestHandler<GetHippot
         {
             Include = programCategory => programCategory
                 .Include(p => p.Programs)
+                .Include(p => p.Localizations).ThenInclude(l => l.Language)
         });
         var mapped = _mapper.Map<IEnumerable<HippotherapyProgramCategoryDto>>(programCategories).ToList();
 

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyProgramCategories/GetByEntityId/GetHippotherapyProgramCategoryLocalizationByEntityIdHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyProgramCategories/GetByEntityId/GetHippotherapyProgramCategoryLocalizationByEntityIdHandler.cs
@@ -1,0 +1,39 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.HippotherapyProgramCategories.GetByEntityId;
+
+public class GetHippotherapyProgramCategoryLocalizationByEntityIdHandler
+    : IRequestHandler<GetHippotherapyProgramCategoryLocalizationByEntityIdQuery, Result<List<HippotherapyProgramCategoryLocalizationDto>>>
+{
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public GetHippotherapyProgramCategoryLocalizationByEntityIdHandler(IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<List<HippotherapyProgramCategoryLocalizationDto>>> Handle(
+        GetHippotherapyProgramCategoryLocalizationByEntityIdQuery request,
+        CancellationToken cancellationToken)
+    {
+        var queryOptions = new QueryOptions<HippotherapyProgramCategoryLocalization>
+        {
+            Filter = l => l.EntityId == request.Id,
+            Include = l => l.Include(loc => loc.Language),
+            AsNoTracking = true,
+        };
+
+        var entities = await _repositoryWrapper.HippotherapyProgramCategoryLocalizationsRepository.GetAllAsync(queryOptions);
+        var responseDto = _mapper.Map<List<HippotherapyProgramCategoryLocalizationDto>>(entities);
+        return Result.Ok(responseDto);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyProgramCategories/GetByEntityId/GetHippotherapyProgramCategoryLocalizationByEntityIdQuery.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Admin/Localization/HippotherapyProgramCategories/GetByEntityId/GetHippotherapyProgramCategoryLocalizationByEntityIdQuery.cs
@@ -1,0 +1,8 @@
+using FluentResults;
+using MediatR;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+namespace VictoryCenter.BLL.Queries.Admin.Localization.HippotherapyProgramCategories.GetByEntityId;
+
+public record GetHippotherapyProgramCategoryLocalizationByEntityIdQuery(long Id)
+    : IRequest<Result<List<HippotherapyProgramCategoryLocalizationDto>>>;

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramCategories/BaseHippotherapyProgramCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramCategories/BaseHippotherapyProgramCategoryLocalizationValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+
+namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramCategories;
+
+public class BaseHippotherapyProgramCategoryLocalizationValidator
+    : AbstractValidator<UpdateHippotherapyProgramCategoryLocalizationDto>
+{
+    public BaseHippotherapyProgramCategoryLocalizationValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage(ErrorMessagesConstants.PropertyIsRequired(nameof(UpdateHippotherapyProgramCategoryLocalizationDto.Name)))
+            .MinimumLength(HippotherapyProgramCategoryLocalizationConstants.NameMinLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMinimumLengthOfNCharacters(
+                nameof(UpdateHippotherapyProgramCategoryLocalizationDto.Name),
+                HippotherapyProgramCategoryLocalizationConstants.NameMinLength))
+            .MaximumLength(HippotherapyProgramCategoryLocalizationConstants.NameMaxLength)
+            .WithMessage(ErrorMessagesConstants.PropertyMustHaveAMaximumLengthOfNCharacters(
+                nameof(UpdateHippotherapyProgramCategoryLocalizationDto.Name),
+                HippotherapyProgramCategoryLocalizationConstants.NameMaxLength));
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryLocalizationValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Create;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.Validators.Localization.Base;
+
+namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramCategories;
+
+public class CreateHippotherapyProgramCategoryLocalizationValidator
+    : AbstractValidator<CreateHippotherapyProgramCategoryLocalizationCommand>
+{
+    public CreateHippotherapyProgramCategoryLocalizationValidator(
+        BaseHippotherapyProgramCategoryLocalizationValidator baseValidator)
+    {
+        RuleFor(c => c.CreateHippotherapyProgramCategoryLocalizationDto)
+            .SetValidator(new LocalizationIdentityValidator<CreateHippotherapyProgramCategoryLocalizationDto>());
+        RuleFor(c => c.CreateHippotherapyProgramCategoryLocalizationDto)
+            .SetValidator(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryLocalizationValidator.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Validators/Localization/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryLocalizationValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Update;
+
+namespace VictoryCenter.BLL.Validators.Localization.HippotherapyProgramCategories;
+
+public class UpdateHippotherapyProgramCategoryLocalizationValidator
+    : AbstractValidator<UpdateHippotherapyProgramCategoryLocalizationCommand>
+{
+    public UpdateHippotherapyProgramCategoryLocalizationValidator(
+        BaseHippotherapyProgramCategoryLocalizationValidator baseValidator)
+    {
+        RuleFor(x => x.UpdateHippotherapyProgramCategoryLocalizationDto)
+            .SetValidator(baseValidator);
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/HippotherapyProgramCategoryLocalizationConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/Localization/HippotherapyProgramCategoryLocalizationConfig.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.DAL.Data.EntityTypeConfigurations.Localization;
+
+public class HippotherapyProgramCategoryLocalizationConfig
+    : EntityLocalizationConfig<HippotherapyProgramCategoryLocalization, HippotherapyProgramCategory>
+{
+    public override void Configure(EntityTypeBuilder<HippotherapyProgramCategoryLocalization> entity)
+    {
+        base.Configure(entity);
+
+        entity.Property(e => e.Name)
+            .IsRequired();
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/VictoryCenterDbContext.cs
@@ -36,6 +36,8 @@ public class VictoryCenterDbContext : IdentityDbContext<AdminUser, IdentityRole<
 
     public DbSet<HippotherapyProgramCategory> HippotherapyProgramCategories { get; set; }
 
+    public DbSet<HippotherapyProgramCategoryLocalization> HippotherapyProgramCategoryLocalizations { get; set; }
+
     public DbSet<HippotherapyProgram> HippotherapyPrograms { get; set; }
 
     public DbSet<HippotherapyProgramSection> HippotherapyProgramSections { get; set; }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramCategory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramCategory.cs
@@ -1,12 +1,17 @@
 using VictoryCenter.DAL.Data.BaseEntity;
+using VictoryCenter.DAL.Entities.Interfaces;
+using VictoryCenter.DAL.Entities.Localization;
 
 namespace VictoryCenter.DAL.Entities;
 
-public class HippotherapyProgramCategory : BaseEntity
+public class HippotherapyProgramCategory : BaseEntity, ITranslatedEntity<HippotherapyProgramCategoryLocalization>
 {
     public string Name { get; set; } = null!;
     public ICollection<HippotherapyProgram> Programs { get; set; } = new List<HippotherapyProgram>();
 
     public ICollection<ReportProgramExpendituresRecord> ReportProgramExpendituresRecords { get; set; } =
         new List<ReportProgramExpendituresRecord>();
+
+    public ICollection<HippotherapyProgramCategoryLocalization> Localizations { get; set; } =
+        new List<HippotherapyProgramCategoryLocalization>();
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramCategory.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/HippotherapyProgramCategory.cs
@@ -12,6 +12,5 @@ public class HippotherapyProgramCategory : BaseEntity, ITranslatedEntity<Hippoth
     public ICollection<ReportProgramExpendituresRecord> ReportProgramExpendituresRecords { get; set; } =
         new List<ReportProgramExpendituresRecord>();
 
-    public ICollection<HippotherapyProgramCategoryLocalization> Localizations { get; set; } =
-        new List<HippotherapyProgramCategoryLocalization>();
+    public ICollection<HippotherapyProgramCategoryLocalization> Localizations { get; set; } = [];
 }

--- a/VictoryCenter/VictoryCenter.DAL/Entities/Localization/HippotherapyProgramCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Entities/Localization/HippotherapyProgramCategoryLocalization.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.DAL.Entities.Localization;
+
+public class HippotherapyProgramCategoryLocalization : LocalizationBase<HippotherapyProgramCategory>
+{
+    public string Name { get; set; } = null!;
+}

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260811065205_AddHippotherapyProgramCategoryLocalization.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260811065205_AddHippotherapyProgramCategoryLocalization.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811065205_AddHippotherapyProgramCategoryLocalization")]
+    partial class AddHippotherapyProgramCategoryLocalization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260811065205_AddHippotherapyProgramCategoryLocalization.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260811065205_AddHippotherapyProgramCategoryLocalization.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHippotherapyProgramCategoryLocalization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "HippotherapyProgramCategoryLocalizations",
+                columns: table => new
+                {
+                    EntityId = table.Column<long>(type: "bigint", nullable: false),
+                    LanguageId = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    TranslationStatus = table.Column<int>(type: "int", nullable: false, defaultValue: 1),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_HippotherapyProgramCategoryLocalizations", x => new { x.EntityId, x.LanguageId });
+                    table.ForeignKey(
+                        name: "FK_HippotherapyProgramCategoryLocalizations_HippotherapyProgramCategories_EntityId",
+                        column: x => x.EntityId,
+                        principalTable: "HippotherapyProgramCategories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_HippotherapyProgramCategoryLocalizations_LocalizationLanguages_LanguageId",
+                        column: x => x.LanguageId,
+                        principalTable: "LocalizationLanguages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HippotherapyProgramCategoryLocalizations_LanguageId",
+                table: "HippotherapyProgramCategoryLocalizations",
+                column: "LanguageId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "HippotherapyProgramCategoryLocalizations");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -10,6 +10,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.HistorySections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyPrograms;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.PdfSection;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
@@ -80,6 +81,8 @@ public interface IRepositoryWrapper
     ITeamCategoryLocalizationsRepository TeamCategoryLocalizationsRepository { get; }
 
     IReportFundsExpendituresCategoryLocalizationsRepository ReportFundsExpendituresCategoryLocalizationsRepository { get; }
+
+    IHippotherapyProgramCategoryLocalizationsRepository HippotherapyProgramCategoryLocalizationsRepository { get; }
 
     IReportFundsExpendituresSettingsLocalizationsRepository ReportFundsExpendituresSettingsLocalizationsRepository { get; }
 

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/HippotherapyProgramCategories/IHippotherapyProgramCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Interfaces/Localization/HippotherapyProgramCategories/IHippotherapyProgramCategoryLocalizationsRepository.cs
@@ -1,0 +1,9 @@
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+
+namespace VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgramCategories;
+
+public interface IHippotherapyProgramCategoryLocalizationsRepository
+    : IRepositoryBase<HippotherapyProgramCategoryLocalization>
+{
+}

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -13,6 +13,7 @@ using VictoryCenter.DAL.Repositories.Interfaces.HistorySections;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyPrograms;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.PdfSection;
 using VictoryCenter.DAL.Repositories.Interfaces.Localization.ReportFundsExpendituresCategories;
@@ -44,6 +45,7 @@ using VictoryCenter.DAL.Repositories.Realizations.HistorySections;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.CompanyProfile;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.FaqQuestions;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyPrograms;
+using VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyProgramCategories;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.Languages;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.PdfSection;
 using VictoryCenter.DAL.Repositories.Realizations.Localization.ReportFundsExpendituresCategories;
@@ -128,6 +130,7 @@ public class RepositoryWrapper : IRepositoryWrapper
     private ISupportOptionsRepository? _supportOptionsRepository;
     private ITeamCategoryLocalizationsRepository? _teamCategoryLocalizationsRepository;
     private IReportFundsExpendituresCategoryLocalizationsRepository? _reportFundsExpendituresCategoryLocalizationsRepository;
+    private IHippotherapyProgramCategoryLocalizationsRepository? _hippotherapyProgramCategoryLocalizationsRepository;
     private IReportFundsExpendituresSettingsLocalizationsRepository? _reportFundsExpendituresSettingsLocalizationsRepository;
     private ITeamMemberLocalizationsRepository? _teamMemberLocalizationsRepository;
     private ITeamMembersRepository? _teamMembersRepository;
@@ -257,6 +260,10 @@ public class RepositoryWrapper : IRepositoryWrapper
     public IReportFundsExpendituresCategoryLocalizationsRepository ReportFundsExpendituresCategoryLocalizationsRepository =>
         _reportFundsExpendituresCategoryLocalizationsRepository ??=
             new ReportFundsExpendituresCategoryLocalizationsRepository(_victoryCenterDbContext);
+
+    public IHippotherapyProgramCategoryLocalizationsRepository HippotherapyProgramCategoryLocalizationsRepository =>
+        _hippotherapyProgramCategoryLocalizationsRepository ??=
+            new HippotherapyProgramCategoryLocalizationsRepository(_victoryCenterDbContext);
 
     public IReportFundsExpendituresSettingsLocalizationsRepository ReportFundsExpendituresSettingsLocalizationsRepository =>
         _reportFundsExpendituresSettingsLocalizationsRepository ??=

--- a/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/HippotherapyProgramCategories/HippotherapyProgramCategoryLocalizationsRepository.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Repositories/Realizations/Localization/HippotherapyProgramCategories/HippotherapyProgramCategoryLocalizationsRepository.cs
@@ -1,0 +1,16 @@
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Localization.HippotherapyProgramCategories;
+using VictoryCenter.DAL.Repositories.Realizations.Base;
+
+namespace VictoryCenter.DAL.Repositories.Realizations.Localization.HippotherapyProgramCategories;
+
+public class HippotherapyProgramCategoryLocalizationsRepository
+    : RepositoryBase<HippotherapyProgramCategoryLocalization>,
+      IHippotherapyProgramCategoryLocalizationsRepository
+{
+    public HippotherapyProgramCategoryLocalizationsRepository(VictoryCenterDbContext context)
+        : base(context)
+    {
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/HippotherapyProgramCategoryLocalizations/Create/CreateHippotherapyProgramCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/HippotherapyProgramCategoryLocalizations/Create/CreateHippotherapyProgramCategoryLocalizationTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.HippotherapyProgramCategoryLocalizations.Create;
+
+public class CreateHippotherapyProgramCategoryLocalizationTests : BaseTestClass
+{
+    public CreateHippotherapyProgramCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnOk()
+    {
+        var freshCategory = new HippotherapyProgramCategory
+        {
+            Name = "Fresh Category For Localization",
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        await Fixture.DbContext.HippotherapyProgramCategories.AddAsync(freshCategory);
+        await Fixture.DbContext.SaveChangesAsync();
+
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateHippotherapyProgramCategoryLocalizationDto
+        {
+            EntityId = freshCategory.Id,
+            LanguageId = language.Id,
+            Name = "New Loc Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/HippotherapyProgramCategoryLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnNotFound_WhenEntityDoesNotExist()
+    {
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateHippotherapyProgramCategoryLocalizationDto
+        {
+            EntityId = 999999,
+            LanguageId = language.Id,
+            Name = "Some Loc Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/HippotherapyProgramCategoryLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateLocalization_ShouldReturnBadRequest_WhenNameIsInvalid()
+    {
+        var category = await Fixture.DbContext.HippotherapyProgramCategories.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+        var language = await Fixture.DbContext.LocalizationLanguages.FirstOrDefaultAsync(l => l.Id == 2)
+            ?? throw new InvalidOperationException("Couldn't setup existing language");
+
+        var createDto = new CreateHippotherapyProgramCategoryLocalizationDto
+        {
+            EntityId = category.Id,
+            LanguageId = language.Id,
+            Name = ""
+        };
+        var serializedDto = JsonConvert.SerializeObject(createDto);
+
+        var response = await Fixture.HttpClient.PostAsync(
+            "/api/HippotherapyProgramCategoryLocalizations/",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/HippotherapyProgramCategoryLocalizations/Update/UpdateHippotherapyProgramCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/Localizations/HippotherapyProgramCategoryLocalizations/Update/UpdateHippotherapyProgramCategoryLocalizationTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.IntegrationTests.Utils;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.ControllerTests.Localizations.HippotherapyProgramCategoryLocalizations.Update;
+
+public class UpdateHippotherapyProgramCategoryLocalizationTests : BaseTestClass
+{
+    public UpdateHippotherapyProgramCategoryLocalizationTests(IntegrationTestDbFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnOk()
+    {
+        var localization = await Fixture.DbContext.HippotherapyProgramCategoryLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var updateDto = new UpdateHippotherapyProgramCategoryLocalizationDto
+        {
+            Name = "Updated Loc Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/HippotherapyProgramCategoryLocalizations/{localization.EntityId}/{localization.LanguageId}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnNotFound_WhenLocalizationDoesNotExist()
+    {
+        var updateDto = new UpdateHippotherapyProgramCategoryLocalizationDto
+        {
+            Name = "Updated Loc Name"
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            "/api/HippotherapyProgramCategoryLocalizations/999999/999999",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocalization_ShouldReturnBadRequest_WhenNameIsInvalid()
+    {
+        var localization = await Fixture.DbContext.HippotherapyProgramCategoryLocalizations.FirstOrDefaultAsync()
+            ?? throw new InvalidOperationException("Couldn't setup existing entity");
+
+        var updateDto = new UpdateHippotherapyProgramCategoryLocalizationDto
+        {
+            Name = ""
+        };
+        var serializedDto = JsonConvert.SerializeObject(updateDto);
+
+        var response = await Fixture.HttpClient.PutAsync(
+            $"/api/HippotherapyProgramCategoryLocalizations/{localization.EntityId}/{localization.LanguageId}",
+            new StringContent(serializedDto, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/HippotherapyProgramCategoryLocalizations/HippotherapyProgramCategoryLocalizationsSeeder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/HippotherapyProgramCategoryLocalizations/HippotherapyProgramCategoryLocalizationsSeeder.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using VictoryCenter.DAL.Data;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.IntegrationTests.Utils.Seeders.Localizations.HippotherapyProgramCategoryLocalizations;
+
+public class HippotherapyProgramCategoryLocalizationsSeeder : ISeeder
+{
+    private readonly VictoryCenterDbContext _dbContext;
+    private readonly ILogger<HippotherapyProgramCategoryLocalizationsSeeder> _logger;
+    private readonly List<HippotherapyProgramCategory> _categories = [];
+    private readonly List<HippotherapyProgramCategoryLocalization> _localizations = [];
+
+    public HippotherapyProgramCategoryLocalizationsSeeder(
+        VictoryCenterDbContext dbContext,
+        ILogger<HippotherapyProgramCategoryLocalizationsSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public int Order => (int)SeederExecutionOrder.HippotherapyProgramCategoryLocalizations;
+    public string Name => nameof(HippotherapyProgramCategoryLocalizationsSeeder);
+
+    public async Task<SeederResult> SeedAsync()
+    {
+        try
+        {
+            _categories.AddRange(new List<HippotherapyProgramCategory>
+            {
+                new() { Name = "Localization Test Category 1", CreatedAt = DateTimeOffset.UtcNow },
+                new() { Name = "Localization Test Category 2", CreatedAt = DateTimeOffset.UtcNow },
+            });
+
+            await _dbContext.HippotherapyProgramCategories.AddRangeAsync(_categories);
+            await _dbContext.SaveChangesAsync();
+
+            _localizations.AddRange(new List<HippotherapyProgramCategoryLocalization>
+            {
+                new() { EntityId = _categories[0].Id, LanguageId = 2, Name = "English Name 1", CreatedAt = DateTimeOffset.UtcNow },
+                new() { EntityId = _categories[1].Id, LanguageId = 2, Name = "English Name 2", CreatedAt = DateTimeOffset.UtcNow },
+            });
+
+            await _dbContext.HippotherapyProgramCategoryLocalizations.AddRangeAsync(_localizations);
+            await _dbContext.SaveChangesAsync();
+
+            if (!await VerifyAsync())
+            {
+                throw new InvalidOperationException($"Verification failed for seeder {Name}");
+            }
+
+            return new SeederResult { Success = true, CreatedCount = _localizations.Count };
+        }
+        catch (Exception ex)
+        {
+            await DisposeAsync();
+            _logger.LogError(ex, "Error in seeder {Name}", Name);
+            return new SeederResult { Success = false, ErrorMessage = ex.Message };
+        }
+    }
+
+    public async Task<bool> DisposeAsync()
+    {
+        try
+        {
+            if (_localizations.Count != 0)
+            {
+                _dbContext.HippotherapyProgramCategoryLocalizations.RemoveRange(_localizations);
+                await _dbContext.SaveChangesAsync();
+                _localizations.Clear();
+            }
+
+            if (_categories.Count != 0)
+            {
+                _dbContext.HippotherapyProgramCategories.RemoveRange(_categories);
+                await _dbContext.SaveChangesAsync();
+                _categories.Clear();
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error disposing seeder {Name}", Name);
+            return false;
+        }
+    }
+
+    public async Task<bool> VerifyAsync()
+    {
+        var count = await _dbContext.HippotherapyProgramCategoryLocalizations.CountAsync();
+        return count >= _localizations.Count;
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/HippotherapyProgramCategoryLocalizations/HippotherapyProgramCategoryLocalizationsSeeder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/Localizations/HippotherapyProgramCategoryLocalizations/HippotherapyProgramCategoryLocalizationsSeeder.cs
@@ -28,20 +28,20 @@ public class HippotherapyProgramCategoryLocalizationsSeeder : ISeeder
     {
         try
         {
-            _categories.AddRange(new List<HippotherapyProgramCategory>
-            {
+            _categories.AddRange(
+            [
                 new() { Name = "Localization Test Category 1", CreatedAt = DateTimeOffset.UtcNow },
                 new() { Name = "Localization Test Category 2", CreatedAt = DateTimeOffset.UtcNow },
-            });
+            ]);
 
             await _dbContext.HippotherapyProgramCategories.AddRangeAsync(_categories);
             await _dbContext.SaveChangesAsync();
 
-            _localizations.AddRange(new List<HippotherapyProgramCategoryLocalization>
-            {
+            _localizations.AddRange(
+            [
                 new() { EntityId = _categories[0].Id, LanguageId = 2, Name = "English Name 1", CreatedAt = DateTimeOffset.UtcNow },
                 new() { EntityId = _categories[1].Id, LanguageId = 2, Name = "English Name 2", CreatedAt = DateTimeOffset.UtcNow },
-            });
+            ]);
 
             await _dbContext.HippotherapyProgramCategoryLocalizations.AddRangeAsync(_localizations);
             await _dbContext.SaveChangesAsync();

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/Seeders/SeederExecutionOrder.cs
@@ -18,6 +18,7 @@ public enum SeederExecutionOrder
     TeamCategoryLocalizations,
     ReportFundsExpendituresCategoryLocalizations,
     ReportFundsExpendituresSettingsLocalizations,
+    HippotherapyProgramCategoryLocalizations,
     EventNewsCategories,
     EventNews,
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/CreateHippotherapyProgramCategoryLocalizationTests.cs
@@ -1,0 +1,145 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Create;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.HippotherapyProgramCategories;
+
+public class CreateHippotherapyProgramCategoryLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization>> _mockLocalizationService;
+    private readonly IValidator<CreateHippotherapyProgramCategoryLocalizationCommand> _validator;
+    private readonly CreateHippotherapyProgramCategoryLocalizationHandler _handler;
+
+    private readonly CreateHippotherapyProgramCategoryLocalizationDto _createDto = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "English Name"
+    };
+
+    private readonly HippotherapyProgramCategoryLocalization _entity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "English Name",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" }
+    };
+
+    private readonly HippotherapyProgramCategoryLocalizationDto _responseDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        Name = "English Name"
+    };
+
+    public CreateHippotherapyProgramCategoryLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization>>();
+        _validator = new CreateHippotherapyProgramCategoryLocalizationValidator(
+            new BaseHippotherapyProgramCategoryLocalizationValidator());
+        _handler = new CreateHippotherapyProgramCategoryLocalizationHandler(
+            _mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCreateLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var result = await _handler.Handle(
+            new CreateHippotherapyProgramCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(_responseDto.Name, result.Value.Name);
+        Assert.Equal(_responseDto.EntityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var invalidDto = new CreateHippotherapyProgramCategoryLocalizationDto
+        {
+            EntityId = 0,
+            LanguageId = 0,
+            Name = ""
+        };
+
+        var result = await _handler.Handle(
+            new CreateHippotherapyProgramCategoryLocalizationCommand(invalidDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("EntityId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("LanguageId must be positive", result.Errors.Select(e => e.Message));
+        Assert.Contains("Name is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new KeyNotFoundException("Entity not found"));
+
+        var result = await _handler.Handle(
+            new CreateHippotherapyProgramCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Entity not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var result = await _handler.Handle(
+            new CreateHippotherapyProgramCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntity(typeof(HippotherapyProgramCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new DbUpdateException());
+
+        var result = await _handler.Handle(
+            new CreateHippotherapyProgramCategoryLocalizationCommand(_createDto),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToCreateEntityInDatabase(typeof(HippotherapyProgramCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_createDto)).Returns(_entity);
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalizationDto>(_entity)).Returns(_responseDto);
+        _mockLocalizationService.Setup(s => s.CreateEntityLocalizationAsync(_entity)).ReturnsAsync(_entity);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/GetHippotherapyProgramCategoryLocalizationByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/GetHippotherapyProgramCategoryLocalizationByEntityIdTests.cs
@@ -15,8 +15,8 @@ public class GetHippotherapyProgramCategoryLocalizationByEntityIdTests
     private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
     private readonly GetHippotherapyProgramCategoryLocalizationByEntityIdHandler _handler;
 
-    private readonly List<HippotherapyProgramCategoryLocalization> _entities = new()
-    {
+    private readonly List<HippotherapyProgramCategoryLocalization> _entities =
+    [
         new HippotherapyProgramCategoryLocalization
         {
             EntityId = 1,
@@ -33,10 +33,11 @@ public class GetHippotherapyProgramCategoryLocalizationByEntityIdTests
             Language = new LocalizationLanguage { Id = 3, Code = "de", CreatedAt = DateTimeOffset.UtcNow },
             CreatedAt = DateTimeOffset.UtcNow
         }
-    };
 
-    private readonly List<HippotherapyProgramCategoryLocalizationDto> _dtos = new()
-    {
+    ];
+
+    private readonly List<HippotherapyProgramCategoryLocalizationDto> _dtos =
+    [
         new HippotherapyProgramCategoryLocalizationDto
         {
             EntityId = 1,
@@ -49,7 +50,8 @@ public class GetHippotherapyProgramCategoryLocalizationByEntityIdTests
             LocalizationInfoDto = new LocalizationInfoDto { Id = 3, Code = "de" },
             Name = "German Name"
         }
-    };
+
+    ];
 
     public GetHippotherapyProgramCategoryLocalizationByEntityIdTests()
     {
@@ -76,8 +78,8 @@ public class GetHippotherapyProgramCategoryLocalizationByEntityIdTests
     [Fact]
     public async Task Handle_ShouldReturnEmptyList_WhenEntityIdDoesNotExist()
     {
-        SetupRepositoryWrapper(new List<HippotherapyProgramCategoryLocalization>());
-        SetupMapper(new List<HippotherapyProgramCategoryLocalizationDto>());
+        SetupRepositoryWrapper([]);
+        SetupMapper([]);
 
         var query = new GetHippotherapyProgramCategoryLocalizationByEntityIdQuery(999);
         var result = await _handler.Handle(query, CancellationToken.None);

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/GetHippotherapyProgramCategoryLocalizationByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/GetHippotherapyProgramCategoryLocalizationByEntityIdTests.cs
@@ -101,6 +101,6 @@ public class GetHippotherapyProgramCategoryLocalizationByEntityIdTests
         _mockMapper
             .Setup(m => m.Map<List<HippotherapyProgramCategoryLocalizationDto>>(
                 It.IsAny<IEnumerable<HippotherapyProgramCategoryLocalization>>()))
-            .Returns(dtosToReturn.ToList());
+            .Returns([.. dtosToReturn]);
     }
 }

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/GetHippotherapyProgramCategoryLocalizationByEntityIdTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/GetHippotherapyProgramCategoryLocalizationByEntityIdTests.cs
@@ -1,0 +1,104 @@
+using AutoMapper;
+using Moq;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Queries.Admin.Localization.HippotherapyProgramCategories.GetByEntityId;
+using VictoryCenter.DAL.Entities.Localization;
+using VictoryCenter.DAL.Repositories.Interfaces.Base;
+using VictoryCenter.DAL.Repositories.Options;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.HippotherapyProgramCategories;
+
+public class GetHippotherapyProgramCategoryLocalizationByEntityIdTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+    private readonly GetHippotherapyProgramCategoryLocalizationByEntityIdHandler _handler;
+
+    private readonly List<HippotherapyProgramCategoryLocalization> _entities = new()
+    {
+        new HippotherapyProgramCategoryLocalization
+        {
+            EntityId = 1,
+            LanguageId = 2,
+            Name = "English Name",
+            Language = new LocalizationLanguage { Id = 2, Code = "en", CreatedAt = DateTimeOffset.UtcNow },
+            CreatedAt = DateTimeOffset.UtcNow
+        },
+        new HippotherapyProgramCategoryLocalization
+        {
+            EntityId = 1,
+            LanguageId = 3,
+            Name = "German Name",
+            Language = new LocalizationLanguage { Id = 3, Code = "de", CreatedAt = DateTimeOffset.UtcNow },
+            CreatedAt = DateTimeOffset.UtcNow
+        }
+    };
+
+    private readonly List<HippotherapyProgramCategoryLocalizationDto> _dtos = new()
+    {
+        new HippotherapyProgramCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+            Name = "English Name"
+        },
+        new HippotherapyProgramCategoryLocalizationDto
+        {
+            EntityId = 1,
+            LocalizationInfoDto = new LocalizationInfoDto { Id = 3, Code = "de" },
+            Name = "German Name"
+        }
+    };
+
+    public GetHippotherapyProgramCategoryLocalizationByEntityIdTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _handler = new GetHippotherapyProgramCategoryLocalizationByEntityIdHandler(
+            _mockMapper.Object, _mockRepositoryWrapper.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnLocalizations_WhenEntityIdExists()
+    {
+        SetupRepositoryWrapper(_entities);
+        SetupMapper(_dtos);
+
+        var query = new GetHippotherapyProgramCategoryLocalizationByEntityIdQuery(1);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(2, result.Value.Count);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenEntityIdDoesNotExist()
+    {
+        SetupRepositoryWrapper(new List<HippotherapyProgramCategoryLocalization>());
+        SetupMapper(new List<HippotherapyProgramCategoryLocalizationDto>());
+
+        var query = new GetHippotherapyProgramCategoryLocalizationByEntityIdQuery(999);
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value);
+    }
+
+    private void SetupRepositoryWrapper(IEnumerable<HippotherapyProgramCategoryLocalization> entitiesToReturn)
+    {
+        _mockRepositoryWrapper
+            .Setup(repo => repo.HippotherapyProgramCategoryLocalizationsRepository
+                .GetAllAsync(It.IsAny<QueryOptions<HippotherapyProgramCategoryLocalization>>()))
+            .ReturnsAsync(entitiesToReturn);
+    }
+
+    private void SetupMapper(IEnumerable<HippotherapyProgramCategoryLocalizationDto> dtosToReturn)
+    {
+        _mockMapper
+            .Setup(m => m.Map<List<HippotherapyProgramCategoryLocalizationDto>>(
+                It.IsAny<IEnumerable<HippotherapyProgramCategoryLocalization>>()))
+            .Returns(dtosToReturn.ToList());
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryLocalizationTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/Localization/HippotherapyProgramCategories/UpdateHippotherapyProgramCategoryLocalizationTests.cs
@@ -1,0 +1,133 @@
+using AutoMapper;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Update;
+using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.DTOs.Common;
+using VictoryCenter.BLL.Interfaces.Localization;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramCategories;
+using VictoryCenter.DAL.Entities;
+using VictoryCenter.DAL.Entities.Localization;
+
+namespace VictoryCenter.UnitTests.MediatRHandlersTests.Localization.HippotherapyProgramCategories;
+
+public class UpdateHippotherapyProgramCategoryLocalizationTests
+{
+    private readonly Mock<IMapper> _mockMapper;
+    private readonly Mock<ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization>> _mockLocalizationService;
+    private readonly IValidator<UpdateHippotherapyProgramCategoryLocalizationCommand> _validator;
+    private readonly UpdateHippotherapyProgramCategoryLocalizationHandler _handler;
+
+    private readonly long _entityId = 1;
+    private readonly long _languageId = 2;
+
+    private readonly UpdateHippotherapyProgramCategoryLocalizationDto _updateDto = new()
+    {
+        Name = "Updated English Name"
+    };
+
+    private readonly HippotherapyProgramCategoryLocalization _entity = new()
+    {
+        EntityId = 1,
+        LanguageId = 2,
+        Name = "Updated English Name",
+        Language = new LocalizationLanguage { Id = 2, Name = "English", Code = "en" }
+    };
+
+    private readonly HippotherapyProgramCategoryLocalizationDto _responseDto = new()
+    {
+        EntityId = 1,
+        LocalizationInfoDto = new LocalizationInfoDto { Id = 2, Code = "en" },
+        Name = "Updated English Name"
+    };
+
+    public UpdateHippotherapyProgramCategoryLocalizationTests()
+    {
+        _mockMapper = new Mock<IMapper>();
+        _mockLocalizationService = new Mock<ILocalizationService<HippotherapyProgramCategory, HippotherapyProgramCategoryLocalization>>();
+        _validator = new UpdateHippotherapyProgramCategoryLocalizationValidator(
+            new BaseHippotherapyProgramCategoryLocalizationValidator());
+        _handler = new UpdateHippotherapyProgramCategoryLocalizationHandler(
+            _mockMapper.Object, _mockLocalizationService.Object, _validator);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateLocalization_Successfully()
+    {
+        SetupDependencies();
+
+        var command = new UpdateHippotherapyProgramCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(_responseDto.Name, result.Value.Name);
+        Assert.Equal(_entityId, result.Value.EntityId);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenValidationFails()
+    {
+        var invalidDto = new UpdateHippotherapyProgramCategoryLocalizationDto { Name = "" };
+        var command = new UpdateHippotherapyProgramCategoryLocalizationCommand(invalidDto, _entityId, _languageId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Name is required", result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenKeyNotFoundExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new KeyNotFoundException("Localization not found"));
+
+        var command = new UpdateHippotherapyProgramCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Localization not found", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenInvalidOperationExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new InvalidOperationException());
+
+        var command = new UpdateHippotherapyProgramCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntity(typeof(HippotherapyProgramCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDbUpdateExceptionThrown()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity))
+            .ThrowsAsync(new DbUpdateException());
+
+        var command = new UpdateHippotherapyProgramCategoryLocalizationCommand(_updateDto, _entityId, _languageId);
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(
+            ErrorMessagesConstants.FailedToUpdateEntityInDatabase(typeof(HippotherapyProgramCategoryLocalization)),
+            result.Errors[0].Message);
+    }
+
+    private void SetupDependencies()
+    {
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalization>(_updateDto)).Returns(_entity);
+        _mockMapper.Setup(m => m.Map<HippotherapyProgramCategoryLocalizationDto>(_entity)).Returns(_responseDto);
+        _mockLocalizationService.Setup(s => s.UpdateEntityLocalizationAsync(_entity)).ReturnsAsync(_entity);
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyProgramCategories/BaseHippotherapyProgramCategoryLocalizationValidatorTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/ValidatorsTests/Localization/HippotherapyProgramCategories/BaseHippotherapyProgramCategoryLocalizationValidatorTests.cs
@@ -1,0 +1,60 @@
+using FluentValidation.TestHelper;
+using VictoryCenter.BLL.Constants.Localization;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.Validators.Localization.HippotherapyProgramCategories;
+
+namespace VictoryCenter.UnitTests.ValidatorsTests.Localization.HippotherapyProgramCategories;
+
+public class BaseHippotherapyProgramCategoryLocalizationValidatorTests
+{
+    private readonly BaseHippotherapyProgramCategoryLocalizationValidator _validator;
+
+    public BaseHippotherapyProgramCategoryLocalizationValidatorTests()
+    {
+        _validator = new BaseHippotherapyProgramCategoryLocalizationValidator();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_ShouldHaveError_WhenName_IsNullOrEmpty(string? name)
+    {
+        var model = new UpdateHippotherapyProgramCategoryLocalizationDto { Name = name! };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenName_IsTooShort()
+    {
+        var model = new UpdateHippotherapyProgramCategoryLocalizationDto
+        {
+            Name = new string('a', HippotherapyProgramCategoryLocalizationConstants.NameMinLength - 1)
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_ShouldHaveError_WhenName_IsTooLong()
+    {
+        var model = new UpdateHippotherapyProgramCategoryLocalizationDto
+        {
+            Name = new string('a', HippotherapyProgramCategoryLocalizationConstants.NameMaxLength + 1)
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_ShouldNotHaveError_WhenModel_IsValid()
+    {
+        var model = new UpdateHippotherapyProgramCategoryLocalizationDto
+        {
+            Name = "Valid Name"
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(x => x.Name);
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HippotherapyProgramCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HippotherapyProgramCategoryLocalizationsController.cs
@@ -11,7 +11,6 @@ public class HippotherapyProgramCategoryLocalizationsController : AuthorizedApiC
 {
     [HttpGet("{entityId:long}")]
     [ProducesResponseType(typeof(List<HippotherapyProgramCategoryLocalizationDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetHippotherapyProgramCategoryLocalizations(
         [FromRoute] long entityId)
     {

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HippotherapyProgramCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/HippotherapyProgramCategoryLocalizationsController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Create;
+using VictoryCenter.BLL.Commands.Admin.Localization.HippotherapyProgramCategories.Update;
+using VictoryCenter.BLL.DTOs.Admin.Localization.HippotherapyProgramCategories;
+using VictoryCenter.BLL.Queries.Admin.Localization.HippotherapyProgramCategories.GetByEntityId;
+using VictoryCenter.WebAPI.Controllers.Common;
+
+namespace VictoryCenter.WebAPI.Controllers.Admin.Localization;
+
+public class HippotherapyProgramCategoryLocalizationsController : AuthorizedApiController
+{
+    [HttpGet("{entityId:long}")]
+    [ProducesResponseType(typeof(List<HippotherapyProgramCategoryLocalizationDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetHippotherapyProgramCategoryLocalizations(
+        [FromRoute] long entityId)
+    {
+        return HandleResult(await Mediator.Send(
+            new GetHippotherapyProgramCategoryLocalizationByEntityIdQuery(entityId)));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(HippotherapyProgramCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateHippotherapyProgramCategoryLocalization(
+        [FromBody] CreateHippotherapyProgramCategoryLocalizationDto createDto)
+    {
+        return HandleResult(await Mediator.Send(
+            new CreateHippotherapyProgramCategoryLocalizationCommand(createDto)));
+    }
+
+    [HttpPut("{entityId:long}/{languageId:long}")]
+    [ProducesResponseType(typeof(HippotherapyProgramCategoryLocalizationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateHippotherapyProgramCategoryLocalization(
+        [FromBody] UpdateHippotherapyProgramCategoryLocalizationDto updateDto,
+        [FromRoute(Name = "entityId")] long EntityId,
+        [FromRoute(Name = "languageId")] long LanguageId)
+    {
+        return HandleResult(await Mediator.Send(
+            new UpdateHippotherapyProgramCategoryLocalizationCommand(updateDto, EntityId, LanguageId)));
+    }
+}

--- a/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/ReportFundsExpendituresCategoryLocalizationsController.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Controllers/Admin/Localization/ReportFundsExpendituresCategoryLocalizationsController.cs
@@ -12,7 +12,6 @@ public class ReportFundsExpendituresCategoryLocalizationsController : Authorized
 {
     [HttpGet("{entityId:long}")]
     [ProducesResponseType(typeof(List<ReportFundsExpendituresCategoryLocalizationDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetReportFundsExpendituresCategoryLocalizations(
         [FromRoute] long entityId)
     {


### PR DESCRIPTION
dev
## Github ticker

* [#1855](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1855)

## Code reviewers

- [ ] @github_username

### Second Level Review

- [ ] @github_username

## Summary of issue

As an Admin, I want to open a modal window to translate a program category, so that I can choose how I want to translate the content ([#1855](<link>)). `HippotherapyProgramCategory` had no translation/localization support at all — no `Localization` entity or table, no endpoints — unlike other categorized entities in the app (`TeamCategory`, `ReportFundsExpendituresCategory`) that already have this infrastructure. This left the client with no data source to power the "Перекласти" action or the existing translation-status badge on program categories. [Related client PR](https://github.com/ita-social-projects/VictoryCenter-Client/pull/539)

## Summary of change

- **New entity** `HippotherapyProgramCategoryLocalization` (`LocalizationBase<HippotherapyProgramCategory>` + `Name`), modeled after `ReportFundsExpendituresCategoryLocalization` — the closest existing single-field analog in the codebase.
- `HippotherapyProgramCategory` now implements `ITranslatedEntity<HippotherapyProgramCategoryLocalization>`.
- **New EF configuration, `DbSet` and migration** `AddHippotherapyProgramCategoryLocalization` — the shared `EntityLocalizationConfig` base already cascade-deletes localizations when the parent category is removed, no extra code needed for that.
- **New repository** `IHippotherapyProgramCategoryLocalizationsRepository` / `HippotherapyProgramCategoryLocalizationsRepository`, registered on `IRepositoryWrapper`.
- **New DTOs, commands (`Create`/`Update`), `GetByEntityId` query, validators and AutoMapper profile**, mirroring the `ReportFundsExpendituresCategoryLocalizations` stack. No `Delete` endpoint — nothing currently in scope requires it.
- **New controller** `HippotherapyProgramCategoryLocalizationsController` (`GET {entityId}`, `POST`, `PUT {entityId}/{languageId}`).
- `GetHippotherapyProgramCategoriesHandler` / `HippotherapyProgramCategoryDto` now include `Localizations`, so the client's existing translation-status badge can render real data instead of always showing "no translation".

## Testing approach

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added administration tools to create, update, and view hippotherapy program category translations.
  * Hippotherapy program categories now include available localizations and language information.
* **Validation**
  * Added required name validation with minimum and maximum length checks.
  * Clear error responses are provided for invalid data or missing categories.
* **Reliability**
  * Added automated coverage for localization creation, updates, retrieval, validation, and common failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->