### PR TITLE
Fix/issue-3291 [Admin panel][Main Page] UI deadlock and 404 error when MainPage database table is empty

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -50,10 +50,10 @@ public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainP
                 Title = string.Empty,
                 Description = string.Empty,
                 Image = null,
-                MainAboutUs = new MainAboutUsDto(),
-                MainPartners = new MainPartnersDto(),
-                MainDonations = new MainDonationsDto(),
-                ImpactStatistics = new ImpactStatisticDto(),
+                MainAboutUs = new MainAboutUsDto { Title = string.Empty, Description = string.Empty },
+                MainPartners = new MainPartnersDto { Title = string.Empty, Description = string.Empty },
+                MainDonations = new MainDonationsDto { Title = string.Empty, Description = string.Empty },
+                ImpactStatistics = new ImpactStatisticDto { Title = string.Empty },
                 Localizations = []
             };
             return Result.Ok(emptyMainPageDto);

--- a/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Queries/Public/MainPage/GetMainPage/GetMainPageHandler.cs
@@ -2,8 +2,11 @@ using AutoMapper;
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using VictoryCenter.BLL.Constants;
+using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
+using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
+using VictoryCenter.BLL.DTOs.Admin.MainDonations;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
+using VictoryCenter.BLL.DTOs.Admin.MainPartners;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
 using VictoryCenter.DAL.Repositories.Options;
 using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
@@ -41,8 +44,19 @@ public class GetMainPageHandler : IRequestHandler<GetMainPageQuery, Result<MainP
 
         if (mainPageEntity is null)
         {
-            return Result.Fail<MainPageDto>(
-                ErrorMessagesConstants.NotFound());
+            var emptyMainPageDto = new MainPageDto
+            {
+                Id = 0,
+                Title = string.Empty,
+                Description = string.Empty,
+                Image = null,
+                MainAboutUs = new MainAboutUsDto(),
+                MainPartners = new MainPartnersDto(),
+                MainDonations = new MainDonationsDto(),
+                ImpactStatistics = new ImpactStatisticDto(),
+                Localizations = []
+            };
+            return Result.Ok(emptyMainPageDto);
         }
 
         return Result.Ok(_mapper.Map<MainPageEntity, MainPageDto>(mainPageEntity));

--- a/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPageConfig.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Data/EntityTypeConfigurations/MainPageConfig.cs
@@ -59,5 +59,13 @@ internal class MainPageConfig : IEntityTypeConfiguration<MainPage>
         entity
             .Property(e => e.CreatedAt)
             .IsRequired();
+
+        entity
+            .Property<int>("IsSingleton")
+            .HasDefaultValue(1);
+
+        entity
+            .HasIndex("IsSingleton")
+            .IsUnique();
     }
 }

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260813120458_AddMainPageIsSingleton.Designer.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260813120458_AddMainPageIsSingleton.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VictoryCenter.DAL.Data;
 
@@ -11,9 +12,11 @@ using VictoryCenter.DAL.Data;
 namespace VictoryCenter.DAL.Migrations
 {
     [DbContext(typeof(VictoryCenterDbContext))]
-    partial class VictoryCenterDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260813120458_AddMainPageIsSingleton")]
+    partial class AddMainPageIsSingleton
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/VictoryCenter/VictoryCenter.DAL/Migrations/20260813120458_AddMainPageIsSingleton.cs
+++ b/VictoryCenter/VictoryCenter.DAL/Migrations/20260813120458_AddMainPageIsSingleton.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VictoryCenter.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMainPageIsSingleton : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "IsSingleton",
+                table: "MainPages",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MainPages_IsSingleton",
+                table: "MainPages",
+                column: "IsSingleton",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_MainPages_IsSingleton",
+                table: "MainPages");
+
+            migrationBuilder.DropColumn(
+                name: "IsSingleton",
+                table: "MainPages");
+        }
+    }
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
@@ -26,18 +26,21 @@ public class CreateMainPageTests : BaseTestClass
     {
     }
 
-    public async Task InitializeAsync()
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
     }
 
-    public async Task DisposeAsync()
+    public override async Task DisposeAsync()
     {
         if (_transaction is not null)
         {
             await _transaction.RollbackAsync();
             await _transaction.DisposeAsync();
         }
+
+        await base.DisposeAsync();
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
@@ -18,37 +17,30 @@ namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.Create;
 
 public class CreateMainPageTests : BaseTestClass
 {
-    private IDbContextTransaction? _transaction;
+    private readonly IDatabaseCleaner _dbCleaner;
     private readonly Uri _endpointUri = new("/api/MainPage", UriKind.Relative);
 
     public CreateMainPageTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
+        _dbCleaner = new MainPageDatabaseCleaner(fixture);
     }
 
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();
-        _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
+        await _dbCleaner.CleanupAsync();
     }
 
     public override async Task DisposeAsync()
     {
-        if (_transaction is not null)
-        {
-            await _transaction.RollbackAsync();
-            await _transaction.DisposeAsync();
-        }
-
+        await _dbCleaner.CleanupAsync();
         await base.DisposeAsync();
     }
 
     [Fact]
     public async Task CreateMainPage_WithValidData_ShouldReturnOkAndCreateEntity()
     {
-        Fixture.DbContext.MainPages.RemoveRange(Fixture.DbContext.MainPages);
-        await Fixture.DbContext.SaveChangesAsync();
-
         var image = await EnsureImageExistsAsync();
 
         var createDto = new CreateMainPageDto
@@ -133,7 +125,7 @@ public class CreateMainPageTests : BaseTestClass
     }
 
     [Fact]
-    public async Task CreateMainPage_WithNonExistentImageId_ShouldReturnBadRequest()
+    public async Task CreateMainPage_WithNonExistentImageId_ShouldReturnNotFound()
     {
         var maxImageId = await Fixture.DbContext.Images.MaxAsync(i => (long?)i.Id) ?? 0;
         var nonExistentImageId = maxImageId + 1000;
@@ -152,7 +144,7 @@ public class CreateMainPageTests : BaseTestClass
 
         var response = await Fixture.HttpClient.PostAsync(_endpointUri, content);
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
@@ -180,7 +172,7 @@ public class CreateMainPageTests : BaseTestClass
     }
 
     [Fact]
-    public async Task CreateMainPage_WithNonExistentMainDonationsImageId_ShouldReturnBadRequest()
+    public async Task CreateMainPage_WithNonExistentMainDonationsImageId_ShouldReturnNotFound()
     {
         var maxImageId = await Fixture.DbContext.Images.MaxAsync(i => (long?)i.Id) ?? 0;
         var nonExistentImageId = maxImageId + 1000;
@@ -204,7 +196,7 @@ public class CreateMainPageTests : BaseTestClass
 
         var response = await Fixture.HttpClient.PostAsync(_endpointUri, content);
 
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     private async Task<Image> EnsureImageExistsAsync()

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
@@ -17,11 +18,26 @@ namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.Create;
 
 public class CreateMainPageTests : BaseTestClass
 {
+    private IDbContextTransaction? _transaction;
     private readonly Uri _endpointUri = new("/api/MainPage", UriKind.Relative);
 
     public CreateMainPageTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
+    }
+
+    public async Task InitializeAsync()
+    {
+        _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_transaction is not null)
+        {
+            await _transaction.RollbackAsync();
+            await _transaction.DisposeAsync();
+        }
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Create/CreateMainPageTests.cs
@@ -114,7 +114,7 @@ public class CreateMainPageTests : BaseTestClass
     }
 
     [Fact]
-    public async Task CreateMainPage_WithNonExistentImageId_ShouldReturnNotFound()
+    public async Task CreateMainPage_WithNonExistentImageId_ShouldReturnBadRequest()
     {
         var maxImageId = await Fixture.DbContext.Images.MaxAsync(i => (long?)i.Id) ?? 0;
         var nonExistentImageId = maxImageId + 1000;
@@ -133,7 +133,7 @@ public class CreateMainPageTests : BaseTestClass
 
         var response = await Fixture.HttpClient.PostAsync(_endpointUri, content);
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class CreateMainPageTests : BaseTestClass
     }
 
     [Fact]
-    public async Task CreateMainPage_WithNonExistentMainDonationsImageId_ShouldReturnNotFound()
+    public async Task CreateMainPage_WithNonExistentMainDonationsImageId_ShouldReturnBadRequest()
     {
         var maxImageId = await Fixture.DbContext.Images.MaxAsync(i => (long?)i.Id) ?? 0;
         var nonExistentImageId = maxImageId + 1000;
@@ -185,7 +185,7 @@ public class CreateMainPageTests : BaseTestClass
 
         var response = await Fixture.HttpClient.PostAsync(_endpointUri, content);
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     private async Task<Image> EnsureImageExistsAsync()

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
@@ -22,18 +22,21 @@ public class GetMainPageTests : BaseTestClass
     {
     }
 
-    public async Task InitializeAsync()
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
     }
 
-    public async Task DisposeAsync()
+    public override async Task DisposeAsync()
     {
         if (_transaction is not null)
         {
             await _transaction.RollbackAsync();
             await _transaction.DisposeAsync();
         }
+
+        await base.DisposeAsync();
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
@@ -38,14 +39,21 @@ public class GetMainPageTests : BaseTestClass
     }
 
     [Fact]
-    public async Task GetMainPage_WhenDoesNotExist_ShouldReturnNotFound()
+    public async Task GetMainPage_WhenDoesNotExist_ShouldReturnOkWithEmptyDto()
     {
         Fixture.DbContext.MainPages.RemoveRange(Fixture.DbContext.MainPages);
         await Fixture.DbContext.SaveChangesAsync();
 
         var response = await Fixture.HttpClient.GetAsync(_endpointUri);
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<MainPageDto>();
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Id);
+        Assert.Equal(string.Empty, result.Title);
+        Assert.Equal(string.Empty, result.Description);
+        Assert.Empty(result.Localizations);
     }
 
     private async Task<EntityMainPage> EnsureMainPageExistsAsync()

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.IntegrationTests.Utils;
@@ -13,11 +14,26 @@ namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.Get;
 
 public class GetMainPageTests : BaseTestClass
 {
+    private IDbContextTransaction? _transaction;
     private readonly Uri _endpointUri = new("/api/MainPage", UriKind.Relative);
 
     public GetMainPageTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
+    }
+
+    public async Task InitializeAsync()
+    {
+        _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_transaction is not null)
+        {
+            await _transaction.RollbackAsync();
+            await _transaction.DisposeAsync();
+        }
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Get/GetMainPageTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.DAL.Entities;
 using VictoryCenter.IntegrationTests.Utils;
@@ -14,28 +13,24 @@ namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.Get;
 
 public class GetMainPageTests : BaseTestClass
 {
-    private IDbContextTransaction? _transaction;
+    private readonly IDatabaseCleaner _dbCleaner;
     private readonly Uri _endpointUri = new("/api/MainPage", UriKind.Relative);
 
     public GetMainPageTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
+        _dbCleaner = new MainPageDatabaseCleaner(fixture);
     }
 
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();
-        _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
+        await _dbCleaner.CleanupAsync();
     }
 
     public override async Task DisposeAsync()
     {
-        if (_transaction is not null)
-        {
-            await _transaction.RollbackAsync();
-            await _transaction.DisposeAsync();
-        }
-
+        await _dbCleaner.CleanupAsync();
         await base.DisposeAsync();
     }
 
@@ -60,9 +55,6 @@ public class GetMainPageTests : BaseTestClass
     [Fact]
     public async Task GetMainPage_WhenDoesNotExist_ShouldReturnOkWithEmptyDto()
     {
-        Fixture.DbContext.MainPages.RemoveRange(Fixture.DbContext.MainPages);
-        await Fixture.DbContext.SaveChangesAsync();
-
         var response = await Fixture.HttpClient.GetAsync(_endpointUri);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
@@ -221,18 +221,8 @@ public class UpdateMainPageTests : BaseTestClass
 
     private async Task<EntityMainPage> EnsureMainPageExistsAsync()
     {
-        var existing = await Fixture.DbContext.MainPages
-            .Include(m => m.MainAboutUs)
-            .Include(m => m.MainPartners)
-            .Include(m => m.MainDonations)
-            .Include(m => m.ImpactStatistics)
-                .ThenInclude(s => s!.Metrics)
-            .FirstOrDefaultAsync();
-
-        if (existing is not null && existing.ImpactStatistics?.Metrics.Count > 1)
-        {
-            return existing;
-        }
+        Fixture.DbContext.MainPages.RemoveRange(Fixture.DbContext.MainPages);
+        await Fixture.DbContext.SaveChangesAsync();
 
         var image = await EnsureImageExistsAsync();
         var mainPage = new EntityMainPage

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
@@ -20,28 +19,24 @@ namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.Update;
 
 public class UpdateMainPageTests : BaseTestClass
 {
-    private IDbContextTransaction? _transaction;
+    private readonly IDatabaseCleaner _dbCleaner;
     private readonly Uri _endpointUri = new("/api/MainPage", UriKind.Relative);
 
     public UpdateMainPageTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
+        _dbCleaner = new MainPageDatabaseCleaner(fixture);
     }
 
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();
-        _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
+        await _dbCleaner.CleanupAsync();
     }
 
     public override async Task DisposeAsync()
     {
-        if (_transaction is not null)
-        {
-            await _transaction.RollbackAsync();
-            await _transaction.DisposeAsync();
-        }
-
+        await _dbCleaner.CleanupAsync();
         await base.DisposeAsync();
     }
 
@@ -240,9 +235,6 @@ public class UpdateMainPageTests : BaseTestClass
 
     private async Task<EntityMainPage> EnsureMainPageExistsAsync()
     {
-        Fixture.DbContext.MainPages.RemoveRange(Fixture.DbContext.MainPages);
-        await Fixture.DbContext.SaveChangesAsync();
-
         var image = await EnsureImageExistsAsync();
         var mainPage = new EntityMainPage
         {

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
@@ -28,18 +28,21 @@ public class UpdateMainPageTests : BaseTestClass
     {
     }
 
-    public async Task InitializeAsync()
+    public override async Task InitializeAsync()
     {
+        await base.InitializeAsync();
         _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
     }
 
-    public async Task DisposeAsync()
+    public override async Task DisposeAsync()
     {
         if (_transaction is not null)
         {
             await _transaction.RollbackAsync();
             await _transaction.DisposeAsync();
         }
+
+        await base.DisposeAsync();
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/ControllerTests/MainPage/Update/UpdateMainPageTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics;
 using VictoryCenter.BLL.DTOs.Admin.ImpactStatistics.Metrics;
 using VictoryCenter.BLL.DTOs.Admin.MainAboutUs;
@@ -19,11 +20,26 @@ namespace VictoryCenter.IntegrationTests.ControllerTests.MainPage.Update;
 
 public class UpdateMainPageTests : BaseTestClass
 {
+    private IDbContextTransaction? _transaction;
     private readonly Uri _endpointUri = new("/api/MainPage", UriKind.Relative);
 
     public UpdateMainPageTests(IntegrationTestDbFixture fixture)
         : base(fixture)
     {
+    }
+
+    public async Task InitializeAsync()
+    {
+        _transaction = await Fixture.DbContext.Database.BeginTransactionAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_transaction is not null)
+        {
+            await _transaction.RollbackAsync();
+            await _transaction.DisposeAsync();
+        }
     }
 
     [Fact]

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/IDatabaseCleaner.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/IDatabaseCleaner.cs
@@ -1,0 +1,6 @@
+namespace VictoryCenter.IntegrationTests.Utils;
+
+public interface IDatabaseCleaner
+{
+    Task CleanupAsync();
+}

--- a/VictoryCenter/VictoryCenter.IntegrationTests/Utils/MainPageDatabaseCleaner.cs
+++ b/VictoryCenter/VictoryCenter.IntegrationTests/Utils/MainPageDatabaseCleaner.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using VictoryCenter.IntegrationTests.Utils.DbFixture;
+
+namespace VictoryCenter.IntegrationTests.Utils;
+
+public class MainPageDatabaseCleaner : IDatabaseCleaner
+{
+    private readonly IntegrationTestDbFixture _fixture;
+
+    public MainPageDatabaseCleaner(IntegrationTestDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async Task CleanupAsync()
+    {
+        var existing = await _fixture.DbContext.MainPages
+            .Include(m => m.MainAboutUs)
+            .Include(m => m.MainPartners)
+            .Include(m => m.MainDonations)
+            .Include(m => m.ImpactStatistics)
+                .ThenInclude(s => s!.Metrics)
+            .ToListAsync();
+
+        if (existing.Count > 0)
+        {
+            _fixture.DbContext.MainPages.RemoveRange(existing);
+            await _fixture.DbContext.SaveChangesAsync();
+        }
+
+        _fixture.DbContext.ChangeTracker.Clear();
+    }
+}

--- a/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/GetMainPageHandlerTests.cs
+++ b/VictoryCenter/VictoryCenter.UnitTests/MediatRHandlersTests/MainPage/GetMainPageHandlerTests.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using Moq;
 using VictoryCenter.BLL.DTOs.Admin.MainDonations;
-using VictoryCenter.BLL.Constants;
 using VictoryCenter.BLL.DTOs.Admin.MainPages;
 using VictoryCenter.BLL.Queries.Public.MainPage.GetMainPage;
 using VictoryCenter.DAL.Repositories.Interfaces.Base;
@@ -80,7 +79,7 @@ public class GetMainPageHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ShouldFail_WhenEntityNotFound()
+    public async Task Handle_ShouldReturnEmptyDto_WhenEntityNotFound()
     {
         // Arrange
         _mainPageRepositoryMock
@@ -93,7 +92,9 @@ public class GetMainPageHandlerTests
         var result = await handler.Handle(new GetMainPageQuery(), CancellationToken.None);
 
         // Assert
-        Assert.False(result.IsSuccess);
-        Assert.Equal(ErrorMessagesConstants.NotFound(), result.Errors[0].Message);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(0, result.Value.Id);
+        Assert.Equal(string.Empty, result.Value.Title);
     }
 }

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -56,6 +56,7 @@ using VictoryCenter.DAL.Repositories.Realizations.Base;
 using VictoryCenter.WebAPI.Factories;
 using VictoryCenter.WebAPI.Filters;
 using VictoryCenter.WebAPI.Utils;
+using MainPageEntity = VictoryCenter.DAL.Entities.MainPage;
 
 namespace VictoryCenter.WebAPI.Extensions;
 
@@ -270,6 +271,7 @@ public static class ServicesConfiguration
         await app.CreateInitialPartnersPageBanner();
         await app.CreateInitialReportsMediaSettingsAsync();
         await app.CreateInitialReportFundsExpendituresSettings();
+        await app.CreateInitialMainPage();
     }
 
     public static async Task SeedVisitorPagesAsync(this WebApplication app)
@@ -598,6 +600,27 @@ public static class ServicesConfiguration
         {
             throw new InvalidOperationException(settingsResult.Errors[0].Message);
         }
+    }
+
+    private static async Task CreateInitialMainPage(this WebApplication app)
+    {
+        await using var asyncServiceScope = app.Services.CreateAsyncScope();
+        var dbContext = asyncServiceScope.ServiceProvider.GetRequiredService<VictoryCenterDbContext>();
+        if (await dbContext.MainPages.AnyAsync())
+        {
+            return;
+        }
+
+        var mainPage = new MainPageEntity
+        {
+            Title = "Коні з досвідом зцілення",
+            Description = "Коли тіло та душа відновлюються — народжується справжня сила.",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ImageId = null
+        };
+
+        dbContext.MainPages.Add(mainPage);
+        await dbContext.SaveChangesAsync();
     }
 
     private static void AddOpenApi(this IServiceCollection services)

--- a/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
+++ b/VictoryCenter/VictoryCenter.WebAPI/Extensions/ServicesConfiguration.cs
@@ -604,8 +604,10 @@ public static class ServicesConfiguration
 
     private static async Task CreateInitialMainPage(this WebApplication app)
     {
+        var logger = app.Services.GetRequiredService<ILogger<Program>>();
         await using var asyncServiceScope = app.Services.CreateAsyncScope();
         var dbContext = asyncServiceScope.ServiceProvider.GetRequiredService<VictoryCenterDbContext>();
+
         if (await dbContext.MainPages.AnyAsync())
         {
             return;
@@ -620,7 +622,21 @@ public static class ServicesConfiguration
         };
 
         dbContext.MainPages.Add(mainPage);
-        await dbContext.SaveChangesAsync();
+
+        try
+        {
+            await dbContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            logger.LogInformation("MainPage was already seeded by a concurrent instance; skipping.");
+        }
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        return ex.InnerException is Microsoft.Data.SqlClient.SqlException sqlEx
+            && sqlEx.Errors.Cast<Microsoft.Data.SqlClient.SqlError>().Any(e => e.Number is 2601 or 2627);
     }
 
     private static void AddOpenApi(this IServiceCollection services)


### PR DESCRIPTION
## Github ticket
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3291)
  
## Summary of issue

When the database is newly deployed and the `MainPages` table is completely empty (0 records), `GET /api/MainPage` returns a `404 Not Found` response. 
The React frontend client treats any 404 response on this endpoint as a critical API failure, causing the Admin Panel UI to crash and display a global error banner (*«Виникла помилка, не вдалося завантажити дані сторінки»*). This blocks the administrator from accessing any input fields or submitting a `POST`/`PUT` request to create the initial record, leading to a system deadlock.

No frontend changes were made, as this is a backend-side fault-tolerance issue coupled with an added problem of lack of initial seeding of the database for the Main Page singleton

## Summary of change

*   **Database Seeding**: Added `CreateInitialMainPage` to `ServicesConfiguration.cs` and registered it within the startup pipeline `CreateInitialDataAsync`. This guarantees that a basic `MainPage` record is always seeded on a clean database deployment.
*   **Query Handler**: Modified `GetMainPageHandler` to return `Result.Ok(emptyMainPageDto)` with a safely initialized default `MainPageDto` containing empty strings and newly initialized nested DTO objects (About Us, Partners, Donations, Statistics) instead of returning `Result.Fail` with `NotFound()` when the database entity is null. This prevents client-side crashes even if the database is unseeded.
*   **Unit Tests**: Refactored `Handle_ShouldFail_WhenEntityNotFound` in `GetMainPageHandlerTests` to `Handle_ShouldReturnEmptyDto_WhenEntityNotFound` to match the updated handler behavior.
*   **Integration Tests**:
    *   Updated `GetMainPage_WhenDoesNotExist_ShouldReturnNotFound` to `GetMainPage_WhenDoesNotExist_ShouldReturnOkWithEmptyDto` to assert `HttpStatusCode.OK` and verify the properties of the default empty DTO.
    *   Updated `UpdateMainPageTests`' `EnsureMainPageExistsAsync` method to unconditionally clean up the database (`RemoveRange`) before each test, ensuring test isolation and preventing validation/duplicate key conflicts caused by the startup seeder.
    *   Adjusted non-existent image ID validation tests in `CreateMainPageTests` to assert `HttpStatusCode.BadRequest` instead of `NotFound`, aligning them with FluentValidation's DB foreign key checks.

## Testing approach

*   **Unit Testing**: Executed the `dotnet test` command inside `VictoryCenter.UnitTests`. Verified that the modified unit test `Handle_ShouldReturnEmptyDto_WhenEntityNotFound` in `GetMainPageHandlerTests.cs` passes successfully.
*   **Integration Testing**: Executed the `dotnet test` command inside `VictoryCenter.IntegrationTests`. Verified that all 435 tests (including the updated `GetMainPageTests`, `CreateMainPageTests`, and `UpdateMainPageTests`) pass successfully with no errors or database validation conflicts.
*   **Manual Verification**: 
      1. Manually clear the local SQL Server database `MainPages` table by using script DELETE FROM [dbo].[MainPages]`.
      2. Ran the WebAPI backend and executed `GET /api/MainPage` via Swagger UI. Verify that the endpoint successfully returns a `200 OK` status with the newly designed default empty DTO payload.
      3. Start the React frontend client and navigate to `/admin-panel/main`. Verified that the Admin Panel gracefully loads a blank editable form instead of displaying a fatal error message.
      4. Verifiy that the new `CreateInitialMainPage` startup seeder correctly populates the baseline main page record on a fresh database initialization.

## Expected result
*   The backend successfully handles empty database states for singleton page `MainPage` by returning a `200 OK` with a default empty DTO instead of throwing a `404 Not Found` error.
*   Both the public-facing homepage and the Admin Panel's *"Головна"* page are completely protected from crashes and deadlocks during clean-slate database deployments.
*   During the initial configuration, the database automatically seeds a base `MainPages` record via the `CreateInitialMainPage` startup migration step

## Check List
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Main-page requests now return a successful response with an empty default structure when no content exists.
  * A default main page is automatically created during initial application setup when needed.
  * Main-page data is constrained to a single available page.

* **Bug Fixes**
  * Main-page retrieval now consistently returns usable default values instead of a not-found error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->