### PR TITLE
"MinDescriptionLength" constant was changed to 5 charachers according to the user story

### DIFF
--- a/VictoryCenter/VictoryCenter.BLL/Constants/TeamCategoryConstants.cs
+++ b/VictoryCenter/VictoryCenter.BLL/Constants/TeamCategoryConstants.cs
@@ -7,6 +7,6 @@ public static class TeamCategoryConstants
     public static readonly string DuplicateCategoryName = "Category with the same name already exists";
     public static readonly int MinNameLength = 5;
     public static readonly int MaxNameLength = 20;
-    public static readonly int MinDescriptionLength = 10;
+    public static readonly int MinDescriptionLength = 5;
     public static readonly int MaxDescriptionLength = 200;
 }


### PR DESCRIPTION
User story: #1167

Issue ticket link
Github ticket: #3324 
  
Summary of issue
Team member category validation wasn't configured to allow descriptions at least 5 characters long even though this is required by the user story:

<img width="507" height="117" alt="image" src="https://github.com/user-attachments/assets/af89f505-eb47-4de1-b102-dfe4792e8ed4" />


Summary of change
Constant "MinDescriptionLength", which is responsible for setting up validation, value was changed according to the user story.

Testing approach
Manual testing.

Expected result
Validation must allow team member category description that is al least 5 characters long.

Check List
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ +]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the minimum team category description length from 10 characters to 5, allowing shorter descriptions to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->