### PR TITLE
Fix/issue 2817 [Team Page] [API] POST /api/TeamCategories - Leading/Trailing spaces accepted in the 'Опис' field  

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Create/CreateTeamCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Create/CreateTeamCategoryHandler.cs
@@ -31,14 +31,17 @@ public class CreateTeamCategoryHandler : IRequestHandler<CreateTeamCategoryComma
     {
         try
         {
-            request = request with
+            if (request.CreateTeamCategoryDto is not null)
             {
-                CreateTeamCategoryDto = request.CreateTeamCategoryDto with
+                request = request with
                 {
-                    Name = request.CreateTeamCategoryDto.Name?.Trim()!,
-                    Description = request.CreateTeamCategoryDto.Description?.Trim()!
-                }
-            };
+                    CreateTeamCategoryDto = request.CreateTeamCategoryDto with
+                    {
+                        Name = request.CreateTeamCategoryDto.Name?.Trim()!,
+                        Description = request.CreateTeamCategoryDto.Description?.Trim()!
+                    }
+                };
+            }
 
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Create/CreateTeamCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Create/CreateTeamCategoryHandler.cs
@@ -31,6 +31,15 @@ public class CreateTeamCategoryHandler : IRequestHandler<CreateTeamCategoryComma
     {
         try
         {
+            request = request with
+            {
+                CreateTeamCategoryDto = request.CreateTeamCategoryDto with
+                {
+                    Name = request.CreateTeamCategoryDto.Name?.Trim()!,
+                    Description = request.CreateTeamCategoryDto.Description?.Trim()!
+                }
+            };
+
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
             var duplicateCategory =

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Update/UpdateTeamCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Update/UpdateTeamCategoryHandler.cs
@@ -32,6 +32,15 @@ public class UpdateTeamCategoryHandler : IRequestHandler<UpdateTeamCategoryComma
     {
         try
         {
+            request = request with
+            {
+                UpdateTeamCategoryDto = request.UpdateTeamCategoryDto with
+                {
+                    Name = request.UpdateTeamCategoryDto.Name?.Trim()!,
+                    Description = request.UpdateTeamCategoryDto.Description?.Trim()!
+                }
+            };
+
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 
             var duplicateCategory =

--- a/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Update/UpdateTeamCategoryHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Commands/Admin/TeamCategories/Update/UpdateTeamCategoryHandler.cs
@@ -32,14 +32,17 @@ public class UpdateTeamCategoryHandler : IRequestHandler<UpdateTeamCategoryComma
     {
         try
         {
-            request = request with
+            if (request.UpdateTeamCategoryDto is not null)
             {
-                UpdateTeamCategoryDto = request.UpdateTeamCategoryDto with
+                request = request with
                 {
-                    Name = request.UpdateTeamCategoryDto.Name?.Trim()!,
-                    Description = request.UpdateTeamCategoryDto.Description?.Trim()!
-                }
-            };
+                    UpdateTeamCategoryDto = request.UpdateTeamCategoryDto with
+                    {
+                        Name = request.UpdateTeamCategoryDto.Name?.Trim()!,
+                        Description = request.UpdateTeamCategoryDto.Description?.Trim()!
+                    }
+                };
+            }
 
             await _validator.ValidateAndThrowAsync(request, cancellationToken);
 

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/CreateTeamCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/CreateTeamCategoryTests.cs
@@ -81,6 +81,85 @@ public class CreateTeamCategoryTests
         Assert.Contains("Validation failed", result.Errors[0].Message);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public async Task Handle_ShouldFail_InvalidDescription(string? description)
+    {
+        _testEntity.Description = description!;
+        _testCategoryDto = _testCategoryDto with
+        {
+            Description = description!
+        };
+        SetupDependencies();
+        var handler = new CreateTeamCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
+
+        var result = await handler.Handle(
+            new CreateTeamCategoryCommand(new CreateTeamCategoryDto
+            {
+                Name = "Test Category",
+                Description = description!,
+            }), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldTrimNameAndDescription_BeforeCreating()
+    {
+        SetupDependencies();
+        var handler = new CreateTeamCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
+
+        var result = await handler.Handle(
+            new CreateTeamCategoryCommand(new CreateTeamCategoryDto
+            {
+                Name = "  Test Category  ",
+                Description = "  Test Category Description  ",
+            }), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        _mapperMock.Verify(
+            m => m.Map<TeamCategory>(It.Is<CreateTeamCategoryDto>(dto =>
+                dto.Name == "Test Category" && dto.Description == "Test Category Description")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenNameIsTooShortOnlyAfterTrimming()
+    {
+        SetupDependencies();
+        var handler = new CreateTeamCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
+
+        var result = await handler.Handle(
+            new CreateTeamCategoryCommand(new CreateTeamCategoryDto
+            {
+                Name = "  Ab  ",
+                Description = "Test Category Description",
+            }), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenDescriptionIsTooShortOnlyAfterTrimming()
+    {
+        SetupDependencies();
+        var handler = new CreateTeamCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
+
+        var result = await handler.Handle(
+            new CreateTeamCategoryCommand(new CreateTeamCategoryDto
+            {
+                Name = "Test Category",
+                Description = "    Hi    ",
+            }), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
     [Fact]
     public async Task Handle_ShouldFail_DuplicateCategoryName()
     {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/CreateTeamCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/CreateTeamCategoryTests.cs
@@ -107,6 +107,18 @@ public class CreateTeamCategoryTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenDtoIsNull()
+    {
+        SetupDependencies();
+        var handler = new CreateTeamCategoryHandler(_mapperMock.Object, _repositoryWrapperMock.Object, _validator);
+
+        var result = await handler.Handle(new CreateTeamCategoryCommand(null!), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
+    [Fact]
     public async Task Handle_ShouldTrimNameAndDescription_BeforeCreating()
     {
         SetupDependencies();

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/UpdateTeamCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/UpdateTeamCategoryTests.cs
@@ -91,6 +91,91 @@ public class UpdateTeamCategoryTests
         Assert.Contains("Validation failed", result.Errors[0].Message);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task Handle_ShouldNotUpdateEntity_IncorrectDescription(string? testDescription)
+    {
+        _testUpdatedCategoryDto = _testUpdatedCategoryDto with
+        {
+            Description = testDescription!
+        };
+        _testUpdatedCategory.Description = testDescription!;
+        SetupDependencies(_testExistingCategory);
+        var handler = new UpdateTeamCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
+
+        var result = await handler.Handle(
+            new UpdateTeamCategoryCommand(
+                new UpdateTeamCategoryDto
+                {
+                    Name = "Updated Name",
+                    Description = testDescription!,
+                }, _testExistingCategory.Id), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldTrimNameAndDescription_BeforeUpdating()
+    {
+        SetupDependencies(_testExistingCategory);
+        var handler = new UpdateTeamCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
+
+        var result = await handler.Handle(
+            new UpdateTeamCategoryCommand(
+                new UpdateTeamCategoryDto
+                {
+                    Name = "  Updated Name  ",
+                    Description = "  Updated Description  ",
+                },
+                _testExistingCategory.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        _mockMapper.Verify(
+            x => x.Map(
+                It.Is<UpdateTeamCategoryDto>(dto => dto.Name == "Updated Name" && dto.Description == "Updated Description"),
+                _testExistingCategory),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotUpdateEntity_WhenNameIsTooShortOnlyAfterTrimming()
+    {
+        SetupDependencies(_testExistingCategory);
+        var handler = new UpdateTeamCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
+
+        var result = await handler.Handle(
+            new UpdateTeamCategoryCommand(
+                new UpdateTeamCategoryDto
+                {
+                    Name = "  Ab  ",
+                    Description = "Updated Description",
+                }, _testExistingCategory.Id), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotUpdateEntity_WhenDescriptionIsTooShortOnlyAfterTrimming()
+    {
+        SetupDependencies(_testExistingCategory);
+        var handler = new UpdateTeamCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
+
+        var result = await handler.Handle(
+            new UpdateTeamCategoryCommand(
+                new UpdateTeamCategoryDto
+                {
+                    Name = "Updated Name",
+                    Description = "    Hi    ",
+                }, _testExistingCategory.Id), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
     [Fact]
     public async Task Handle_ShouldNotUpdateEntity_DuplicateName()
     {

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/UpdateTeamCategoryTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/TeamCategories/UpdateTeamCategoryTests.cs
@@ -118,6 +118,19 @@ public class UpdateTeamCategoryTests
     }
 
     [Fact]
+    public async Task Handle_ShouldFail_WhenDtoIsNull()
+    {
+        SetupDependencies(_testExistingCategory);
+        var handler = new UpdateTeamCategoryHandler(_mockMapper.Object, _mockRepositoryWrapper.Object, _validator);
+
+        var result = await handler.Handle(
+            new UpdateTeamCategoryCommand(null!, _testExistingCategory.Id), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Validation failed", result.Errors[0].Message);
+    }
+
+    [Fact]
     public async Task Handle_ShouldTrimNameAndDescription_BeforeUpdating()
     {
         SetupDependencies(_testExistingCategory);


### PR DESCRIPTION
## Github ticket
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2871)
  
## Summary of issue

`POST /api/TeamCategories` accepted leading/trailing whitespace in the `name` and `description` fields without trimming or validating against it. A request with `"description": " (( Test Description )) "` returned `200 OK` and persisted the value with the surrounding spaces intact, since FluentValidation's `MinimumLength` / `MaximumLength` rules were evaluated against the raw, untrimmed string.

## Summary of change

*   **Handler Logic**: Modified `CreateTeamCategoryHandler` and `UpdateTeamCategoryHandler` to trim `Name` and `Description` (`?.Trim()`, null-safe) before validation and persistence, matching the existing convention already used in `CreateTeamMemberHandler`.
*   **Tests**: Added unit tests to `CreateTeamCategoryTests` and `UpdateTeamCategoryTests` covering: trimming before mapping/persistence, rejection of content that's too short only after trimming, and null-safety for `Description` (extending the existing null/empty/whitespace coverage that previously only applied to `Name`).


## Check List
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Team category names and descriptions are now trimmed before validation and saving.
  - Inputs that become too short after trimming are correctly rejected.
  - Invalid, empty, or whitespace-only descriptions are rejected consistently during creation and updates.

- **Tests**
  - Added coverage for input trimming and validation during team category creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->